### PR TITLE
Multiple config files

### DIFF
--- a/test/config_test.py
+++ b/test/config_test.py
@@ -346,12 +346,6 @@ jobs:
                 name: "action4_0"
                 command: "test_command4.0"
 """)
-
-    @teardown
-    def teardown(self):
-        shutil.rmtree(self.test_dir)
-
-    def test_multiple_configs(self):
         self.test_config = config.load_config(StringIO.StringIO(self.config))
         self.my_mcp = mcp.MasterControlProgram(self.test_dir, 'config')
         self.test_config.apply(self.my_mcp)
@@ -365,9 +359,133 @@ jobs:
         self.job3 = self.my_mcp.jobs['test_job3']
         self.job4 = self.my_mcp.jobs['test_job4']
 
-        self.serv = self.my_mcp.services['service0']
+        self.serv0 = self.my_mcp.services['service0']
+        self.serv1 = self.my_mcp.services['service1']
 
         self.all_jobs = [self.job0, self.job1, self.job2, self.job3, self.job4]
+
+    @teardown
+    def teardown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_attributes(self):
+        assert hasattr(self.test_config, "working_dir")
+        assert hasattr(self.test_config, "nodes")
+        assert hasattr(self.test_config, "jobs")
+        assert hasattr(self.test_config, "ssh_options")
+
+        assert_equal(len(self.test_config.jobs), 5)
+        assert_equal(len(self.test_config.services), 2)
+        assert_equal(len(self.test_config.nodes), 3)
+
+    def test_node_attribute(self):
+        assert_equal(len(self.my_mcp.nodes), 2)
+        assert_equal(self.my_mcp.nodes[0].hostname, "batch0")
+        assert_equal(self.my_mcp.nodes[1].hostname, "batch1")
+
+        assert_equal(self.my_mcp.nodes[0].conch_options['noagent'], False)
+        assert_equal(self.my_mcp.nodes[1].conch_options['noagent'], False)
+
+        assert self.job4.node_pool.nodes[0] is self.my_mcp.nodes[0]
+
+    def test_job_name_attribute(self):
+        for j in self.all_jobs:
+            assert hasattr(j, "name")
+
+        assert_equal(self.job0.name, "test_job0")
+        assert_equal(self.job1.name, "test_job1")
+        assert_equal(self.job2.name, "test_job2")
+        assert_equal(self.job3.name, "test_job3")
+        assert_equal(self.job4.name, "test_job4")
+
+    def test_job_node_attribute(self):
+        for j in self.all_jobs:
+            assert hasattr(j, "node_pool")
+
+        assert_equal(self.job0.node_pool.nodes[0], self.node0)
+        assert_equal(self.job1.node_pool.nodes[0], self.node0)
+        assert_equal(self.job2.node_pool.nodes[0], self.node1)
+        assert_equal(self.job3.node_pool.nodes[0], self.node1)
+
+        assert_equal(self.job4.node_pool.nodes[0], self.node0)
+        assert_equal(self.job4.node_pool.nodes[1], self.node1)
+
+    def test_job_schedule_attribute(self):
+        for j in self.all_jobs:
+            assert hasattr(j, "scheduler")
+
+        assert isinstance(self.job0.scheduler, scheduler.IntervalScheduler)
+        assert_equal(self.job0.scheduler.interval, datetime.timedelta(seconds=20))
+
+        assert isinstance(self.job1.scheduler, scheduler.DailyScheduler)
+        assert_equal(self.job1.scheduler.start_time, datetime.time(hour=0, minute=30, second=0))
+        assert self.job1.scheduler.wait_days
+
+        assert isinstance(self.job2.scheduler, scheduler.DailyScheduler)
+        assert_equal(self.job2.scheduler.start_time, datetime.time(hour=16, minute=30, second=0))
+
+        assert isinstance(self.job3.scheduler, scheduler.ConstantScheduler)
+        assert isinstance(self.job4.scheduler, scheduler.DailyScheduler)
+
+    def test_actions_name_attribute(self): 
+        for job_count in range(len(self.all_jobs)):
+            j = self.all_jobs[job_count]
+
+            for act_count in range(len(j.topo_actions)):
+                a = j.topo_actions[act_count]
+                assert hasattr(a, "name")
+                assert_equal(a.name, "action%s_%s" % (job_count, act_count))
+
+    def test_all_nodes_attribute(self):
+        assert self.job4.all_nodes
+        assert not self.job3.all_nodes
+
+    def test_actions_command_attribute(self): 
+        for job_count in range(len(self.all_jobs)):
+            j = self.all_jobs[job_count]
+
+            for act_count in range(len(j.topo_actions)):
+                a = j.topo_actions[act_count]
+                assert hasattr(a, "command")
+                assert_equal(a.command, "test_command%s.%s" % (job_count, act_count))
+
+    def test_actions_requirements(self):
+        dep0 = self.job1.topo_actions[1]
+        dep1 = self.job3.topo_actions[2]
+        req0 = self.job1.topo_actions[0]
+        req1 = self.job3.topo_actions[0]
+
+        assert hasattr(dep0, 'required_actions')
+        assert hasattr(dep1, 'required_actions')
+
+        assert_equals(len(dep0.required_actions), 1)
+        assert_equals(len(dep1.required_actions), 2)
+        assert_equals(len(req0.required_actions), 0)
+        assert_equals(len(req1.required_actions), 0)
+
+        assert dep0.required_actions[0] is req0
+        assert dep1.required_actions[0] is req1
+
+    def test_command_context(self):
+        assert hasattr(self.test_config, "command_context")
+        assert_equal(self.test_config.command_context['python'], "/usr/bin/python")
+        assert_equal(self.my_mcp.context['python'], "/usr/bin/python")
+        assert_equal(self.job1.context['python'], "/usr/bin/python")
+
+    def test_service_attributes(self):
+        assert_equal(self.serv0.count, 2)
+        assert_equal(self.serv0.name, 'service0')
+
+        assert_equal(self.serv0.monitor_interval, 20)
+        assert self.serv0.pid_file_template
+        assert self.serv0.command
+        assert self.serv0.context
+
+        assert_equal(self.serv1.name, 'service1')
+        assert_equal(self.serv1.monitor_interval, 20)
+        assert self.serv1.pid_file_template
+        assert self.serv1.command
+        assert self.serv1.context
 
 
 class BadJobConfigTest(TestCase):


### PR DESCRIPTION
This is one crack at [#36](https://github.com/rhettg/Tron/issues/36).

There are several problems with supporting multiple config files. Frankly, I don't expect this pull request to be accepted. Although it works, it's super hacky.

It adds an `include: [path1, path2, ...]` to the top level of the config file. The YAML files referenced in the list may have `jobs:` and `services:` in them which are appended to the jobs and services, respectively.

Problems come from the fact that `*` references can only work within a single document, so jobs and services cannot refer to nodes unless those nodes are in the same document. Nodes could be redefined in the included files, but then they would appear multiple times in the MCP's node list.

This branch's solution is to do some basic parsing and string replacing to just paste the extra jobs and services into the main file. While this approach is minimally invasive to the rest of the code, it isn't very maintainable.

It would be much easier to do this if nodes had string identifiers or could be referred to by hostname. Then none of the string stuff would be necessary because the references could be resolved in code.
