### PR TITLE
added missing import and fixed import ordering

### DIFF
--- a/tron/www.py
+++ b/tron/www.py
@@ -6,16 +6,21 @@ import datetime
 import logging
 import urllib
 
-from twisted.internet import reactor
+try:
+    import json as simplejson
+except ImportError:
+    import simplejson
+
 from twisted.cred import checkers
-from twisted.web import server, resource, http
+from twisted.internet import reactor
+from twisted.web import http, resource, server
 
-import simplejson
-
-from tron.utils import timeutils
+from tron import action
 from tron import config
-from tron import service
 from tron import job
+from tron import service
+from tron.utils import timeutils
+
 
 log = logging.getLogger("tron.www")
 


### PR DESCRIPTION
A fix for issue 22 https://github.com/Yelp/Tron/issues/22

www.py was missing an import. I added the correct import and re-ordered the imports to be in alphabetical order.

I ran the tests, this branch passed them.

Resubmitted against the development branch.
