### PR TITLE
better formatting when logging to syslog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+tron (0.2.8.1-1) unstable; urgency=low
+
+  * Set a meaningful Formatter when logging to syslog (jbrown)
+
+ -- James Brown <jbrown@yelp.com>  Mon, 12 Dec 2011 16:26:05 -0800
+
 tron (0.2.8-1) unstable; urgency=low
 
   * Now on PyPI (irskep)

--- a/tron/config.py
+++ b/tron/config.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from logging import handlers
+import logging.handlers
 import os
 import re
 import socket
@@ -240,14 +240,16 @@ class TronConfiguration(yaml.YAMLObject):
 
             already_exists = False
             for h in set(handlers_to_be_removed):
-                if (isinstance(h, handlers.SysLogHandler) and
+                if (isinstance(h, logging.handlers.SysLogHandler) and
                     h.address == self.syslog_address):
                     handlers_to_be_removed.remove(h)
                     already_exists = True
 
             if not already_exists:
                 try:
-                    new_handlers.append(handlers.SysLogHandler(self.syslog_address))
+                    h = logging.handlers.SysLogHandler(self.syslog_address)
+                    h.setFormatter(logging.Formatter("tron[%(process)d]: %(message)s"))
+                    new_handlers.append(h)
                 except socket.error:
                     raise ConfigError('%s is not a valid syslog address' %
                                       self.syslog_address)


### PR DESCRIPTION
It's common to include the name of the program doing the logging, and its pid, when using syslog. This changes to a somewhat more typical formatter.
