### PR TITLE
Job can be configured disabled

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -128,6 +128,7 @@ jobs:
         node: *nodePool
         all_nodes: True
         schedule: "daily"
+        enabled: False
         actions:
             - &actionDaily
                 name: "action4_0"
@@ -194,10 +195,12 @@ services:
                         name='cleanup',
                         command='test_command0.1',
                         requires=(),
-                        node=None)),
+                        node=None),
+                    enabled=True),
                 'test_job1': ConfigJob(
                     name='test_job1',
                     node='batch0',
+                    enabled=True,
                     schedule=ConfigDailyScheduler(
                         ordinals=None,
                         weekdays=set([0, 2, 4]),
@@ -224,6 +227,7 @@ services:
                 'test_job2': ConfigJob(
                     name='test_job2',
                     node='batch1',
+                    enabled=True,
                     schedule=ConfigDailyScheduler(
                         ordinals=None,
                         weekdays=None,
@@ -246,6 +250,7 @@ services:
                     name='test_job3',
                     node='batch1',
                     schedule=ConfigConstantScheduler(),
+                    enabled=True,
                     actions=FrozenDict(**{
                         'action3_1': ConfigAction(
                             name='action3_1',
@@ -286,7 +291,8 @@ services:
                     queueing=True,
                     run_limit=50,
                     all_nodes=True,
-                    cleanup_action=None)
+                    cleanup_action=None,
+                    enabled=False)
                 }),
                 services=FrozenDict(**{
                     'service0': ConfigService(
@@ -319,6 +325,7 @@ services:
         assert_equal(test_config.jobs, expected.jobs)
         assert_equal(test_config.services, expected.services)
         assert_equal(test_config, expected)
+        assert_equal(test_config.jobs['test_job4'].enabled, False)
 
 
 class BadJobConfigTest(TestCase):

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -127,6 +127,7 @@ ConfigJob = config_object_factory(
         'run_limit',            # int
         'all_nodes',            # bool
         'cleanup_action',       # ConfigAction
+        'enabled',              # bool
     ])
 
 
@@ -531,7 +532,8 @@ class ValidateJob(ValidatorWithNamedPath):
     defaults = {
         'run_limit':            50,
         'all_nodes':            False,
-        'cleanup_action':       None
+        'cleanup_action':       None,
+        'enabled':              True,
     }
 
     validators = {
@@ -543,6 +545,7 @@ class ValidateJob(ValidatorWithNamedPath):
         'cleanup_action':       lambda _, v: valid_cleanup_action(v),
         'node':                 lambda _, v: normalize_node(v),
         'queueing':             valid_bool,
+        'enabled':              valid_bool,
     }
 
     def set_defaults(self, job):

--- a/tron/job.py
+++ b/tron/job.py
@@ -304,7 +304,8 @@ class Job(object):
         run_limit=RUN_LIMIT,
         all_nodes=False,
         scheduler=None,
-        node_pool=None
+        node_pool=None,
+        enabled=True
     ):
         self.name = name
         self.topo_actions = [action] if action else []
@@ -314,7 +315,7 @@ class Job(object):
 
         self.queueing = queueing
         self.all_nodes = all_nodes
-        self.enabled = True
+        self.enabled = enabled
         self.last_success = None
 
         self.run_limit = run_limit
@@ -333,7 +334,8 @@ class Job(object):
             run_limit=job_config.run_limit,
             all_nodes=job_config.all_nodes,
             node_pool=node_pools[job_config.node] if job_config.node else None,
-            scheduler=scheduler_from_config(job_config.schedule, time_zone)
+            scheduler=scheduler_from_config(job_config.schedule, time_zone),
+            enabled=job_config.enabled
         )
 
         new_actions = dict(

--- a/tron/service.py
+++ b/tron/service.py
@@ -349,7 +349,6 @@ class Service(object):
                  restart_interval=None, pid_file_template=None, count=0):
         self.name = name
         self.command = command
-        self.scheduler = None
         self.node_pool = node_pool
         self.count = count
         self.monitor_interval = monitor_interval
@@ -561,8 +560,7 @@ class Service(object):
 
         rebuild_all_instances = any([
             self.command != prev_service.command,
-            self.pid_file_template != prev_service.pid_file_template,
-            self.scheduler != prev_service.scheduler])
+            self.pid_file_template != prev_service.pid_file_template])
 
         # Since we are inheriting all the existing instances, it's safe to also
         # inherit the previous state machine as well.


### PR DESCRIPTION
Resolves issue #88

Jobs can be configured normally, but set to disabled: True if you don't want them to run on their own.
