### PR TITLE
Manually cancelled jobs should still continue to schedule new runs.

### DIFF
--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -332,8 +332,10 @@ class JobScheduler(Observer):
         if queued_run:
             reactor.callLater(0, self.run_job, queued_run, run_queued=True)
 
-        if self.job.scheduler.schedule_on_complete:
-            self.schedule()
+        # Attempt to schedule a new run.  This will only schedule a run if the
+        # previous run was cancelled from a scheduled state, or if the job
+        # scheduler is `schedule_on_complete`.
+        self.schedule()
     handler = handle_job_events
 
     def get_runs_to_schedule(self, ignore_last_run_time=False):

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -353,6 +353,7 @@ class JobRunCollection(object):
     def remove_pending(self):
         """Remove pending runs from the run list."""
         for pending in list(self.get_pending()):
+            pending.clear_observers()
             pending.cancel()
             pending.cleanup()
             self.runs.remove(pending)


### PR DESCRIPTION
Previously if a job run was cancelled it would effectively disable a Job.
