### PR TITLE
Fix for missing format specifier

### DIFF
--- a/tron/api/www.py
+++ b/tron/api/www.py
@@ -66,7 +66,7 @@ class ActionRunResource(resource.Resource):
 
     def render_POST(self, request):
         cmd = requestargs.get_string(request, 'command')
-        log.info("Handling '%s' request for action run %s",
+        log.info("Handling '%s' request for action run %s.%s",
                  cmd, self._job_run.id, self._action_name)
 
         if cmd not in ('start', 'success', 'cancel', 'fail', 'skip'):


### PR DESCRIPTION
Was causing: -

```

Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 842, in emit
    msg = self.format(record)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 719, in format
    return fmt.format(record)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 464, in format
    record.message = record.getMessage()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 328, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Logged from file www.py, line 70
```
