### PR TITLE
Do not allow actions to be manually started if their job run is still scheduled

### DIFF
--- a/.pyautotest
+++ b/.pyautotest
@@ -1,0 +1,1 @@
+test_runner_name: "testify"


### PR DESCRIPTION
Resolves issue #158

Replace some turtles with mock
