### PR TITLE
Allow job runs to overlap.

### DIFF
--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -36,6 +36,10 @@ Optional Fields
     not defined to queue overlapping then this setting is ignored.
     IntervalScheduler and ConstantScheduler will not queue overlapping.
 
+**allow_overlap** (default **False**)
+    If **True** new job runs will start even if the previous run is still running.
+    By default new job runs are either cancelled or queued (see **queuing**).
+
 **run_limit** (default **50**)
     Number of runs which will be stored. Once a Job has more then run_limit
     runs, the output and state for the oldest run are removed. Failed runs
@@ -58,7 +62,8 @@ Optional Fields
     See :ref:`job_cleanup_actions`.
 
 **enabled** (default **True**)
-    If **False** the job will not be queued to run.
+    If **False** the job will not be schedule to run.
+
 
 .. _job_actions:
 

--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -82,6 +82,7 @@ jobs:
         name: "test_job1"
         node: node0
         schedule: "daily 00:30:00 MWF"
+        allow_overlap: True
         actions:
             -
                 name: "action1_0"
@@ -190,7 +191,8 @@ services:
                         command='test_command0.1',
                         requires=(),
                         node=None),
-                    enabled=True),
+                    enabled=True,
+                    allow_overlap=False),
                 'test_job1': ConfigJob(
                     name='test_job1',
                     node='node0',
@@ -217,7 +219,8 @@ services:
                     queueing=True,
                     run_limit=50,
                     all_nodes=False,
-                    cleanup_action=None),
+                    cleanup_action=None,
+                    allow_overlap=True),
                 'test_job2': ConfigJob(
                     name='test_job2',
                     node='node1',
@@ -239,7 +242,8 @@ services:
                     queueing=True,
                     run_limit=50,
                     all_nodes=False,
-                    cleanup_action=None),
+                    cleanup_action=None,
+                    allow_overlap=False),
                 'test_job3': ConfigJob(
                     name='test_job3',
                     node='node1',
@@ -265,7 +269,8 @@ services:
                     queueing=True,
                     run_limit=50,
                     all_nodes=False,
-                    cleanup_action=None),
+                    cleanup_action=None,
+                    allow_overlap=False),
                 'test_job4': ConfigJob(
                     name='test_job4',
                     node='nodePool',
@@ -286,7 +291,8 @@ services:
                     run_limit=50,
                     all_nodes=True,
                     cleanup_action=None,
-                    enabled=False)
+                    enabled=False,
+                    allow_overlap=False)
                 }),
                 services=FrozenDict({
                     'service0': ConfigService(

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -416,7 +416,8 @@ class ValidateJob(ValidatorWithNamedPath):
         'all_nodes':            False,
         'cleanup_action':       None,
         'enabled':              True,
-        'queueing':             True
+        'queueing':             True,
+        'allow_overlap':        False
     }
 
     validators = {
@@ -429,6 +430,7 @@ class ValidateJob(ValidatorWithNamedPath):
         'node':                 valid_identifier,
         'queueing':             valid_bool,
         'enabled':              valid_bool,
+        'allow_overlap':        valid_bool,
     }
 
     def _validate_dependencies(self, job, actions,

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -84,6 +84,7 @@ ConfigJob = config_object_factory(
         'all_nodes',            # bool
         'cleanup_action',       # ConfigAction
         'enabled',              # bool
+        'allow_overlap',        # bool
     ])
 
 

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -77,7 +77,8 @@ class Job(Observable, Observer):
 
     def __init__(self, name, scheduler, queueing=True, all_nodes=False,
             node_pool=None, enabled=True, action_graph=None,
-            run_collection=None, parent_context=None, output_path=None):
+            run_collection=None, parent_context=None, output_path=None,
+            allow_overlap=None):
         super(Job, self).__init__()
         self.name               = name
         self.action_graph       = action_graph
@@ -87,6 +88,7 @@ class Job(Observable, Observer):
         self.all_nodes          = all_nodes
         self.enabled            = enabled
         self.node_pool          = node_pool
+        self.allow_overlap      = allow_overlap
         self.context            = command_context.CommandContext(
                                     JobContext(self), parent_context)
         self.output_path        = output_path or filehandler.OutputPath()
@@ -111,7 +113,8 @@ class Job(Observable, Observer):
             run_collection      = runs,
             action_graph        = action_graph,
             parent_context      = parent_context,
-            output_path         = output_path
+            output_path         = output_path,
+            allow_overlap       = job_config.allow_overlap
         )
 
     def update_from_job(self, job):
@@ -310,7 +313,7 @@ class JobScheduler(Observer):
 
         node = job_run.node if self.job.all_nodes else None
         # If there is another job run still running, queue or cancel this one
-        if any(self.job.runs.get_active(node)):
+        if not self.job.allow_overlap and any(self.job.runs.get_active(node)):
             self._queue_or_cancel_active(job_run)
             return
 


### PR DESCRIPTION
New configuration option for Jobs 'allow_overlap'
