### PR TITLE
Add a config hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,4 +73,4 @@ tests:
 test: tests
 
 test_all:
-	PYTHONPATH=. testify tests
+	PYTHONPATH=. testify tests --summary

--- a/bin/tronfig
+++ b/bin/tronfig
@@ -39,8 +39,9 @@ def parse_options():
     return options
 
 
-def upload_config(client, config_name, contents):
-    response = client.config(config_name, data=contents)
+def upload_config(client, config_name, contents, config_hash):
+    response = client.config(config_name,
+                             config_data=contents, config_hash=config_hash)
     if 'error' in response:
         print response['error']
         return False
@@ -63,6 +64,7 @@ def edit_config(contents):
     with open(fi.name) as upload_file:
         return upload_file.read()
 
+
 def validate(config_name, config_content):
     try:
         config_data = manager.from_string(config_content)
@@ -71,21 +73,25 @@ def validate(config_name, config_content):
     except ConfigError, e:
         print "Error: %s" % e
 
+
 def print_config(client, config_name):
-    print client.config(config_name)
+    print client.config(config_name)['config']
 
 
 def update_from_stdin(client, config_name):
     config_content = sys.stdin.read()
+    config_hash = client.config(config_name)['hash']
     if validate(config_name, config_content):
-        upload_config(client, config_name, config_content)
+        upload_config(client, config_name, config_content, config_hash)
 
 
 def update_with_editor(client, config_name):
     if not sys.stdout.isatty():
         raise SystemExit("No editing possible.")
 
-    config_content = client.config(config_name)
+    response        = client.config(config_name)
+    config_content  = response['config']
+    config_hash     = response['hash']
     while True:
         config_content = edit_config(config_content)
         if not config_content:
@@ -93,7 +99,7 @@ def update_with_editor(client, config_name):
             return
 
         if validate(config_name, config_content):
-            if upload_config(client, config_name, config_content):
+            if upload_config(client, config_name, config_content, config_hash):
                 return
 
         response = raw_input(

--- a/tests/api/www_test.py
+++ b/tests/api/www_test.py
@@ -7,12 +7,13 @@ import twisted.web.http
 import twisted.web.server
 
 from testify import TestCase, class_setup, assert_equal, run, setup
-from testify import class_teardown
+from testify import class_teardown, setup_teardown
 from testify.assertions import assert_in
 from testify.utils import turtle
 from tests import mocks
 from tests.assertions import assert_call
-from tron.api import www
+from tron import mcp
+from tron.api import www, controller
 from tests.testingutils import Turtle
 
 try:
@@ -23,6 +24,11 @@ except ImportError:
 
 REQUEST = twisted.web.server.Request(mock.Mock(), None)
 REQUEST.childLink = lambda val : "/jobs/%s" % val
+
+
+def build_request(**kwargs):
+    args = dict((k, [v]) for k, v in kwargs.iteritems())
+    return mock.create_autospec(twisted.web.server.Request, args=args)
 
 
 class WWWTestCase(TestCase):
@@ -282,6 +288,36 @@ class ServiceTest(WWWTestCase):
     def test_missing_service(self):
         child = self.resource.getChildWithDefault("bar", mock.Mock())
         assert isinstance(child, twisted.web.resource.NoResource)
+
+
+class ConfigResourceTestCase(TestCase):
+
+    @setup_teardown
+    def setup_resource(self):
+        self.mcp = mock.create_autospec(mcp.MasterControlProgram)
+        self.resource = www.ConfigResource(self.mcp)
+        self.controller = self.resource.controller = mock.create_autospec(
+            controller.ConfigController)
+        with mock.patch('tron.api.www.respond', autospec=True) as self.respond:
+            yield
+
+    def test_render_GET(self):
+        name = 'the_nane'
+        request = build_request(name=name)
+        self.resource.render_GET(request)
+        self.controller.read_config.assert_called_with(name)
+        self.respond.assert_called_with(request,
+                self.resource.controller.read_config.return_value)
+
+    def test_render_POST(self):
+        name, config, hash = 'the_name', mock.Mock(), mock.Mock()
+        request = build_request(name=name, config=config, hash=hash)
+        self.resource.render_POST(request)
+        self.controller.update_config.assert_called_with(name, config, hash)
+        response_content = {
+            'status': 'Active',
+            'error': self.controller.update_config.return_value}
+        self.respond.assert_called_with(request, response_content)
 
 
 if __name__ == '__main__':

--- a/tests/commands/client_test.py
+++ b/tests/commands/client_test.py
@@ -15,9 +15,9 @@ class ClientTestCase(TestCase):
 
     def test_config_post(self):
         self.client.request = mock.create_autospec(self.client.request)
-        name, data = 'name', 'stuff'
-        self.client.config(name, data=data)
-        expected_data =  {'config': data, 'name': name}
+        name, data, hash = 'name', 'stuff', 'hash'
+        self.client.config(name, config_data=data, config_hash=hash)
+        expected_data =  {'config': data, 'name': name, 'hash': hash}
         self.client.request.assert_called_with('/config', expected_data)
 
     def test_config_get_default(self):

--- a/tests/trond_test.py
+++ b/tests/trond_test.py
@@ -59,7 +59,7 @@ class TrondTestCase(sandbox.SandboxTestCase):
         self.sandbox.save_config(SINGLE_ECHO_CONFIG)
         self.sandbox.trond()
         # make sure it got in
-        assert_equal(client.config('MASTER'), SINGLE_ECHO_CONFIG)
+        assert_equal(client.config('MASTER')['config'], SINGLE_ECHO_CONFIG)
 
         # reconfigure and confirm results
         second_config = DOUBLE_ECHO_CONFIG + TOUCH_CLEANUP_FMT
@@ -67,7 +67,7 @@ class TrondTestCase(sandbox.SandboxTestCase):
         events = client.events()
         assert_equal(events[0]['name'], 'restoring')
         assert_equal(events[1]['name'], 'run_created')
-        assert_equal(client.config('MASTER'), second_config)
+        assert_equal(client.config('MASTER')['config'], second_config)
         
         # reconfigure, by uploading a third configuration
         self.sandbox.tronfig(ALT_NAMESPACED_ECHO_CONFIG, name='ohce')
@@ -169,7 +169,7 @@ class TrondTestCase(sandbox.SandboxTestCase):
         self.sandbox.trond()
         self.sandbox.tronfig(SERVICE_CONFIG)
 
-        wait_on_config = lambda: 'fake_service' in client.config('MASTER')
+        wait_on_config = lambda: 'fake_service' in client.config('MASTER')['config']
         sandbox.wait_on_sandbox(wait_on_config)
 
         self.sandbox.tronctl(['start', 'MASTER_fake_service'])

--- a/tron/api/www.py
+++ b/tron/api/www.py
@@ -437,18 +437,19 @@ class ConfigResource(resource.Resource):
         config_name = requestargs.get_string(request, 'name')
         if not config_name:
             return respond(request, {'error': "'name' for config is required."})
-        response = {'config': self.controller.read_config(config_name)}
-        return respond(request, response)
+        return respond(request, self.controller.read_config(config_name))
 
     def render_POST(self, request):
         log.info("Handling reconfigure request")
         config_content = requestargs.get_string(request, 'config')
         config_name = requestargs.get_string(request, 'name')
+        config_hash = requestargs.get_string(request, 'hash')
         if not config_name:
             return respond(request, {'error': "'name' for config is required."})
 
         response = {'status': "Active"}
-        error = self.controller.update_config(config_name, config_content)
+        error = self.controller.update_config(
+            config_name, config_content, config_hash)
         if error:
             response['error'] = error
         return respond(request, response)

--- a/tron/commands/client.py
+++ b/tron/commands/client.py
@@ -68,11 +68,13 @@ class Client(object):
     def events(self):
         return self.request('/events')['data']
 
-    def config(self, config_name, data=None):
+    def config(self, config_name, config_data=None, config_hash=None):
         """This may be a post or a get, depending on data."""
-        if data:
-            return self.request('/config', dict(config=data, name=config_name))
-        return self.request('/config?name=%s' % config_name)['config']
+        if config_data:
+            request_data = dict(
+                        config=config_data, name=config_name, hash=config_hash)
+            return self.request('/config', request_data)
+        return self.request('/config?name=%s' % config_name)
 
     def home(self):
         return self.request('/')

--- a/tron/config/manager.py
+++ b/tron/config/manager.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import os
 import yaml
@@ -34,6 +35,10 @@ def read_raw(path):
         return fh.read()
 
 
+def hash_digest(content):
+    return hashlib.sha1(content).hexdigest()
+
+
 class ManifestFile(object):
     """Manage the manifest file, which tracks name to filename."""
 
@@ -67,6 +72,8 @@ class ManifestFile(object):
 
 class ConfigManager(object):
     """Read, load and write configuration."""
+
+    DEFAULT_HASH = hash_digest("")
 
     def __init__(self, config_path):
         self.config_path = config_path
@@ -102,8 +109,15 @@ class ConfigManager(object):
         name_mapping = dict((name, read(filename)) for name, filename in seq)
         return config_parse.ConfigContainer.create(name_mapping)
 
+    def get_hash(self, name):
+        """Return a hash of the configuration contents for name."""
+        if name not in self:
+            return self.DEFAULT_HASH
+        return hash_digest(self.read_raw_config(name))
+
     def __contains__(self, name):
         return name in self.manifest
+
 
 def create_new_config(path, master_content, master_filename='master'):
     """Create a new configuration directory with master config."""


### PR DESCRIPTION
When tronfig retrieves config contents it also gets a hash of the on disk file. When it updates the config, it returns the hash. The api verifies that the on disk configuration has not changed.

This should prevent the configs from being clobbered when more then a single user is updating with tronfig.
