### PR TITLE
0.6.0.2, better handling for service instance monitoring

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+tron (0.6.0.2) unstable; urgency=low
+
+  * Allow serviceinstances to transition from unknown to down
+  * Better handling for serviceinstance monitor task failing
+
+ -- Daniel Nephin <dnephin@yelp.com>  Thu, 04 Apr 2013 12:47:14 -0700
+
 tron (0.6.0.1) unstable; urgency=low
 
   * minor visual improvements to tronview

--- a/tests/actioncommand_test.py
+++ b/tests/actioncommand_test.py
@@ -88,3 +88,9 @@ class ActionCommandTestCase(TestCase):
     def test_is_complete_true(self):
         self.ac.machine.state = self.ac.COMPLETE
         assert self.ac.is_complete, self.ac.machine.state
+
+    def test_is_done(self):
+        self.ac.machine.state = self.ac.FAILSTART
+        assert self.ac.is_done, self.ac.machine.state
+        self.ac.machine.state = self.ac.COMPLETE
+        assert self.ac.is_done, self.ac.machine.state

--- a/tron/__init__.py
+++ b/tron/__init__.py
@@ -1,4 +1,4 @@
-__version_info__    = (0, 6, 0, 1)
+__version_info__    = (0, 6, 0, 2)
 __version__         = ".".join("%s" % v for v in __version_info__)
 
 __author__          = 'Yelp <yelplabs@yelp.com>'

--- a/tron/actioncommand.py
+++ b/tron/actioncommand.py
@@ -12,6 +12,8 @@ class ActionState(state.NamedEventState):
 
 class CompletedActionCommand(object):
     is_complete = True
+    is_done = True
+    is_failed = False
 
 
 class ActionCommand(object):
@@ -98,7 +100,13 @@ class ActionCommand(object):
 
     @property
     def is_complete(self):
+        """Complete implies done and success."""
         return self.machine.state == self.COMPLETE
+
+    @property
+    def is_done(self):
+        """Done implies no more work will be done, but might not be success."""
+        return self.machine.state in (self.COMPLETE, self.FAILSTART)
 
     def __repr__(self):
         return "ActionCommand %s %s: %s" % (self.id, self.command, self.state)
@@ -132,3 +140,6 @@ class StringBufferStore(object):
 
     def get_stream(self, name):
         return self.buffers[name].get_value()
+
+    def clear(self):
+        self.buffers.clear()

--- a/tron/core/serviceinstance.py
+++ b/tron/core/serviceinstance.py
@@ -14,7 +14,8 @@ log = logging.getLogger(__name__)
 
 
 MIN_HANG_CHECK_SECONDS  = 10
-HANG_CHECK_DELAY_RATIO = 0.8
+HANG_CHECK_DELAY_RATIO = 0.9
+
 
 def create_hang_check(delay, func):
     delay = max(delay * HANG_CHECK_DELAY_RATIO, MIN_HANG_CHECK_SECONDS)
@@ -85,7 +86,7 @@ class ServiceInstanceMonitorTask(observer.Observable, observer.Observer):
 
     def run(self):
         """Run the monitoring command."""
-        if not self.action.is_complete:
+        if not self.action.is_done:
             log.warn("%s: Monitor action already exists.", self)
             return
 
@@ -98,10 +99,17 @@ class ServiceInstanceMonitorTask(observer.Observable, observer.Observer):
     def command(self):
         return self.command_template % self.pid_filename
 
-    def handle_action_event(self, _action, event):
+    def handle_action_event(self, action, event):
+        if action != self.action:
+            msg = "Ignoring %s %s, action was cleared due to hang check."
+            log.warn(msg % (action, event))
+            return
+
         if event == ActionCommand.EXITING:
-            return self._handle_action_exit()
+            self.hang_check_callback.cancel()
+            self._handle_action_exit()
         if event == ActionCommand.FAILSTART:
+            self.hang_check_callback.cancel()
             self.notify(self.NOTIFY_FAILED)
             self.queue()
 
@@ -109,13 +117,13 @@ class ServiceInstanceMonitorTask(observer.Observable, observer.Observer):
 
     def _handle_action_exit(self):
         log.debug("%s exit, failure: %r", self, self.action.is_failed)
-        self.hang_check_callback.cancel()
         if self.action.is_failed:
             self.notify(self.NOTIFY_DOWN)
             return
 
         self.notify(self.NOTIFY_UP)
         self.queue()
+        self.buffer_store.clear()
 
     def cancel(self):
         """Cancel the monitor callback and hang check."""
@@ -123,8 +131,9 @@ class ServiceInstanceMonitorTask(observer.Observable, observer.Observer):
         self.hang_check_callback.cancel()
 
     def fail(self):
-        log.warning("%s is still running %s", self, self.action)
+        log.warning("%s is still running %s.", self, self.action)
         self.notify(self.NOTIFY_FAILED)
+        self.action = actioncommand.CompletedActionCommand
 
     def __str__(self):
         return "%s(%s)" % (self.__class__.__name__, self.id)
@@ -232,7 +241,8 @@ class ServiceInstance(observer.Observer):
                             monitor=STATE_MONITORING,
                             stop=STATE_STOPPING)
     STATE_UNKNOWN       = ServiceInstanceState("unknown",
-                            monitor=STATE_MONITORING)
+                            monitor=STATE_MONITORING,
+                            stop=STATE_DOWN)
 
     STATE_MONITORING['monitor_fail']    = STATE_UNKNOWN
     STATE_UP['stop']                    = STATE_STOPPING
@@ -315,6 +325,9 @@ class ServiceInstance(observer.Observer):
 
         if event == task.NOTIFY_FAILED:
             self.failures.append(get_failures_from_task(task))
+
+        if event == ServiceInstanceMonitorTask.NOTIFY_UP:
+            self.failures = []
 
     def _handle_start_task_complete(self):
         if self.machine.state != ServiceInstance.STATE_STARTING:


### PR DESCRIPTION
When a service monitor fails due to failstart it throws some warnings, this should better reflect the intended behavior. Also allow for a service instance to be stopped if the monitor fails.
