### PR TITLE
ServiceInstanceMonitorTask.fail fix

### DIFF
--- a/tron/core/serviceinstance.py
+++ b/tron/core/serviceinstance.py
@@ -137,8 +137,8 @@ class ServiceInstanceMonitorTask(observer.Observable, observer.Observer):
         old_action = self.action
         self.action = actioncommand.CompletedActionCommand
         log.warning("%s is still running %s.", self, self.action)
+        old_action.write_stderr("Monitoring failed")
         self.node.stop(old_action)
-        self.action.write_stderr("Monitoring failed")
         self.notify(self.NOTIFY_FAILED)
         self.queue()
 


### PR DESCRIPTION
A simple fix to the ServiceInstanceMonitorTask; the stderr write was going to the CompletedActionCommand rather than the old, failed one as it should have.
