### PR TITLE
Fixed SSHAuthOptions to compare against something that Twisted won't touch

### DIFF
--- a/tron/ssh.py
+++ b/tron/ssh.py
@@ -28,7 +28,7 @@ class SSHAuthOptions(object):
     def __init__(self, identitys, use_agent, config):
         self.use_agent = use_agent
         self.identitys = identitys
-        self.config    = config
+        self._config    = config
 
     @classmethod
     def from_config(cls, ssh_config):
@@ -40,7 +40,7 @@ class SSHAuthOptions(object):
         return not self.use_agent
 
     def __eq__(self, other):
-        return other and other.config == self.config
+        return other and other._config == self._config
 
     def __ne__(self, other):
         return not self == other


### PR DESCRIPTION
When testing tronfig, I noticed that every time a reconfiguration was completed that there would be a number of extra, idle SSH connection daemons open equal to the number of nodes inside of the configuration file, even if the node configuration or anything related was untouched (for reference, I was changing `buffer_size`). This led me to wonder if the Node objects were always being discarded in favor of new ones, even if the configuration was the same.

Doing some IPDB investigation, it turned out that the `conch_options.identitys` field was actually getting changed between when a Node was created and when it was used (it was `()`, but changed to `['~/.ssh/id_rsa', '~/.ssh/id_dsa']`). It turns out that Twisted will use some defaults for SSH files if it is given none, and the `SSHAuthOptions` object was getting passed instead of a `ConchOptions` object to a Twisted `SSHClientTransport` (it's actually the Tron `ClientTransport`, but it's a subclass of the Twisted object). When the value of `identitys` is Falsy, Twisted changes this attribute to point to the default SSH files.

This is simply a fix to make the needed `__eq__` comparison not use attributes that Twisted will potentially modify by making a hidden _config object that saves the passed `ssh_config` object given in `from_config`.
