### PR TITLE
Implemented logging in Tronstore

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -343,11 +343,17 @@ As of v0.3.3 Logging is no longer configured in the tron configuration file.
 
 Tron uses Python's standard logging and by default uses a rotating log file
 handler that rotates files each day. The default log directory is
-``/var/log/tron/tron.log``.
+``/var/log/tron/tron.log`` for trond logging and ``/var/log/tron/tronstore.log``
+for tronstore logging.
 
 To configure logging pass -l <logging.conf> to trond. You can modify the
 default logging.conf by copying it from tron/logging.conf. See
 http://docs.python.org/howto/logging.html#configuring-logging
+
+PLEASE ENSURE THAT ``logger_tronstore`` HAS A HANDLER THAT WRITES TO A SEPARATE
+FILE THAN THE OTHER LOGGERS. TRONSTORE RUNS IN A SEPARATE PROCESS, MEANING
+IT CANNOT WRITE TO THE SAME LOG FILE OR YOU WILL LIKELY GET UNREADABLE LOG
+ENTRIES. In addition, ``logger_tronstore`` MUST have ``qualname=tronstore``.
 
 Interesting logs
 ~~~~~~~~~~~~~~~~
@@ -357,6 +363,10 @@ name.  There are a couple special cases:
 
 **twisted**
     Twisted sends its logs to the `twisted` log
+
+**tronstore**
+    Tronstore sends its logs to the `tronstore` log
+    Please ensure that the handler for this logger writes to a separate file.
 
 **tron.api.www.access**
     API access logs are sent to this log at the INFO log level.  They follow

--- a/tests/data/logging.conf
+++ b/tests/data/logging.conf
@@ -1,8 +1,8 @@
 [loggers]
-keys=root, twisted, tron
+keys=root, twisted, tron, tronstore
 
 [handlers]
-keys=fileHandler
+keys=fileHandler, tronstoreHandler
 
 [formatters]
 keys=defaultFormatter
@@ -23,11 +23,23 @@ handlers=fileHandler
 qualname=tron
 propagate=0
 
+[logger_tronstore]
+level=WARN
+handlers=tronstoreHandler
+qualname=tronstore
+propagate=0
+
 [handler_fileHandler]
 class=logging.FileHandler
 level=WARN
 formatter=defaultFormatter
 args=('{0}',)
+
+[handler_tronstoreHandler]
+class=logging.FileHandler
+level=WARN
+formatter=defaultFormatter
+args=('tronstore.log',)
 
 [formatter_defaultFormatter]
 format=%(asctime)s %(name)s %(levelname)s %(message)s

--- a/tests/serialize/runstate/tronstore/process_test.py
+++ b/tests/serialize/runstate/tronstore/process_test.py
@@ -2,9 +2,11 @@ import contextlib
 import mock
 import signal
 import os
+import logging
 from testify import TestCase, assert_equal, assert_raises, setup_teardown
 from tron.serialize.runstate.tronstore import tronstore
-from tron.serialize.runstate.tronstore.process import StoreProcessProtocol, TronStoreError
+from tron.serialize.runstate.tronstore.process import StoreProcessProtocol, TronstoreError
+
 
 class StoreProcessProtocolTestCase(TestCase):
 
@@ -33,7 +35,8 @@ class StoreProcessProtocolTestCase(TestCase):
 
 	def test_start_process(self):
 		self.pipe_setup_patch.assert_called_once_with()
-		self.process_patch.assert_called_once_with(target=tronstore.main, args=(self.process.config, self.test_pipe_b))
+		self.process_patch.assert_called_once_with(target=tronstore.main,
+			args=(self.process.config, self.test_pipe_b, logging.getLogger('tronstore')))
 		assert self.process_patch.daemon
 		self.process.process.start.assert_called_once_with()
 
@@ -42,7 +45,7 @@ class StoreProcessProtocolTestCase(TestCase):
 			mock.patch.object(self.process.process, 'is_alive', return_value=False),
 			mock.patch.object(self.process, '_start_process'),
 		) as (alive_patch, start_patch):
-			assert_raises(TronStoreError, self.process._verify_is_alive)
+			assert_raises(TronstoreError, self.process._verify_is_alive)
 			alive_patch.assert_called_with()
 			assert_equal(alive_patch.call_count, 2)
 			start_patch.assert_called_once_with()

--- a/tests/serialize/runstate/tronstore/store_test.py
+++ b/tests/serialize/runstate/tronstore/store_test.py
@@ -253,11 +253,12 @@ class SyncStoreTestCase(TestCase):
             connection_details='with_all_the_strength_of_a_raging_fire',
             db_store_method='mysterious_as_the_dark_side_of_the_moon')
         self.store_class = mock.Mock()
+        self.log = mock.Mock()
         with contextlib.nested(
             mock.patch.object(runstate.tronstore.store, 'build_store', return_value=self.store_class),
             mock.patch('tron.serialize.runstate.tronstore.store.Lock', autospec=True)
         ) as (self.build_patch, self.lock_patch):
-            self.store = SyncStore(self.fake_config)
+            self.store = SyncStore(self.fake_config, self.log)
             self.lock = self.lock_patch.return_value
 
     def test__init__(self):
@@ -271,7 +272,7 @@ class SyncStoreTestCase(TestCase):
         assert_equal(self.store_class, self.store.store)
 
     def test__init__null_config(self):
-        store = SyncStore(None)
+        store = SyncStore(None, self.log)
         assert isinstance(store.store, NullStore)
 
     def test_save(self):
@@ -283,8 +284,8 @@ class SyncStoreTestCase(TestCase):
         self.store_class.save.assert_called_once_with(fake_arg, fake_kwarg=fake_kwarg)
 
     def test_restore(self):
-        fake_arg = 'catch_a_ride'
-        fake_kwarg = 'no_refunds'
+        fake_arg = 'ill_make_a_man'
+        fake_kwarg = 'out_of_you'
         self.store.restore(fake_arg, fake_kwarg=fake_kwarg)
         self.lock.__enter__.assert_called_once_with()
         self.lock.__exit__.assert_called_once_with(None, None, None)

--- a/tests/serialize/runstate/tronstore/tronstore_test.py
+++ b/tests/serialize/runstate/tronstore/tronstore_test.py
@@ -59,7 +59,8 @@ class TronstoreMainTestCase(TestCase):
 		self.request_patch.assert_called_once_with()
 		self.pipe_patch.assert_called_once_with(self.pipe)
 		self.response_patch.assert_called_once_with()
-		self.thread_patch.assert_called_once_with(self.response_factory, self.pipe, self.store_class)
+		self.thread_patch.assert_called_once_with(self.response_factory, self.pipe,
+			self.store_class, self.log)
 		assert_equal(self.main.config, self.config)
 		assert not self.main.is_shutdown
 		assert not self.main.shutdown_req_id
@@ -82,7 +83,8 @@ class TronstoreMainTestCase(TestCase):
 		self.thread_pool.start.assert_called_once_with()
 		self.store_class.cleanup.assert_called_once_with()
 		self.store_patch.assert_any_call(fake_data, self.log)
-		self.thread_patch.assert_any_call(self.response_factory, self.pipe, self.store_class)
+		self.thread_patch.assert_any_call(self.response_factory, self.pipe,
+			self.store_class, self.log)
 		assert_equal(self.thread_patch.call_count, 2)
 		assert_equal(self.main.config, fake_data)
 		self.response_factory.build.assert_called_once_with(True, fake_id, '')
@@ -99,7 +101,7 @@ class TronstoreMainTestCase(TestCase):
 		self.store_patch.assert_any_call(fake_data, self.log)
 		self.store_patch.assert_any_call(self.config, self.log)
 		self.thread_patch.assert_any_call(self.response_factory, self.pipe,
-			self.store_class)
+			self.store_class, self.log)
 		assert_equal(self.thread_patch.call_count, 2)
 		self.thread_pool.stop.assert_called_once_with()
 		self.store_class.cleanup.assert_called_once_with()
@@ -369,9 +371,12 @@ class TronstorePoolTestCase(TestCase):
 		self.factory = mock.Mock()
 		self.pipe = mock.Mock()
 		self.store = mock.Mock()
-		with mock.patch('tron.serialize.runstate.tronstore.tronstore.Thread', autospec=True) \
-		as self.thread_patch:
-			self.pool = tronstore.TronstorePool(self.factory, self.pipe, self.store)
+		self.log = mock.Mock()
+		with contextlib.nested(
+			mock.patch('tron.serialize.runstate.tronstore.tronstore.Thread', autospec=True),
+			mock.patch('tron.serialize.runstate.tronstore.tronstore.PoolWatcher', autospec=True)
+		) as (self.thread_patch, self.watch_patch):
+			self.pool = tronstore.TronstorePool(self.factory, self.pipe, self.store, self.log)
 			yield
 
 	def test__init__(self):
@@ -390,6 +395,7 @@ class TronstorePoolTestCase(TestCase):
 				self.store,
 				self.pool.keep_working
 			))
+		self.watch_patch.assert_called_once_with(self.pool, self.log)
 
 	def test_start(self):
 		self.pool.keep_working.set(False)
@@ -397,10 +403,13 @@ class TronstorePoolTestCase(TestCase):
 		assert self.pool.keep_working.value
 		assert not self.thread_patch.return_value.daemon
 		assert_equal(self.thread_patch.return_value.start.call_count, self.pool.POOL_SIZE)
+		assert not self.watch_patch.return_value.daemon
+		self.watch_patch.return_value.start.assert_called_once_with()
 
 	def test_stop(self):
 		self.pool.keep_working.set(True)
 		self.thread_patch.return_value.is_alive.return_value = False
+		self.watch_patch.return_value.is_alive.return_value = False
 		with mock.patch.object(self.pool, 'has_work', return_value=False) \
 		as work_patch:
 			self.pool.stop()
@@ -419,6 +428,40 @@ class TronstorePoolTestCase(TestCase):
 		as empty_patch:
 			assert not self.pool.has_work()
 			empty_patch.assert_called_once_with()
+
+
+class PoolWatcherTestCase(TestCase):
+
+	@setup_teardown
+	def setup_pool_watcher(self):
+		self.pool = mock.Mock(keep_working=mock.Mock(val=True))
+		self.log = mock.Mock()
+		with contextlib.nested(
+			mock.patch('tron.serialize.runstate.tronstore.tronstore.Thread', autospec=True),
+			mock.patch.object(tronstore.time, 'sleep')
+		) as (_, self.sleep_patch):
+			self.watcher = tronstore.PoolWatcher(self.pool, self.log)
+			yield
+
+	def test__init__(self):
+		assert_equal(self.watcher.pool, self.pool)
+		assert_equal(self.watcher.log, self.log)
+		assert_equal(self.watcher.last_sizes, [])
+		assert_equal(self.watcher.last_diffs, [])
+
+	def test_run_falling_behind(self):
+		work_sizes = [1, 10, 100, 1000, 10000, 100000, 1000000, ValueError]
+		self.pool.work_size = mock.Mock(side_effect=iter(work_sizes))
+		assert_raises(ValueError, self.watcher.run)
+		self.sleep_patch.assert_any_call(1.0)
+		assert self.log.warn.call_count
+
+	def test_run_not_falling_behind(self):
+		work_sizes = [1000000, 100000, 10000, 1000, 100, 10, 1, ValueError]
+		self.pool.work_size = mock.Mock(side_effect=iter(work_sizes))
+		assert_raises(ValueError, self.watcher.run)
+		self.sleep_patch.assert_any_call(1.0)
+		assert_equal(self.log.warn.call_count, 0)
 
 
 if __name__ == "__main__":

--- a/tron/logging.conf
+++ b/tron/logging.conf
@@ -1,8 +1,8 @@
 [loggers]
-keys=root, twisted, tron
+keys=root, twisted, tron, tronstore
 
 [handlers]
-keys=timed_rotating_file_handler
+keys=timed_rotating_file_handler, tronstore_file_handler
 
 [formatters]
 keys=default_formatter
@@ -23,11 +23,23 @@ handlers=timed_rotating_file_handler
 qualname=tron
 propagate=0
 
+[logger_tronstore]
+level=WARN
+handlers=tronstore_file_handler
+qualname=tronstore
+propagate=0
+
 [handler_timed_rotating_file_handler]
 class=logging.handlers.TimedRotatingFileHandler
 level=INFO
 formatter=default_formatter
 args=('/var/log/tron/tron.log', 'D')
+
+[handler_tronstore_file_handler]
+class=logging.handlers.TimedRotatingFileHandler
+level=INFO
+formatter=default_formatter
+args=('/var/log/tron/tronstore.log', 'D')
 
 [formatter_default_formatter]
 format=%(asctime)s %(name)s %(levelname)s %(message)s

--- a/tron/serialize/runstate/tronstore/parallelstore.py
+++ b/tron/serialize/runstate/tronstore/parallelstore.py
@@ -70,12 +70,15 @@ class ParallelStore(object):
         by shutting down and restarting tronstore. THIS MUST BE CALLED
         AT LEAST ONCE, as tronstore is started with a null configuration
         whenever a ParallelStore object is created."""
+        log.info("Loading new state persistence configuration into Tronstore...")
         config_req = self.request_factory.build(msg_enums.REQUEST_CONFIG, '', new_config)
         response = self.process.send_request_get_response(config_req)
         if response.success:
+            log.info('Successfully loaded new configuration into Tronstore.')
             self.process.update_config(new_config)
             return True
         else:
+            log.warn("Failed to load new configuration into Tronstore.")
             return False
 
     def __repr__(self):

--- a/tron/serialize/runstate/tronstore/store.py
+++ b/tron/serialize/runstate/tronstore/store.py
@@ -297,27 +297,25 @@ class SyncStore(object):
         with self.lock:
             try:
                 return self.store.save(*args, **kwargs)
-            except Exception, e:
-                self.log.error('Error encountered while saving data:\n %s'
-                    % traceback.print_exc(e))
+            except:
+                self.log.exception('Exception encountered while saving data')
                 return False
 
     def restore(self, *args, **kwargs):
         with self.lock:
             try:
                 return self.store.restore(*args, **kwargs)
-            except Exception, e:
-                self.log.error('Error encountered while restoring data:\n %s'
-                    % traceback.print_exc(e))
+            except:
+                self.log.exception('Exception encountered while restoring data')
                 return (False, None)
 
     def cleanup(self):
         with self.lock:
             try:
                 self.store.cleanup()
-            except Exception, e:
-                self.log.error('Error encountered while cleaning up %s:\n %s'
-                    % (self.store, traceback.print_exc(e)))
+            except:
+                self.log.exception('Exception encountered while cleaning up %r'
+                    % self.store)
 
     def __repr__(self):
         return "SyncStore('%s')" % self.store.__repr__()

--- a/tron/serialize/runstate/tronstore/store.py
+++ b/tron/serialize/runstate/tronstore/store.py
@@ -1,6 +1,7 @@
 import shelve
 import urlparse
 import os
+import traceback
 from contextlib import contextmanager
 from threading import Lock
 
@@ -44,7 +45,7 @@ class ShelveStore(object):
         self.shelve.close()
 
     def __repr__(self):
-        return "ShelveStateStore('%s')" % self.filename
+        return "ShelveStateStore('%s')" % self.fname
 
 
 class SQLStore(object):
@@ -135,8 +136,6 @@ class SQLStore(object):
             if not result:
                 return (False, None)
             elif result[1] != self.serializer.name:
-                # TODO: If/when we have logging in the Tronstore process,
-                #       log here that the db_store_method was different
                 serializer = serialize_class_map[result[1]]
                 return (True, serializer.deserialize(result[0]))
             else:
@@ -278,8 +277,9 @@ class SyncStore(object):
     modular nature.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, log):
         """Parse the configuration file and set up the store class."""
+        self.log = log
         self.lock = Lock()
         if not config:
             self.store = NullStore()
@@ -295,15 +295,29 @@ class SyncStore(object):
 
     def save(self, *args, **kwargs):
         with self.lock:
-            return self.store.save(*args, **kwargs)
+            try:
+                return self.store.save(*args, **kwargs)
+            except Exception, e:
+                self.log.error('Error encountered while saving data:\n %s'
+                    % traceback.print_exc(e))
+                return False
 
     def restore(self, *args, **kwargs):
         with self.lock:
-            return self.store.restore(*args, **kwargs)
+            try:
+                return self.store.restore(*args, **kwargs)
+            except Exception, e:
+                self.log.error('Error encountered while restoring data:\n %s'
+                    % traceback.print_exc(e))
+                return (False, None)
 
     def cleanup(self):
         with self.lock:
-            self.store.cleanup()
+            try:
+                self.store.cleanup()
+            except Exception, e:
+                self.log.error('Error encountered while cleaning up %s:\n %s'
+                    % (self.store, traceback.print_exc(e)))
 
     def __repr__(self):
         return "SyncStore('%s')" % self.store.__repr__()

--- a/tron/serialize/runstate/tronstore/tronstore.py
+++ b/tron/serialize/runstate/tronstore/tronstore.py
@@ -205,9 +205,8 @@ class TronstoreMain(object):
             self.config = request.data
             self.pipe.send_bytes(self.response_factory.build(True, request.id, '').serialized)
             self.log.info('Configuration loaded successfully.')
-        except Exception, e:
-            self.log.error('Error encountered when loading config:\n %s'
-                % traceback.print_exc(e))
+        except:
+            self.log.exception('Error encountered when loading config')
 
             self.log.debug('Recreating old store object...')
             self.store_class = store.SyncStore(self.config, self.log)

--- a/tron/serialize/runstate/tronstore/tronstore.py
+++ b/tron/serialize/runstate/tronstore/tronstore.py
@@ -206,7 +206,7 @@ class TronstoreMain(object):
             self.pipe.send_bytes(self.response_factory.build(True, request.id, '').serialized)
             self.log.info('Configuration loaded successfully.')
         except:
-            self.log.exception('Error encountered when loading config')
+            self.log.exception('Exception encountered when loading config')
 
             self.log.debug('Recreating old store object...')
             self.store_class = store.SyncStore(self.config, self.log)


### PR DESCRIPTION
This is an extension to Tronstore that implements logging. Now, there is a new [logging_tronstore] logger in the default logging and test logging configuration files, which is registered to a new handler that writes to a completely different file.

The actual logger is implemented by simply passing the tronstore logging object in the arguments to tronstore.main from trond. Python is actually really smart about recreating this object, so when Tronstore starts, it has a nice, configured logging object all ready to go.

I've made notes in the documentation about ensuring that the Tronstore logger writes to a different file, as Python cannot ensure logging concurrency between processes (threads are fine, however). This means that if the same file is used for Tronstore and trond, then it's very likely that log lines will be written at the same time.

In testing, since the critical tronstore logging (warns, errors) will only happen when trond is blocked on something, using the same file ended up working fine so long as the tronstore logging configuration was set to WARN or higher- however, turning on INFO level logging will make everything look pretty nasty.
