### PR TITLE
Implemented a --hostname argument for tronview

### DIFF
--- a/bin/tronview
+++ b/bin/tronview
@@ -30,6 +30,9 @@ def parse_options():
     parser.add_option("--namespace", type="string",
                       help="Show jobs/services for the specified namespace",
                       default=None)
+    parser.add_option("--hostname", type="string",
+                      help="Show jobs/services for the specified hostname",
+                      default=None)
 
     options, args = parser.parse_args(sys.argv)
     return options, args[1:]
@@ -49,9 +52,11 @@ def view_all(options, client):
         return display_events(client.events())
 
     return "".join([
-        display.DisplayServices().format(client.services(namespace=options.namespace)),
+        display.DisplayServices().format(
+            client.services(namespace=options.namespace, hostname=options.hostname)),
         '\n',
-        display.DisplayJobs().format(client.jobs(namespace=options.namespace))
+        display.DisplayJobs().format(
+            client.jobs(namespace=options.namespace, hostname=options.hostname))
     ])
 
 def view_job(options, job_id, client):

--- a/tests/api/resource_test.py
+++ b/tests/api/resource_test.py
@@ -167,7 +167,7 @@ class JobCollectionResourceTestCase(WWWTestCase):
     def test_render_GET(self):
         self.resource.get_data = Turtle()
         result = self.resource.render_GET(REQUEST)
-        assert_call(self.resource.get_data, 0, False, False, None)
+        assert_call(self.resource.get_data, 0, False, False, None, None)
         assert 'jobs' in result
 
     def test_getChild(self):

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -678,8 +678,6 @@ class JobCollectionTestCase(TestCase):
     def test_get_jobs_from_namespace(self):
         fake_job_uno = mock.create_autospec(job.JobContainer)
         fake_job_dos = mock.create_autospec(job.JobContainer)
-        #fake_job_uno.namespace = 'uno'
-        #fake_job_dos.namespace = 'dos'
         uno_patch = mock.patch.object(fake_job_uno, 'namespace', new='uno')
         dos_patch = mock.patch.object(fake_job_dos, 'namespace', new='dos')
         fake_jobs = [fake_job_uno, fake_job_dos]
@@ -694,6 +692,23 @@ class JobCollectionTestCase(TestCase):
             assert_equal(self.collection.get_jobs_by_namespace('uno'),
                 [fake_job_uno])
             assert_equal(self.collection.get_jobs_by_namespace('dos'),
+                [fake_job_dos])
+
+    def test_get_jobs_from_hostname(self):
+        fake_job_uno = mock.create_autospec(job.JobContainer)
+        fake_job_dos = mock.create_autospec(job.JobContainer)
+        fake_job_uno.node_pool = mock.Mock(
+            get_by_hostname=lambda x: x == 'uno')
+        fake_job_dos.node_pool = mock.Mock(
+            get_by_hostname=lambda x: x == 'dos')
+        fake_jobs = [fake_job_uno, fake_job_dos]
+        def fake_jobs_iter():
+            return iter(fake_jobs)
+        with mock.patch.object(self.collection.jobs, 'itervalues',
+                               side_effect=fake_jobs_iter):
+            assert_equal(self.collection.get_jobs_by_hostname('uno'),
+                [fake_job_uno])
+            assert_equal(self.collection.get_jobs_by_hostname('dos'),
                 [fake_job_dos])
 
 

--- a/tests/core/service_test.py
+++ b/tests/core/service_test.py
@@ -269,6 +269,23 @@ class ServiceCollectionTestCase(TestCase):
             assert_equal(self.collection.get_services_by_namespace('dos'),
                 [fake_service_dos])
 
+    def test_get_services_by_hostname(self):
+        fake_service_uno = service.Service(mock.MagicMock(), mock.Mock())
+        fake_service_dos = service.Service(mock.MagicMock(), mock.Mock())
+        fake_service_uno.instances.node_pool = mock.Mock(
+            get_by_hostname=lambda x: x == 'uno')
+        fake_service_dos.instances.node_pool = mock.Mock(
+            get_by_hostname=lambda x: x == 'dos')
+        fake_services = [fake_service_uno, fake_service_dos]
+        def fake_services_iter():
+            return iter(fake_services)
+        with mock.patch.object(self.collection.services, 'itervalues',
+        side_effect=fake_services_iter):
+            assert_equal(self.collection.get_services_by_hostname('uno'),
+                [fake_service_uno])
+            assert_equal(self.collection.get_services_by_hostname('dos'),
+                [fake_service_dos])
+
 
 
 if __name__ == "__main__":

--- a/tron/commands/client.py
+++ b/tron/commands/client.py
@@ -109,18 +109,24 @@ class Client(object):
     def get_url(self, identifier):
         return get_object_type_from_identifier(self.index(), identifier).url
 
-    def services(self, namespace=None):
-        params = {'namespace': namespace} if namespace else {}
+    def services(self, namespace=None, hostname=None):
+        params = {}
+        if namespace:
+            params['namespace'] = namespace
+        if hostname:
+            params['hostname'] = hostname
         return self.http_get('/api/services', params).get('services')
 
     def service(self, service_url):
         return self.http_get(service_url)
 
-    def jobs(self, include_job_runs=False, include_action_runs=False, namespace=None):
+    def jobs(self, include_job_runs=False, include_action_runs=False, namespace=None, hostname=None):
         params = {'include_job_runs': int(include_job_runs),
                   'include_action_runs': int(include_action_runs)}
         if namespace:
             params['namespace'] = namespace
+        if hostname:
+            params['hostname'] = hostname
         return self.http_get('/api/jobs', params).get('jobs')
 
     def job(self, job_url, include_action_runs=False, count=0):

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -356,6 +356,10 @@ class JobCollection(object):
         return [job for job in self
             if job.namespace == namespace]
 
+    def get_jobs_by_hostname(self, hostname):
+        return [job for job in self
+            if job.node_pool.get_by_hostname(hostname)]
+
     def get_names(self):
         return self.jobs.keys()
 

--- a/tron/core/service.py
+++ b/tron/core/service.py
@@ -220,6 +220,10 @@ class ServiceCollection(object):
         return [service for service in self
             if service.config.namespace == namespace]
 
+    def get_services_by_hostname(self, hostname):
+        return [service for service in self
+            if service.instances.node_pool.get_by_hostname(hostname)]
+
     def get_names(self):
         return self.services.keys()
 


### PR DESCRIPTION
Pretty similar to what #251 did, but now with a hostname argument instead! As requested in #138, there is now a `--hostname` argument for tronview that shows all jobs and services that have that hostname in their `node_pool`.
