### PR TITLE
Update action_run state change handling to avoid starting actions before...

### DIFF
--- a/tests/core/jobrun_test.py
+++ b/tests/core/jobrun_test.py
@@ -8,7 +8,6 @@ from tron import node, event, actioncommand
 from tron.core import jobrun, actionrun, actiongraph, job
 from tests.testingutils import Turtle, autospec_method
 from tron.serialize import filehandler
-from tron.utils import timeutils
 
 
 def build_mock_job():
@@ -247,18 +246,10 @@ class JobRunTestCase(TestCase):
     def test_handler_action_run_skipped(self):
         self.action_run.is_broken = False
         self.action_run.is_skipped = True
-        self.action_run.start_time = None
+        self.job_run.action_runs.is_scheduled = True
         autospec_method(self.job_run._start_action_runs)
         self.job_run.handler(self.action_run, mock.Mock())
         assert not self.job_run._start_action_runs.mock_calls
-
-    def test_handler_action_run_skipped_after_start(self):
-        self.action_run.is_broken = False
-        self.action_run.is_skipped = True
-        self.action_run.start_time = timeutils.current_time()
-        autospec_method(self.job_run._start_action_runs)
-        self.job_run.handler(self.action_run, mock.Mock())
-        assert self.job_run._start_action_runs.mock_calls
 
     def test_state(self):
         assert_equal(self.job_run.state, actionrun.ActionRun.STATE_SUCCEEDED)

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -187,17 +187,10 @@ class JobRun(Observable, Observer):
         if not action_run.is_done:
             return
 
-        # Skipping is manual and may occur before the job's scheduled time.
-        # If it is skipped after the run has started, start_time will be set.
-        is_skipped_before_start = (action_run.is_skipped
-                                   and action_run.start_time is None)
+        if action_run.is_skipped and self.action_runs.is_scheduled:
+            return
 
-        # If the action_run is skipped before the start, any startable
-        # (including dependent) actions will be run at the scheduled
-        # time, so don't start them now.
-        if (not action_run.is_broken
-            and not is_skipped_before_start
-            and any(self._start_action_runs())):
+        if not action_run.is_broken and any(self._start_action_runs()):
             log.info("Action runs started for %s." % self)
             return
 


### PR DESCRIPTION
This fixes #279 by updating action_run state-change-handling to avoid starting actions before they are started at the scheduled time. If the action_run was started, skipping it will still trigger a start of all startable actions.
