### PR TITLE
Ignore error in start task

### DIFF
--- a/tests/core/serviceinstance_test.py
+++ b/tests/core/serviceinstance_test.py
@@ -230,7 +230,7 @@ class ServiceInstanceStartTaskTestCase(TestCase):
         patcher = mock.patch('tron.core.serviceinstance.log', autospec=True)
         with patcher as mock_log:
             self.task.handle_action_event(action, event)
-            assert_equal(mock_log.warn.call_count, 0)
+            assert_equal(mock_log.warn.call_count, 1)
 
 
 class ServiceInstanceTestCase(TestCase):

--- a/tron/core/serviceinstance.py
+++ b/tron/core/serviceinstance.py
@@ -211,8 +211,11 @@ class ServiceInstanceStartTask(observer.Observable, observer.Observer):
 
     def handle_action_event(self, action, event):
         """Watch for events from the ActionCommand."""
-        if event == ActionCommand.EXITING or event == ActionCommand.FAILSTART:
+        if event == ActionCommand.EXITING:
             self.notify(self.NOTIFY_STARTED)
+        if event == ActionCommand.FAILSTART:
+            log.warn("Failed to start service %s on %s.", self.id, self.node)
+            self.notify(self.NOTIFY_FAILED)
 
     handler = handle_action_event
 


### PR DESCRIPTION
Ignore both exit status error and network failure in service start task. This will make a true failed start recover slower, but it also make reconnect to a node with service already running possible. 

The later situation should be more common. 
