### PR TITLE
Fix a but in service monitor failure

### DIFF
--- a/tron/core/serviceinstance.py
+++ b/tron/core/serviceinstance.py
@@ -120,7 +120,7 @@ class ServiceInstanceMonitorTask(observer.Observable, observer.Observer):
     def _handle_action_exit(self):
         log.debug("%s exit, failure: %r", self, self.action.is_failed)
         if self.action.is_failed:
-            self.notify(self.NOTIFY_FAILED)
+            self.fail()
             return
 
         self.notify(self.NOTIFY_UP)


### PR DESCRIPTION
Current code will cause an immediate monitor task restart before node.py cleanup run state.
