### PR TITLE
Fix monitor task requeue

### DIFF
--- a/tests/actioncommand_test.py
+++ b/tests/actioncommand_test.py
@@ -80,6 +80,9 @@ class ActionCommandTestCase(TestCase):
         assert_equal(self.ac.state, ActionCommand.FAILSTART)
         assert self.ac.end_time
 
+    def test_is_unknown(self):
+        assert self.ac.is_unknown
+
     def test_is_failed(self):
         assert not self.ac.is_failed
 

--- a/tests/core/serviceinstance_test.py
+++ b/tests/core/serviceinstance_test.py
@@ -131,6 +131,7 @@ class ServiceInstanceMonitorTaskTestCase(TestCase):
     def test_handle_action_exit_up(self):
         self.task.action = mock.create_autospec(ActionCommand)
         self.task.action.is_failed = False
+        self.task.action.is_unknown = False
         autospec_method(self.task.queue)
         self.task._handle_action_exit()
         self.task.notify.assert_called_with(self.task.NOTIFY_UP)
@@ -138,10 +139,19 @@ class ServiceInstanceMonitorTaskTestCase(TestCase):
 
     def test_handle_action_exit_down(self):
         self.task.action = mock.create_autospec(ActionCommand)
+        self.task.action.is_unknown = False
         autospec_method(self.task.queue)
         self.task._handle_action_exit()
         self.task.notify.assert_called_with(self.task.NOTIFY_DOWN)
         assert_equal(self.task.queue.call_count, 0)
+
+    def test_handle_action_unknown(self):
+        self.task.action = mock.create_autospec(ActionCommand)
+        self.task.action.is_unknown = True
+        autospec_method(self.task.queue)
+        self.task._handle_action_exit()
+        self.task.notify.assert_called_with(self.task.NOTIFY_FAILED)
+        assert_equal(self.task.queue.call_count, 1)
 
     def test_fail(self):
         self.task.action = mock.create_autospec(actioncommand.ActionCommand)

--- a/tron/actioncommand.py
+++ b/tron/actioncommand.py
@@ -101,6 +101,10 @@ class ActionCommand(object):
         self.done()
 
     @property
+    def is_unknown(self):
+        return self.exit_status is None
+
+    @property
     def is_failed(self):
         return bool(self.exit_status)
 

--- a/tron/core/serviceinstance.py
+++ b/tron/core/serviceinstance.py
@@ -119,6 +119,10 @@ class ServiceInstanceMonitorTask(observer.Observable, observer.Observer):
 
     def _handle_action_exit(self):
         log.debug("%s exit, failure: %r", self, self.action.is_failed)
+        if self.action.is_unknown:
+            self.notify(self.NOTIFY_FAILED)
+            self.queue()
+            return
         if self.action.is_failed:
             self.notify(self.NOTIFY_DOWN)
             return
@@ -318,7 +322,7 @@ class ServiceInstance(observer.Observer):
             return self.machine.transition('stop')
 
     def restore(self):
-        self.monitor_task.run()
+        self.monitor_task.queue()
 
     event_to_transition_map = {
         ServiceInstanceMonitorTask.NOTIFY_START:        'monitor',


### PR DESCRIPTION
Revert previous change to handle monitor task network error.
Add an unknown property to actioncommand.
Requeue monitor task on network failure.
Requeu monitor task on instance restore.
