### PR TITLE
Vagrant 'development playground' environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ docs/images/
 tronweb/js/cs/*.js
 tronweb_tests/spec/*.js
 tronweb_tests/lib/
+.vagrant/
+vagrant/insecure_tron_key
+vagrant/insecure_tron_key.pub

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ docs:
 doc: docs
 
 man: 
-	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(DOCS_DIR) $(DOCS_DIR)/man
+	which $(SPHINXBUILD) >/dev/null && $(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(DOCS_DIR) $(DOCS_DIR)/man || true
 	@echo
 	@echo "Build finished. The manual pages are in $(DOCS_BUILDDIR)/man."
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,102 @@
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+# -*- ruby -*-
+VAGRANTFILE_API_VERSION = "2"
+
+stub_name = "tron-v"
+
+trusty_box = 'puppetlabs/ubuntu-14.04-64-nocm'
+precise_box = 'puppetlabs/ubuntu-12.04-64-nocm'
+lucid_box = 'chef/ubuntu-10.04'
+
+base_dir = File.dirname(__FILE__)
+unless File.exists?("#{base_dir}/vagrant/insecure_tron_key")
+  system("cd #{base_dir}/vagrant && ssh-keygen -q -t rsa -N '' -f insecure_tron_key")
+end
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  nodes = [
+    { name: 'batch-01', memory: '1024', box: lucid_box,  ip: '192.168.33.41' },
+    { name: 'batch-02', memory: '1024', box: lucid_box,  ip: '192.168.33.42' },
+    { name: 'batch-03', memory: '1024', box: trusty_box, ip: '192.168.33.43' },
+  ]
+
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
+  end
+
+  config.vm.define "master.#{stub_name}", primary: true do |master|
+
+    master.vm.box = lucid_box
+    master.vm.hostname = "master.#{stub_name}"
+
+    master.vm.network :private_network, ip: "192.168.33.40"
+
+    master.vm.provider "virtualbox" do |v|
+      v.customize ["modifyvm", :id, "--memory", "1024"]
+      v.name = "master.#{stub_name}"
+    end
+
+
+    # Development and operational package prereqs
+    master.vm.provision :shell, inline: "apt-get update"
+    master.vm.provision :shell, inline: "DEBIAN_FRONTEND=noninteractive apt-get install -y postfix"
+    master.vm.provision :shell, inline: "apt-get install -y vim rsync python-twisted python-yaml python-dev python-pip python-virtualenv debhelper devscripts python-support cdbs python-central"
+    if master.vm.box != lucid_box
+      # Sphinx on Lucid does not support man page building
+      master.vm.provision :shell, inline: "apt-get install -y python-sphinx"
+    end
+    master.vm.provision :shell, inline: "apt-get install -y python-daemon python-lockfile"
+    master.vm.provision :shell, inline: "pip install pytz"
+
+    # Dirty hack, as current package build is hardcoded to
+    # /usr/local/bin/python
+    master.vm.provision :shell, inline: "ln -sf /usr/bin/python /usr/local/bin/python"
+
+    # Build the tron package
+    master.vm.provision :shell, privileged: false, inline: "cd && rm -f tron_*.deb"
+    master.vm.provision :shell, privileged: false, inline: "cd && rsync -r --exclude .vagrant --exclude .git /vagrant/ ~/tron/ && cd ~/tron && make deb"
+
+    # pre-configure our playground trond
+    master.vm.provision :shell, inline: "install -d -m 2750 -o vagrant -g vagrant /var/lib/tron"
+    master.vm.provision :shell, inline: "install -d -m 2750 -o vagrant -g vagrant /var/log/tron"
+    master.vm.provision :shell, inline: "cp /vagrant/vagrant/tron.default /etc/default/tron"
+    master.vm.provision :shell, privileged: false, inline: "install -m 600 /vagrant/vagrant/insecure_tron_key /home/vagrant/.ssh/id_rsa"
+    master.vm.provision :shell, inline: "install -m 644 /vagrant/vagrant/hosts /etc/hosts"
+
+    # Fire up the requisite ssh-agent and load our private key.
+    master.vm.provision :shell, privileged: false, inline: "ssh-agent > /var/lib/tron/ssh-agent.sh"
+    master.vm.provision :shell, privileged: false, inline: ". /var/lib/tron/ssh-agent.sh && ssh-add /home/vagrant/.ssh/id_rsa"
+
+    # and then install the package, ensuring stopped+started.
+    master.vm.provision :shell, privileged: false, inline: "killall -9 trond >/dev/null && sleep 1 || true"
+    master.vm.provision :shell, privileged: false, inline: "rm -f /var/lib/tron/tron.pid"
+    master.vm.provision :shell, inline: "DEBIAN_FRONTEND=noninteractive dpkg --force-confold -i /home/vagrant/tron_*deb"
+    master.vm.provision :shell, privileged: false, inline: ". /var/lib/tron/ssh-agent.sh && /usr/bin/trond"
+
+  end
+
+  nodes.each do |node|
+    config.vm.define "#{node[:name]}.#{stub_name}" do |vm_config|
+
+      vm_config.vm.box = node[:box]
+      vm_config.vm.hostname = "#{node[:name]}.#{stub_name}"
+
+      vm_config.vm.network :private_network, ip: node[:ip]
+      node.fetch(:code_repos, []).each do |code_repo|
+        vm_config.vm.synced_folder "../#{code_repo[:repo]}", "/srv/vagrant_repos/#{code_repo[:mount]}"
+      end
+
+      vm_config.vm.provider "virtualbox" do |v|
+        v.customize ["modifyvm", :id, "--memory", node[:memory]]
+        v.name = node[:name]
+      end
+
+      vm_config.vm.provision :shell, privileged: false, inline: "cat /vagrant/vagrant/insecure_tron_key.pub >> /home/vagrant/.ssh/authorized_keys"
+      vm_config.vm.provision :shell, inline: "install -m 644 /vagrant/vagrant/hosts /etc/hosts"
+
+    end
+
+  end
+
+end

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -47,6 +47,57 @@ of Tron create a working directory and start
 
 A sample testing config file is available at ``tests/data/test_config.yaml``
 
+Running Tron under Vagrant
+--------------------------
+
+A Vagrantfile is present that will fire up a working multi-node Tron playground
+environment.
+
+Fire this up with::
+
+    $ vagrant up
+    $ vagrant ssh master.tron-v
+
+:command:`trond` will be running, with no nodes configured.
+
+A basic environment can then be loaded with :command:`tronfig`::
+
+    ssh_options:
+        agent: true
+    
+    nodes:
+        - name: 'batch-01'
+          hostname: 'batch-01'
+          username: 'vagrant'
+        - name: 'batch-02'
+          hostname: 'batch-02'
+          username: 'vagrant'
+        - name: 'batch-03'
+          hostname: 'batch-03'
+          username: 'vagrant'
+
+    node_pools:
+       - name: all_nodes
+         nodes: 
+         - 'batch-01'
+         - 'batch-02'
+         - 'batch-03'
+
+    command_context:
+
+    jobs:
+        - name: "get_uname_details"
+          node: all_nodes
+          schedule: "interval 1 minute"
+          actions:
+          - name: "uname"
+            command: "uname -a"
+
+    services:
+
+The tests detailed below should also be runnable in this environment.
+
+
 Running the Tests
 -----------------
 Tron uses the `Testify <https://github.com/Yelp/Testify>`_ unit testing

--- a/vagrant/hosts
+++ b/vagrant/hosts
@@ -1,0 +1,7 @@
+127.0.0.1       localhost
+
+192.168.33.40   master.tron-v master
+192.168.33.41   batch-01.tron-v batch-01
+192.168.33.42   batch-02.tron-v batch-02
+192.168.33.43   batch-03.tron-v batch-03
+

--- a/vagrant/tron.default
+++ b/vagrant/tron.default
@@ -1,0 +1,21 @@
+# Defaults for tron initscript
+# sourced by /etc/init.d/tron
+# installed at /etc/default/tron by the maintainer scripts
+
+#
+# This is a POSIX shell fragment
+#
+
+# Additional options that are passed to the Daemon.
+DAEMON_OPTS="-l /var/lib/tron/logging.conf"
+
+# User the daemon will run as. Needs to have appropriate credentials to SSH into your working nodes.
+# You should take care in setting permissions appropriately for log and working directories on /var
+DAEMONUSER=""
+
+# Enable this when you have configured tron to your liking.
+RUN="yes"
+
+
+[ -f /var/lib/tron/ssh-agent.sh ] && . /var/lib/tron/ssh-agent.sh
+


### PR DESCRIPTION
This adds a multi-node Vagrant environment consisting of a tron 'master' node
and three 'batch-*' nodes for jobs/services.

The master node is fully configured, and ready for addition of the nodes and node_pool
entries via tronfig, which is documented in docs/developing.rst.

The tron master node is currenly Ubuntu 10.04 LTS, due to limitations in the debian package
build process. This also mirrors the most common deployment pattern for tron at the time of
writing, hopefully with a view to making this easier to migrate from.