### PR TITLE
Add job and service support fields: owner, summary, notes.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,7 +72,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     master.vm.provision :shell, privileged: false, inline: "killall -9 trond >/dev/null && sleep 1 || true"
     master.vm.provision :shell, privileged: false, inline: "rm -f /var/lib/tron/tron.pid"
     master.vm.provision :shell, inline: "DEBIAN_FRONTEND=noninteractive dpkg --force-confold -i /home/vagrant/tron_*deb"
-    master.vm.provision :shell, privileged: false, inline: ". /var/lib/tron/ssh-agent.sh && /usr/bin/trond"
+    master.vm.provision :shell, privileged: false, inline: ". /var/lib/tron/ssh-agent.sh && /usr/bin/trond -H 0.0.0.0"
 
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -94,6 +94,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       vm_config.vm.provision :shell, privileged: false, inline: "cat /vagrant/vagrant/insecure_tron_key.pub >> /home/vagrant/.ssh/authorized_keys"
       vm_config.vm.provision :shell, inline: "install -m 644 /vagrant/vagrant/hosts /etc/hosts"
+      vm_config.vm.provision :shell, inline: "install -m 644 /vagrant/vagrant/sshd_config /etc/ssh/sshd_config"
+      vm_config.vm.provision :shell, inline: "/etc/init.d/ssh reload"
 
     end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,6 +63,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     master.vm.provision :shell, inline: "cp /vagrant/vagrant/tron.default /etc/default/tron"
     master.vm.provision :shell, privileged: false, inline: "install -m 600 /vagrant/vagrant/insecure_tron_key /home/vagrant/.ssh/id_rsa"
     master.vm.provision :shell, inline: "install -m 644 /vagrant/vagrant/hosts /etc/hosts"
+    master.vm.provision :shell, inline: "install -m 644 /vagrant/vagrant/sshd_config /etc/ssh/sshd_config"
+    master.vm.provision :shell, inline: "/etc/init.d/ssh reload"
 
     # Fire up the requisite ssh-agent and load our private key.
     master.vm.provision :shell, privileged: false, inline: "ssh-agent > /var/lib/tron/ssh-agent.sh"

--- a/tests/commands/display_test.py
+++ b/tests/commands/display_test.py
@@ -13,9 +13,9 @@ class DisplayServicesTestCase(TestCase):
     @setup
     def setup_data(self):
         self.data = [
-            dict(name="My Service",      state="stopped", live_count="4", enabled=True),
-            dict(name="Another Service", state="running", live_count="2", enabled=False),
-            dict(name="Yet another",     state="running", live_count="1", enabled=True)
+            dict(name="My Service",      state="stopped", live_count="4", owner="alice", enabled=True),
+            dict(name="Another Service", state="running", live_count="2", owner="bob",   enabled=False),
+            dict(name="Yet another",     state="running", live_count="1", owner="ted",   enabled=True)
         ]
         self.display = DisplayServices()
 

--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -187,6 +187,9 @@ services:
                     name='MASTER.test_job0',
                     namespace='MASTER',
                     node='node0',
+                    owner='',
+                    summary='',
+                    notes='',
                     schedule=ConfigIntervalScheduler(
                         timedelta=datetime.timedelta(0, 20), jitter=None),
                     actions=FrozenDict({
@@ -211,6 +214,9 @@ services:
                     namespace='MASTER',
                     node='node0',
                     enabled=True,
+                    owner='',
+                    summary='',
+                    notes='',
                     schedule=schedule_parse.ConfigDailyScheduler(
                         days=set([1, 3, 5]),
                         hour=0, minute=30, second=0,
@@ -240,6 +246,9 @@ services:
                     namespace='MASTER',
                     node='node1',
                     enabled=True,
+                    owner='',
+                    summary='',
+                    notes='',
                     schedule=schedule_parse.ConfigDailyScheduler(
                         days=set(),
                         hour=16, minute=30, second=0,
@@ -265,6 +274,9 @@ services:
                     node='node1',
                     schedule=ConfigConstantScheduler(),
                     enabled=True,
+                    owner='',
+                    summary='',
+                    notes='',
                     actions=FrozenDict({
                         'action3_1': schema.ConfigAction(
                             name='action3_1',
@@ -292,6 +304,9 @@ services:
                     name='MASTER.test_job4',
                     namespace='MASTER',
                     node='nodePool',
+                    owner='',
+                    summary='',
+                    notes='',
                     schedule=schedule_parse.ConfigDailyScheduler(
                         days=set(),
                         hour=0, minute=0, second=0,
@@ -322,6 +337,9 @@ services:
                         monitor_interval=20,
                         monitor_retries=5,
                         restart_delay=None,
+                        owner='',
+                        summary='',
+                        notes='',
                         count=2)
                 }
             )
@@ -380,6 +398,13 @@ jobs:
         name: "test_job2"
         node: node1
         schedule: "daily 16:30:00"
+        owner: "bob@example.com"
+        summary: "Flobbles the jibber service into submission"
+        notes: |
+          This is a multiple line notes section for
+          giving information about this job.
+
+          Second sentence.
         actions:
             -
                 name: "action2_0"
@@ -421,6 +446,20 @@ services:
         count: 2
         pid_file: "/var/run/%(name)s-%(instance_number)s.pid"
         monitor_interval: 20
+    -
+        name: "service1"
+        node: NodePool
+        command: "service_command1"
+        count: 20
+        pid_file: "/var/run/%(name)s-%(instance_number)s.pid"
+        monitor_interval: 40
+        owner: "bob@example.com"
+        summary: "Jibber service, handles dequeueing submitted flobbles"
+        notes: |
+          This is a multiple line notes section for
+          giving information about this job.
+
+          Second sentence.
 """
 
     def test_attributes(self):
@@ -430,6 +469,9 @@ services:
                     name='test_job0',
                     namespace='test_namespace',
                     node='node0',
+                    owner='',
+                    summary='',
+                    notes='',
                     schedule=ConfigIntervalScheduler(
                         timedelta=datetime.timedelta(0, 20),
                         jitter=None,
@@ -456,6 +498,9 @@ services:
                     namespace='test_namespace',
                     node='node0',
                     enabled=True,
+                    owner='',
+                    summary='',
+                    notes='',
                     schedule=schedule_parse.ConfigDailyScheduler(
                         days=set([1, 3, 5]),
                         hour=0,
@@ -487,6 +532,9 @@ services:
                     namespace='test_namespace',
                     node='node1',
                     enabled=True,
+                    owner='bob@example.com',
+                    summary='Flobbles the jibber service into submission',
+                    notes='This is a multiple line notes section for\ngiving information about this job.\n\nSecond sentence.\n',
                     schedule=schedule_parse.ConfigDailyScheduler(
                         days=set(),
                         hour=16,
@@ -514,6 +562,9 @@ services:
                     node='node1',
                     schedule=ConfigConstantScheduler(),
                     enabled=True,
+                    owner='',
+                    summary='',
+                    notes='',
                     actions=FrozenDict({
                         'action3_1': schema.ConfigAction(
                             name='action3_1',
@@ -541,6 +592,9 @@ services:
                     name='test_job4',
                     namespace='test_namespace',
                     node='NodePool',
+                    owner='',
+                    summary='',
+                    notes='',
                     schedule=schedule_parse.ConfigDailyScheduler(
                         days=set(),
                         hour=0, minute=0, second=0,
@@ -566,12 +620,28 @@ services:
                         namespace='test_namespace',
                         name='service0',
                         node='NodePool',
+                        owner='',
+                        summary='',
+                        notes='',
                         pid_file='/var/run/%(name)s-%(instance_number)s.pid',
                         command='service_command0',
                         monitor_interval=20,
                         monitor_retries=5,
                         restart_delay=None,
-                        count=2)
+                        count=2),
+                    'service1': schema.ConfigService(
+                        namespace='test_namespace',
+                        name='service1',
+                        node='NodePool',
+                        owner='bob@example.com',
+                        summary='Jibber service, handles dequeueing submitted flobbles',
+                        notes='This is a multiple line notes section for\ngiving information about this job.\n\nSecond sentence.\n',
+                        pid_file='/var/run/%(name)s-%(instance_number)s.pid',
+                        command='service_command1',
+                        monitor_interval=40.0,
+                        monitor_retries=5,
+                        restart_delay=None,
+                        count=20),
                 }
             )
         )
@@ -582,6 +652,8 @@ services:
         assert_equal(test_config.jobs['test_job2'], expected.jobs['test_job2'])
         assert_equal(test_config.jobs['test_job3'], expected.jobs['test_job3'])
         assert_equal(test_config.jobs['test_job4'], expected.jobs['test_job4'])
+        assert_equal(test_config.services['service0'], expected.services['service0'])
+        assert_equal(test_config.services['service1'], expected.services['service1'])
         assert_equal(test_config.jobs, expected.jobs)
         assert_equal(test_config.services, expected.services)
         assert_equal(test_config, expected)
@@ -918,6 +990,9 @@ class ValidateJobsAndServicesTestCase(TestCase):
             schema.ConfigJob(name='MASTER.test_job0',
                 namespace='MASTER',
                 node='node0',
+                owner='',
+                summary='',
+                notes='',
                 schedule=ConfigIntervalScheduler(
                     timedelta=datetime.timedelta(0, 20), jitter=None),
                 actions=FrozenDict({'action0_0':
@@ -940,6 +1015,9 @@ class ValidateJobsAndServicesTestCase(TestCase):
             schema.ConfigService(name='MASTER.test_service0',
                           namespace='MASTER',
                           node='node0',
+                          owner='',
+                          summary='',
+                          notes='',
                           pid_file='/var/run/%(name)s-%(instance_number)s.pid',
                           command='service_command0',
                           monitor_interval=20,
@@ -1078,14 +1156,14 @@ class ConfigContainerTestCase(TestCase):
         job_names, service_names = self.container.get_job_and_service_names()
         expected = ['test_job1', 'test_job0', 'test_job3', 'test_job2', 'test_job4']
         assert_equal(job_names, expected)
-        assert_equal(service_names, ['service0'])
+        assert_equal(service_names, ['service1', 'service0'])
 
     def test_get_jobs(self):
         expected = ['test_job1', 'test_job0', 'test_job3', 'test_job2', 'test_job4']
         assert_equal(expected, self.container.get_jobs().keys())
 
     def test_get_services(self):
-        assert_equal(self.container.get_services().keys(), ['service0'])
+        assert_equal(self.container.get_services().keys(), ['service1', 'service0'])
 
     def test_get_node_names(self):
         node_names = self.container.get_node_names()

--- a/tron/api/adapter.py
+++ b/tron/api/adapter.py
@@ -323,6 +323,9 @@ class ServiceAdapter(ReprAdapter):
         'live_count',
         'monitor_interval',
         'restart_delay',
+        'owner',
+        'summary',
+        'notes',
         'events']
 
     def __init__(self, service, include_events=False):
@@ -334,6 +337,15 @@ class ServiceAdapter(ReprAdapter):
 
     def get_count(self):
         return self._obj.config.count
+
+    def get_owner(self):
+        return self._obj.config.owner
+
+    def get_summary(self):
+        return self._obj.config.summary
+
+    def get_notes(self):
+        return self._obj.config.notes
 
     def get_state(self):
         return self._obj.get_state()

--- a/tron/api/adapter.py
+++ b/tron/api/adapter.py
@@ -229,6 +229,9 @@ class JobAdapter(ReprAdapter):
         'runs',
         'max_runtime',
         'action_graph',
+        'owner',
+        'summary',
+        'notes',
     ]
 
     def __init__(self, job,

--- a/tron/api/adapter.py
+++ b/tron/api/adapter.py
@@ -245,6 +245,15 @@ class JobAdapter(ReprAdapter):
     def get_name(self):
         return self._obj.get_name()
 
+    def get_owner(self):
+        return self._obj.get_owner()
+
+    def get_summary(self):
+        return self._obj.get_summary()
+
+    def get_notes(self):
+        return self._obj.get_notes()
+
     def get_scheduler(self):
         return SchedulerAdapter(self._obj.scheduler).get_repr()
 

--- a/tron/commands/display.py
+++ b/tron/commands/display.py
@@ -258,14 +258,16 @@ def format_action_run_details(content, stdout=True, stderr=True):
 
 class DisplayServices(TableDisplay):
 
-    columns = ['Name',  'State',    'Count'      ]
-    fields  = ['name',  'state',    'live_count' ]
-    widths  = [50,      12,          5           ]
+    columns = ['Name',  'State',    'Count',      'Owner']
+    fields  = ['name',  'state',    'live_count', 'owner']
+    widths  = [50,      12,          7,           30     ]
     title   = 'services'
     resize_fields = ['name']
 
     detail_labels = [
         ('Service',             'name'              ),
+        ('Owner',               'owner'             ),
+        ('Summary',             'summary'           ),
         ('Enabled',             'enabled'           ),
         ('State',               'state'             ),
         ('Max instances',       'count'             ),
@@ -274,6 +276,8 @@ class DisplayServices(TableDisplay):
         ('Node Pool',           'node_pool'         ),
         ('Monitor interval',    'monitor_interval'  ),
         ('Restart delay',       'restart_delay'     ),
+        ('Restart delay',       'restart_delay'     ),
+        ('Notes',               'notes'             ),
     ]
 
     colors = {

--- a/tron/commands/display.py
+++ b/tron/commands/display.py
@@ -338,14 +338,16 @@ class DisplayJobRuns(TableDisplay):
 
 class DisplayJobs(TableDisplay):
 
-    columns = ['Name',  'State',    'Scheduler',    'Last Success']
-    fields  = ['name',  'status',   'scheduler',    'last_success']
-    widths  = [50,       10,         20,             20           ]
+    columns = ['Name',  'State',    'Scheduler',    'Last Success',  'Owner']
+    fields  = ['name',  'status',   'scheduler',    'last_success',  'owner']
+    widths  = [50,       10,         20,             22,             30]
     title = 'jobs'
     resize_fields = ['name']
 
     detail_labels = [
         ('Job',                 'name'              ),
+        ('Owner',               'owner'             ),
+        ('Summary',             'summary'           ),
         ('State',               'status'            ),
         ('Scheduler',           'scheduler'         ),
         ('Max runtime',         'max_runtime'       ),
@@ -353,6 +355,7 @@ class DisplayJobs(TableDisplay):
         ('Run on all nodes',    'all_nodes'         ),
         ('Allow overlapping',   'allow_overlap'     ),
         ('Queue overlapping',   'queueing'          ),
+        ('Notes',               'notes'             ),
     ]
 
     colors = {

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -281,6 +281,9 @@ class ValidateJob(Validator):
         'queueing':             True,
         'allow_overlap':        False,
         'max_runtime':          None,
+        'notes':                '',
+        'owner':                '',
+        'summary':              '',
     }
 
     validators = {
@@ -295,6 +298,9 @@ class ValidateJob(Validator):
         'enabled':              valid_bool,
         'allow_overlap':        valid_bool,
         'max_runtime':          config_utils.valid_time_delta,
+        'owner':                valid_string,
+        'summary':              valid_string,
+        'notes':                valid_string,
     }
 
     def cast(self, in_dict, config_context):
@@ -344,7 +350,10 @@ class ValidateService(Validator):
     defaults = {
         'count':                1,
         'monitor_retries':      5,
-        'restart_delay':        None
+        'restart_delay':        None,
+        'notes':                '',
+        'owner':                '',
+        'summary':              '',
     }
 
     validators = {
@@ -356,6 +365,9 @@ class ValidateService(Validator):
         'count':                valid_int,
         'node':                 valid_node_name,
         'restart_delay':        valid_float,
+        'owner':                valid_string,
+        'summary':              valid_string,
+        'notes':                valid_string,
     }
 
     def cast(self, in_dict, config_context):

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -105,6 +105,9 @@ ConfigJob = config_object_factory(
         'actions',              # FrozenDict of ConfigAction
         'namespace',            # str
     ],[
+        'owner',                # str
+        'summary',              # str
+        'notes',                # str
         'queueing',             # bool
         'run_limit',            # int
         'all_nodes',            # bool
@@ -145,6 +148,9 @@ ConfigService = config_object_factory(
         'monitor_interval',     # float
         'namespace',            # str
     ],[
+        'owner',                # str
+        'summary',              # str
+        'notes',                # str
         'restart_delay',        # float
         'monitor_retries',      # int
         'count',                # int

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -58,11 +58,15 @@ class Job(Observable, Observer):
 
     # TODO: use config object
     def __init__(self, name, scheduler, queueing=True, all_nodes=False,
+            owner='', summary='', notes='',
             node_pool=None, enabled=True, action_graph=None,
             run_collection=None, parent_context=None, output_path=None,
             allow_overlap=None, action_runner=None, max_runtime=None):
         super(Job, self).__init__()
         self.name               = name
+        self.owner              = owner
+        self.summary            = summary
+        self.notes              = notes
         self.action_graph       = action_graph
         self.scheduler          = scheduler
         self.runs               = run_collection
@@ -133,13 +137,13 @@ class Job(Observable, Observer):
         return self.name
 
     def get_owner(self):
-        return 'OWNER'
+        return self.owner
 
     def get_summary(self):
-        return 'SUMMARY'
+        return self.summary
 
     def get_notes(self):
-        return 'NOTES'
+        return self.notes
 
     def get_runs(self):
         return self.runs

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -90,6 +90,9 @@ class Job(Observable, Observer):
 
         return cls(
             name                = job_config.name,
+            owner               = job_config.owner,
+            summary             = job_config.summary,
+            notes               = job_config.notes,
             queueing            = job_config.queueing,
             all_nodes           = job_config.all_nodes,
             node_pool           = node_repo.get_by_name(job_config.node),
@@ -128,6 +131,15 @@ class Job(Observable, Observer):
 
     def get_name(self):
         return self.name
+
+    def get_owner(self):
+        return 'OWNER'
+
+    def get_summary(self):
+        return 'SUMMARY'
+
+    def get_notes(self):
+        return 'NOTES'
 
     def get_runs(self):
         return self.runs

--- a/vagrant/pretend_tron_service.sh
+++ b/vagrant/pretend_tron_service.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+pidfile=$1
+sleep_time=$2
+
+if [ -f $pidfile ]; then
+  echo "FATAL: pidfile already exists. But treat this as ok to see hwat tron does"
+  exit 0
+fi
+
+echo $$ > $pidfile
+
+while true; do
+  echo "$(hostname): $(date)"
+  sleep $sleep_time
+done
+
+rm -f $pidfile

--- a/vagrant/sshd_config
+++ b/vagrant/sshd_config
@@ -1,0 +1,89 @@
+# Package generated configuration file
+# See the sshd_config(5) manpage for details
+
+# What ports, IPs and protocols we listen for
+Port 22
+# Use these options to restrict which interfaces/protocols sshd will bind to
+#ListenAddress ::
+#ListenAddress 0.0.0.0
+Protocol 2
+# HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+#Privilege Separation is turned on for security
+UsePrivilegeSeparation yes
+
+# Lifetime and size of ephemeral version 1 server key
+KeyRegenerationInterval 3600
+ServerKeyBits 768
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Authentication:
+LoginGraceTime 120
+PermitRootLogin yes
+StrictModes yes
+
+RSAAuthentication yes
+PubkeyAuthentication yes
+#AuthorizedKeysFile	%h/.ssh/authorized_keys
+
+# Don't read the user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+# For this to work you will also need host keys in /etc/ssh_known_hosts
+RhostsRSAAuthentication no
+# similar for protocol version 2
+HostbasedAuthentication no
+# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
+#IgnoreUserKnownHosts yes
+
+# To enable empty passwords, change to yes (NOT RECOMMENDED)
+PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Change to no to disable tunnelled clear text passwords
+#PasswordAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosGetAFSToken no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+X11Forwarding yes
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+#UseLogin no
+
+MaxSessions 50
+#MaxStartups 10:30:60
+#Banner /etc/issue.net
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+Subsystem sftp /usr/lib/openssh/sftp-server
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+UseDNS no
+GSSAPIAuthentication no

--- a/vagrant/tronfig/MASTER.yaml
+++ b/vagrant/tronfig/MASTER.yaml
@@ -1,0 +1,62 @@
+---
+
+command_context:
+  TEST_VAR: wibble
+  EMAIL_USER: vagrant@localhost
+
+ssh_options:
+  agent: false
+  identities:
+    - /vagrant/vagrant/insecure_tron_key
+
+notification_options:
+  smtp_host: localhost
+  notification_addr: vagrant@localhost
+
+nodes:
+  - hostname: 'batch-01'
+    username: vagrant
+  - hostname: 'batch-02'
+    username: vagrant
+  - hostname: 'batch-03'
+    username: vagrant
+
+node_pools:
+  - name: all_pool
+    nodes: [ 'batch-01', 'batch-02', 'batch-03' ]
+  - name: pool_a
+    nodes: [ 'batch-01' ]
+  - name: pool_b
+    nodes: [ 'batch-02', 'batch-03' ]
+  - name: weighted_pool
+    nodes:
+     - 'batch-01'
+     - 'batch-01'
+     - 'batch-01'
+     - 'batch-01'
+     - 'batch-02'
+     - 'batch-02'
+     - 'batch-03'
+
+jobs:
+  - name: "hostname_test"
+    node: all_pool
+    schedule: "interval 1 mins"
+    actions:
+      - name: "hostname"
+        command: "hostname -f"
+  - name: "sleep_test"
+    node: all_pool
+    schedule: "interval 1 mins"
+    actions:
+      - name: "sleep_a_minute"
+        command: "sleep 60"
+
+services:
+  -  name: "watch_test"
+     node: "weighted_pool"
+     count: 20
+     monitor_interval: 30
+     restart_delay: 60
+     pid_file: "/tmp/%(name)s-%(instance_number)s.pid"
+     command: "watch -n 10 ls /tmp"

--- a/vagrant/tronfig/MASTER.yaml
+++ b/vagrant/tronfig/MASTER.yaml
@@ -41,12 +41,19 @@ node_pools:
 jobs:
   - name: "hostname_test"
     node: all_pool
+    owner: 'bob'
+    summary: 'should run hostname on each node every minute'
+    notes: 'Is PATH required?'
     schedule: "interval 1 mins"
     actions:
       - name: "hostname"
         command: "hostname -f"
   - name: "sleep_test"
     node: all_pool
+    summary: 'should run sleep 60 on each node every minute'
+    owner: 'longish_name'
+    notes: 'Is PATH required?'
+    schedule: "interval 1 mins"
     schedule: "interval 1 mins"
     actions:
       - name: "sleep_a_minute"

--- a/vagrant/tronfig/deploy-tronfig.sh
+++ b/vagrant/tronfig/deploy-tronfig.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+
+tronfig - < MASTER.yaml
+for config in $( ls *.yaml | grep -v MASTER.yaml ); do
+  namespace=${config%%.yaml}
+  tronfig $namespace - < $config
+done
+

--- a/vagrant/tronfig/other_namespace.yaml
+++ b/vagrant/tronfig/other_namespace.yaml
@@ -1,0 +1,6 @@
+---
+
+jobs:
+
+services:
+

--- a/vagrant/tronfig/test_namespace.yaml
+++ b/vagrant/tronfig/test_namespace.yaml
@@ -1,0 +1,19 @@
+---
+
+jobs:
+
+services:
+  -  name: "pretend_tron_service_1"
+     owner: "vagrant@localhost"
+     summary: "Testing a service that runs on many nodes"
+     notes: |
+       runs on weighted nodes, so we should have many more on batch-01 than
+       on the other nodes.
+
+       how does a second paragraph break things?
+     node: "weighted_pool"
+     count: 20
+     monitor_interval: 30
+     restart_delay: 60
+     pid_file: "/tmp/%(name)s-%(instance_number)s.pid"
+     command: "/vagrant/vagrant/pretend_tron_service.sh %(pid_file)s 10"


### PR DESCRIPTION
When supporting Tron with a large configuration managed by many people and teams, it gets very difficult to see who owns what. 'git blame' and looking at the code of individual jobs, basically.

Namespaces help with this, and naturally comments in the YAML files help too. However, this is pretty basic and very difficult to enforce.

This PR adds the following fields to the configuration, and extends visibility to the API and Tronview.

* owner (string)
* summary (string)
* notes (string)

These should allow job/service authors to give reasonable hints as to who to contact in the event of maintenance/update, what the job/service does, and arbitrary notes (such as links to runbooks, details of business impacts, etc).

The fields are all optional, and default to the empty string.

The PR also updates the Vagrant playground environment to have working playground tronfig, with these fields included.

