### PR TITLE
Fixing build failure

### DIFF
--- a/tests/commands/display_test.py
+++ b/tests/commands/display_test.py
@@ -85,11 +85,11 @@ class DisplayJobsTestCase(TestCase):
     def setup_data(self):
         self.data = [
             dict(name='important_things', status='running',
-                scheduler=mock.MagicMock(), last_success='unknown'),
+                scheduler=mock.MagicMock(), last_success='unknown', owner='alice'),
             dict(name='other_thing', status='success',
                 scheduler=mock.MagicMock(), last_success='2012-01-23 10:23:23',
                 action_names=['other', 'first'],
-                node_pool=['blam']),
+                node_pool=['blam'], owner=['bob', 'ted']),
         ]
         self.run_data = [
             dict(


### PR DESCRIPTION
When running make tests the build fails with the following message:

========================================================================
FAILURES
The following tests are expected to pass.

========================================================================
tests.commands.display_test DisplayJobsTestCase.test_format
------------------------------------------------------------
Traceback (most recent call last):
  File "./tests/commands/display_test.py", line 132, in test_format
    lines = self.do_format()
  File "./tests/commands/display_test.py", line 127, in do_format
    out = DisplayJobs().format(self.data)
  File "./tron/commands/display.py", line 176, in format
    self.out.append(self.format_row(row))
  File "./tron/commands/display.py", line 115, in format_row
    for i, value in enumerate(self.sorted_fields(fields))
  File "./tron/commands/display.py", line 110, in sorted_fields
    return [values[name] for name in self.fields]
KeyError: 'owner'

========================================================================

Reason is that owner is not an optional field and needs to be specified.
This commit takes care of this and makes the build succeed.