### PR TITLE
extra cleanup after twisted ssh channel close

### DIFF
--- a/tron/ssh.py
+++ b/tron/ssh.py
@@ -116,6 +116,7 @@ class ClientConnection(connection.SSHConnection):
             channel.openFailed(None)
 
         connection.SSHConnection.channelClosed(self, channel)
+        del self.deferreds[channel.id]
 
     def ssh_CHANNEL_REQUEST(self, packet):
         """

--- a/tron/ssh.py
+++ b/tron/ssh.py
@@ -116,7 +116,8 @@ class ClientConnection(connection.SSHConnection):
             channel.openFailed(None)
 
         connection.SSHConnection.channelClosed(self, channel)
-        del self.deferreds[channel.id]
+        if channel.id in self.deferreds:
+            del self.deferreds[channel.id]
 
     def ssh_CHANNEL_REQUEST(self, packet):
         """


### PR DESCRIPTION
In twisted connection.py, deferreds[channel.id] is set to [] after channel close. Latest twisted use del self.deferreds[channel.id][:], but both will leak 1 int and 1 empty list per command execution. Memory will be release after connection close but in a real world usage ssh connection usually persist the entire duration of tron uptime.

All the code use self.deferreds expect non existent value, so it is safe to not leave an empty list behind.