### PR TITLE
Add 'hour' to the command context

### DIFF
--- a/docs/command_context.rst
+++ b/docs/command_context.rst
@@ -28,6 +28,11 @@ command configuration (as well as pid_file_template for services).
     as `shortdate`. For example, ``%(day+1)s`` would return the day after the
     run date.
 
+**hour**
+    Current hour in `HH` (0-23) format. Supports the same arithmetic operations
+    as `shortdate`. For example, ``%(hour+1)s`` would return the hour after the
+    run hour (mod 24).
+
 **unixtime**
     Current timestamp. Supports addition and subtraction of seconds. For
     example ``%(unixtime+20)s`` would return the timestamp 20 seconds after

--- a/tests/utils/timeutils_test.py
+++ b/tests/utils/timeutils_test.py
@@ -204,5 +204,17 @@ class DateArithmeticTestCase(testingutils.MockTimeTestCase):
         daynum = self.now.toordinal() - 1
         assert_equal(DateArithmetic.parse('daynumber-1'), daynum)
 
+    def test_hour(self):
+        hour = self.now.strftime("%H")
+        assert_equal(DateArithmetic.parse('hour'), hour)
+
+    def test_hour_plus(self):
+        hour = "%02d" % ((int(self.now.strftime("%H")) + 1) % 24)
+        assert_equal(DateArithmetic.parse('hour+1'), hour)
+
+    def test_hour_minus(self):
+        hour = "%02d" % ((int(self.now.strftime("%H")) - 1) % 24)
+        assert_equal(DateArithmetic.parse('hour-1'), hour)
+
     def test_bad_date_format(self):
         assert DateArithmetic.parse('~~') is None

--- a/tron/utils/timeutils.py
+++ b/tron/utils/timeutils.py
@@ -27,11 +27,11 @@ def delta_total_seconds(td):
     return (microseconds + (seconds + days * 24 * 3600) * 10**6) / 10**6
 
 
-def macro_timedelta(start_date, years=0, months=0, days=0):
+def macro_timedelta(start_date, years=0, months=0, days=0, hours=0):
     """Since datetime doesn't provide timedeltas at the year or month level,
     this function generates timedeltas of the appropriate sizes.
     """
-    delta = datetime.timedelta(days=days)
+    delta = datetime.timedelta(days=days, hours=hours)
 
     new_month = start_date.month + months
     while new_month > 12:
@@ -42,7 +42,7 @@ def macro_timedelta(start_date, years=0, months=0, days=0):
         years -= 1
 
     end_date = datetime.datetime(
-        start_date.year + years, new_month, start_date.day)
+        start_date.year + years, new_month, start_date.day, start_date.hour)
     delta += end_date - start_date
 
     return delta
@@ -69,6 +69,7 @@ class DateArithmetic(object):
         'year':                 '%Y',
         'month':                '%m',
         'day':                  '%d',
+        'hour':                 '%H',
         'shortdate':            '%Y-%m-%d'
     }
 
@@ -86,7 +87,7 @@ class DateArithmetic(object):
         attr, value = match.groups()
         delta = int(value) if value else 0
 
-        if attr in ('shortdate', 'year', 'month', 'day'):
+        if attr in ('shortdate', 'year', 'month', 'day', 'hour'):
             if delta:
                 kwargs = {'days' if attr == 'shortdate' else attr + 's': delta}
                 dt += macro_timedelta(dt, **kwargs)


### PR DESCRIPTION
Primary: @yyejun 

This adds an "hour" variable to the command context to make it easier for people to have hourly batches who don't want the granularity of seconds with unixtime.