### PR TITLE
only keep last buffer from ssh connection

### DIFF
--- a/tron/ssh.py
+++ b/tron/ssh.py
@@ -206,12 +206,12 @@ class ExecChannel(channel.SSHChannel):
         return True
 
     def dataReceived(self, data):
-        self.data.append(data)
+        self.data = [data]
         for callback in self.output_callbacks:
             callback(data)
 
     def extReceived(self, dataType, data):
-        self.data.append(data)
+        self.data = [data]
         for callback in self.error_callbacks:
             callback(data)
 


### PR DESCRIPTION
Attempt reduce tron memory usage. Only the last ssh network data will be saved to disk.