### PR TITLE
[wip] use dh-virtualenv to package tron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,13 @@ tronweb_tests/lib/
 vagrant/insecure_tron_key
 vagrant/insecure_tron_key.pub
 .tox
+
+# Generated debian artifacts
+debian/tron
+debian/files
+debian/tron.substvars
+debian/tron.debhelper.log
+debian/tron.postinst.debhelper
+debian/tron.postrm.debhelper
+debian/tron.prerm.debhelper
+debian/tron.substvars

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ DOCS_BUILDDIR=docs/_build
 DOCS_STATICSDIR=$(DOCS_DIR)/images
 ALLSPHINXOPTS=-d $(DOCS_BUILDDIR)/doctrees $(SPHINXOPTS)
 
+DOCKER_RUN=docker run -t -v $(CURDIR)/:/work:rw tron-deb-builder
+
 .PHONY : all source install clean tests docs
 
 all:
@@ -34,8 +36,12 @@ install:
 rpm:
 	$(PYTHON) setup.py bdist_rpm --post-install=rpm/postinstall --pre-uninstall=rpm/preuninstall
 
-deb: man
-	dpkg-buildpackage -d && mv ../*.deb dist/
+build_%_docker:
+	[ -d dist ] || mkdir dist
+	cd ./yelp_package/$*/ && docker build -t tron-deb-builder .
+
+package_%_deb: build_%_docker
+	$(DOCKER_RUN) /bin/bash -c "dpkg-buildpackage -d && mv ../*.deb dist/"
 
 publish:
 	python setup.py sdist bdist_wheel	

--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,7 @@ rpm:
 	$(PYTHON) setup.py bdist_rpm --post-install=rpm/postinstall --pre-uninstall=rpm/preuninstall
 
 deb: man
-	# build the source package in the parent directory
-	# then rename it to project_version.orig.tar.gz
-	$(PYTHON) setup.py sdist $(COMPILE) --dist-dir=../
-	rename -f 's/$(PROJECT)-(.*)\.tar\.gz/$(PROJECT)_$$1\.orig\.tar\.gz/' ../*
-	# build the package
-	dpkg-buildpackage -i -I -rfakeroot -uc -us
+	dpkg-buildpackage -d && mv ../*.deb dist/
 
 publish:
 	python setup.py sdist bdist_wheel	
@@ -72,7 +67,7 @@ docs:
 
 doc: docs
 
-man: 
+man:
 	which $(SPHINXBUILD) >/dev/null && $(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(DOCS_DIR) $(DOCS_DIR)/man || true
 	@echo
 	@echo "Build finished. The manual pages are in $(DOCS_BUILDDIR)/man."

--- a/debian/control
+++ b/debian/control
@@ -2,15 +2,13 @@ Source: tron
 Section: admin
 Priority: optional
 Maintainer: Daniel Nephin <dnephin@yelp.com>
-Build-Depends: debhelper (>= 6.0.4), python-support (>= 0.5.3), cdbs (>= 0.4.51), python-central (>= 0.5.6)
-XS-Python-Version: >=2.5
-Standards-Version: 3.7.2
+Build-Depends: debhelper (>= 7), python2.7, dh-virtualenv
+Standards-Version: 3.8.3
 
 Package: tron
 Architecture: all
 Homepage: http://github.com/yelp/Tron
-XB-Python-Version: ${python:Versions}
-Depends: ${misc:Depends}, ${python:Depends}, python-twisted (>=10.0.0), python-yaml
+Depends: python2.7, ${shlibs:Depends}, ${misc:Depends}
 Description: Tron is a job scheduling, running and monitoring package.
   Designed to replace Cron for complex scheduling and dependencies.
   Provides:

--- a/debian/init.d
+++ b/debian/init.d
@@ -41,7 +41,6 @@
 PATH=/usr/bin:/usr/sbin:/sbin:/bin
 
 DAEMON=/usr/bin/trond # Introduce the server's location here
-PYTHON=/usr/local/bin/python
 NAME=tron             # Introduce the short server's name here
 DESC=tron             # Introduce a short description here
 LOGDIR=/var/log/tron  # Log directory to use
@@ -133,8 +132,8 @@ start_server() {
 # if we are using a daemonuser then change the user id
             start-stop-daemon --start --quiet --pidfile $PIDFILE \
                         --chuid $DAEMONUSER \
-                        --startas $DAEMON \
-                        --exec $PYTHON -- $DAEMON_OPTS
+                        --startas $DAEMON
+                        -- $DAEMON_OPTS
             errcode=$?
         fi
         return $errcode
@@ -149,8 +148,7 @@ stop_server() {
 # if we are using a daemonuser then look for process that match
             start-stop-daemon --stop --quiet --pidfile $PIDFILE \
                         --user $DAEMONUSER \
-                        --startas $DAEMON \
-                        --exec $PYTHON
+                        --startas $DAEMON
             errcode=$?
         fi
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,12 +1,21 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
-DEB_PYTHON_SYSTEM=pycentral
-DEB_DH_INSTALLINIT_ARGS="-n"
+PIP_INDEX_URL ?= https://pypi.python.org/simple
 
-include /usr/share/cdbs/1/rules/debhelper.mk
-include /usr/share/cdbs/1/class/python-distutils.mk
+%:
+	dh $@ --with python-virtualenv
 
-clean::
-	rm -rf build build-stamp python-build-stamp-* configure-stamp build/ MANIFEST
-	dh_clean
+# do not call `make clean` as part of packaging
+override_dh_auto_clean:
+	true
+
+override_dh_auto_build:
+	true
+
+# do not call `make test` as part of packaging
+override_dh_auto_test:
+	true
+
+override_dh_virtualenv:
+	dh_virtualenv -i $(PIP_INDEX_URL) --python=/usr/bin/python2.7 --preinstall no-manylinux1 --preinstall pip-custom-platform --pip-tool pip-custom-platform

--- a/debian/tron.links
+++ b/debian/tron.links
@@ -1,0 +1,4 @@
+opt/venvs/tron/bin/trond usr/bin/trond
+opt/venvs/tron/bin/tronfig usr/bin/tronfig
+opt/venvs/tron/bin/tronctl usr/bin/tronctl
+opt/venvs/tron/bin/tronview usr/bin/tronview

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'python-daemon',
         'lockfile>=0.7',
         'SQLAlchemy>=1.0.15',
+        'yelp-clog'
     ],
     packages=find_packages(exclude=['tests.*','tests'])+['tronweb'],
     scripts=[

--- a/tests/commands/client_test.py
+++ b/tests/commands/client_test.py
@@ -47,7 +47,6 @@ class RequestTestCase(TestCase):
         http_response = build_file_mock(content)
         response = client.load_response_content(http_response)
         assert_equal(response.error, client.DECODE_ERROR)
-        assert_in('No JSON object', response.msg)
         assert_equal(response.content, content)
 
     def test_request_http_error(self):

--- a/yelp_package/trusty/Dockerfile
+++ b/yelp_package/trusty/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:trusty
+
+RUN apt-get update > /dev/null && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        debhelper \
+        dpkg-dev \
+        python-pip \
+        wget \
+        gdebi-core \
+        gcc \
+        python-dev \
+        && apt-get clean > /dev/null
+
+RUN cd /tmp && \
+    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
+    gdebi -n dh-virtualenv*.deb && \
+    rm dh-virtualenv_*.deb
+
+WORKDIR /work


### PR DESCRIPTION
Note: this also makes the python version in the virtualenv 2.7. Happy to do that in a separate PR if we want to?

I'm copy+pasting a lot of this from paasta, and am certainly no expert at debian packaging, so I'm open to feedback.

still to do: 
- [x] update the Make target for building the package
- [x] create symlinks in /usr/bin
- [x] make sure the init script for trond works

EDIT: seems the init script is broken anyway. My change hasn't broken it any more?