### PR TITLE
dont assume the USER env var

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -5,6 +5,7 @@ import stat
 import tempfile
 from textwrap import dedent
 import textwrap
+import getpass
 
 import mock
 import pytz
@@ -174,9 +175,9 @@ services:
             state_persistence=config_parse.DEFAULT_STATE_PERSISTENCE,
             nodes=FrozenDict({
                 'node0': schema.ConfigNode(name='node0',
-                    username=os.environ['USER'], hostname='node0', port=22),
+                    username=getpass.getuser(), hostname='node0', port=22),
                 'node1': schema.ConfigNode(name='node1',
-                    username=os.environ['USER'], hostname='node1', port=22)
+                    username=getpass.getuser(), hostname='node1', port=22)
             }),
             node_pools=FrozenDict({
                 'nodePool': schema.ConfigNodePool(nodes=('node0', 'node1'),

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -5,6 +5,7 @@ contain a validated configuration.
 import itertools
 import logging
 import os
+import getpass
 
 import pytz
 from tron import command_context
@@ -181,8 +182,8 @@ class ValidateNode(Validator):
     }
 
     defaults = {
-        'port':                 22,
-        'username':             os.environ['USER'],
+        'port': 22,
+        'username': getpass.getuser(),
     }
 
     def do_shortcut(self, node):
@@ -441,7 +442,7 @@ def validate_jobs_and_services(config, config_context):
 
 
 DEFAULT_STATE_PERSISTENCE = ConfigState('tron_state', 'shelve', None, 1)
-DEFAULT_NODE = ValidateNode().do_shortcut('localhost')
+DEFAULT_NODE = ValidateNode().do_shortcut(node='localhost')
 
 
 class ValidateConfig(Validator):


### PR DESCRIPTION
use the more reliable getpass.getuser() instead of expecting a USER env
var to be present.

Fixes #315