### PR TITLE
Added rerun for re-running jobs instead of restart

### DIFF
--- a/bin/tronctl
+++ b/bin/tronctl
@@ -19,6 +19,7 @@ from tron.commands import client
 
 COMMAND_HELP = (
     ('start',           'Start the selected job, job run, action, or service'),
+    ('rerun',           'Re-run a full job (all actions) with a new job id'),
     ('cancel',          'Cancel the selected job run'),
     ('disable',         'Disable selected job and cancel any outstanding runs'),
     ('enable',          'Enable the selected job and schedule the next run'),

--- a/docs/man_tronctl.rst
+++ b/docs/man_tronctl.rst
@@ -56,6 +56,9 @@ start <action_run_id>
 restart <job_run_id>
     Creates a new job run with the same run time as this job.
 
+rerun <job_run_id>
+    Creates a new job run with the same run time as this job (same as restart).
+
 cancel <job_run_id | action_run_id>
     Cancels the specified job run or action run.
 

--- a/tron/api/controller.py
+++ b/tron/api/controller.py
@@ -78,7 +78,7 @@ class JobRunController(object):
         self.job_scheduler = job_scheduler
 
     def handle_command(self, command):
-        if command == 'restart':
+        if command == 'restart' or command == 'rerun':
             runs = self.job_scheduler.manual_start(self.job_run.run_time)
             return "Created %s" % ",".join(str(run) for run in runs)
 


### PR DESCRIPTION
I would like to change the name of this command to "rerun" like in paasta. I think it makes more sense for jobs.

Once we remove the service functionality entirely I'll deprecate the "restart" command entirely in favor of rerun.