### PR TITLE
Add option to delete namespaces in tronfig

### DIFF
--- a/bin/tronfig
+++ b/bin/tronfig
@@ -34,6 +34,8 @@ def parse_options():
                       help="Print named config without a header")
     parser.add_option("-C", "--check", action="store_true", dest="check",
                       help="Only check configuration, don't apply")
+    parser.add_option("-d", "--delete", action="store_true",
+                      help="Delete the configuration for this namespace")
 
     options, args = parser.parse_args()
     set_options_from_args(options, args)
@@ -85,6 +87,22 @@ def print_config(client, config_name, no_header):
     print client.config(config_name, no_header=no_header)['config']
 
 
+def delete_config(client, config_name):
+    if config_name == schema.MASTER_NAMESPACE:
+        log.error("Deleting MASTER namespace is not allowed. Name must be specified.")
+        return
+
+    response = raw_input(
+        "This will delete the configuration for the %s namespace. Proceed? (y/n): " % config_name)
+    if response[:1].lower() != 'y':
+        return
+
+    config_hash = client.config(config_name)['hash']
+    if upload_config(client, config_name, "", config_hash):
+        return
+    raise SystemExit("tronfig deletion failed")
+
+
 def update_from_stdin(client, config_name, check=False):
     config_content = sys.stdin.read()
     config_hash = client.config(config_name)['hash']
@@ -127,7 +145,9 @@ if __name__ == '__main__':
 
     if options.print_config:
         print_config(client, config_name, options.no_header)
+    elif options.delete:
+        delete_config(client, config_name)
     elif options.from_stdin:
-        update_from_stdin(client, config_name, check=config.check)
+        update_from_stdin(client, config_name, check=options.check)
     else:
         update_with_editor(client, config_name)

--- a/tests/api/controller_test.py
+++ b/tests/api/controller_test.py
@@ -261,6 +261,33 @@ class ConfigControllerTestCase(TestCase):
         error = self.controller.update_config(name, content, config_hash)
         assert_equal(error, "Configuration has changed. Please try again.")
 
+    def test_delete_config(self):
+        name, content, config_hash = None, "", mock.Mock()
+        self.manager.get_hash.return_value = config_hash
+        assert not self.controller.delete_config(name, content, config_hash)
+        self.manager.delete_config.assert_called_with(name)
+        self.mcp.reconfigure.assert_called_with()
+        self.manager.get_hash.assert_called_with(name)
+
+    def test_delete_config_failure(self):
+        name, content, config_hash = None, "", mock.Mock()
+        self.manager.get_hash.return_value = config_hash
+        self.manager.delete_config.side_effect = Exception("some error")
+        error = self.controller.delete_config(name, content, config_hash)
+        assert error
+        self.manager.delete_config.assert_called_with(name)
+        assert not self.mcp.reconfigure.call_count
+
+    def test_delete_config_hash_mismatch(self):
+        name, content, config_hash = None, "", mock.Mock()
+        error = self.controller.delete_config(name, content, config_hash)
+        assert_equal(error, "Configuration has changed. Please try again.")
+
+    def test_delete_config_content_not_empty(self):
+        name, content, config_hash = None, "content", mock.Mock()
+        error = self.controller.delete_config(name, content, config_hash)
+        assert error
+
     def test_get_namespaces(self):
         result = self.controller.get_namespaces()
         self.manager.get_namespaces.assert_called_with()

--- a/tests/api/resource_test.py
+++ b/tests/api/resource_test.py
@@ -343,7 +343,7 @@ class ConfigResourceTestCase(TestCase):
         self.respond.assert_called_with(request,
                 self.resource.controller.read_config.return_value)
 
-    def test_render_POST(self):
+    def test_render_POST_update(self):
         name, config, hash = 'the_name', mock.Mock(), mock.Mock()
         request = build_request(name=name, config=config, hash=hash)
         self.resource.render_POST(request)
@@ -351,6 +351,16 @@ class ConfigResourceTestCase(TestCase):
         response_content = {
             'status': 'Active',
             'error': self.controller.update_config.return_value}
+        self.respond.assert_called_with(request, response_content)
+
+    def test_render_POST_delete(self):
+        name, config, hash = 'the_name', '', mock.Mock()
+        request = build_request(name=name, config=config, hash=hash)
+        self.resource.render_POST(request)
+        self.controller.delete_config.assert_called_with(name, config, hash)
+        response_content = {
+            'status': 'Active',
+            'error': self.controller.delete_config.return_value}
         self.respond.assert_called_with(request, response_content)
 
 

--- a/tests/config/manager_test.py
+++ b/tests/config/manager_test.py
@@ -70,6 +70,16 @@ class ManifestFileTestCase(TestCase):
         expected = {'zing': 'zing.yaml'}
         assert_equal(manager.read(self.manifest.filename), expected)
 
+    def test_delete(self):
+        current = {
+            'one': 'a.yaml',
+            'two': 'b.yaml',
+        }
+        manager.write(self.manifest.filename, current)
+        self.manifest.delete('one')
+        expected = {'two': 'b.yaml'}
+        assert_equal(manager.read(self.manifest.filename), expected)
+
     def test_get_file_mapping(self):
         file_mapping = {
             'one': 'a.yaml',
@@ -133,6 +143,15 @@ class ConfigManagerTestCase(TestCase):
         assert_equal(manager.read(path), self.content)
         self.manifest.get_file_name.assert_called_with(name)
         self.manifest.add.assert_called_with(name, path)
+
+    @mock.patch('os.remove', autospec=True)
+    def test_delete_config(self, mock_remove):
+        name = 'namespace'
+        path = 'namespace.yaml'
+        self.manifest.get_file_name.return_value = path
+        self.manager.delete_config(name)
+        self.manifest.delete.assert_called_with(name)
+        mock_remove.assert_called_with(path)
 
     @mock.patch('tron.config.manager.config_parse.ConfigContainer', autospec=True)
     def test_validate_with_fragment(self, mock_config_container):

--- a/tron/api/controller.py
+++ b/tron/api/controller.py
@@ -235,5 +235,20 @@ class ConfigController(object):
             log.error("Configuration update failed: %s" % e)
             return str(e)
 
+    def delete_config(self, name, content, config_hash):
+        """Delete a configuration fragment and reload the MCP."""
+        if self.config_manager.get_hash(name) != config_hash:
+            return "Configuration has changed. Please try again."
+
+        if content != "":
+            return "Configuration content is not empty, will not delete."
+
+        try:
+            self.config_manager.delete_config(name)
+            self.mcp.reconfigure()
+        except Exception, e:
+            log.error("Deleting configuration for %s failed: %s" % (name, e))
+            return str(e)
+
     def get_namespaces(self):
         return self.config_manager.get_namespaces()

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -327,6 +327,9 @@ class ConfigResource(resource.Resource):
         if check:
             fn = self.controller.check_config
             req = "configure check"
+        elif config_content == "":
+            fn = self.controller.delete_config
+            req = "configuration delete"
         else:
             fn = self.controller.update_config
             req = "reconfigure"

--- a/tron/commands/client.py
+++ b/tron/commands/client.py
@@ -100,7 +100,7 @@ class Client(object):
         check=False
     ):
         """Retrieve or update the configuration."""
-        if config_data:
+        if config_data is not None:
             data_check = 1 if check else 0
             request_data = dict(
                 config=config_data,

--- a/tron/config/manager.py
+++ b/tron/config/manager.py
@@ -60,6 +60,16 @@ class ManifestFile(object):
         manifest[name] = filename
         write(self.filename, manifest)
 
+    def delete(self, name):
+        manifest = read(self.filename)
+        if name not in manifest:
+            msg = "Name %s does not exist in manifest, cannot delete."
+            log.info(msg % name)
+            return
+
+        del manifest[name]
+        write(self.filename, manifest)
+
     def get_file_mapping(self):
         return read(self.filename)
 
@@ -92,6 +102,11 @@ class ConfigManager(object):
         self.validate_with_fragment(name, from_string(content))
         filename = self.get_filename_from_manifest(name)
         write_raw(filename, content)
+
+    def delete_config(self, name):
+        filename = self.get_filename_from_manifest(name)
+        self.manifest.delete(name)
+        os.remove(filename)
 
     def get_filename_from_manifest(self, name):
         def create_filename():


### PR DESCRIPTION
If a POST request with an empty string is sent, the namespace config file will be deleted.
