### PR TITLE
Local validation options, cleanup of unused functionality

### DIFF
--- a/bin/tronfig
+++ b/bin/tronfig
@@ -105,17 +105,18 @@ def validate_dir(path):
 def get_config_input(namespace, source=None):
     if source is None:
         source = namespace
+        namespace = None
 
     if source == '-':
         source_io = sys.stdin
-        namespace = schema.MASTER_NAMESPACE
+        namespace = namespace or schema.MASTER_NAMESPACE
     else:
         source_io = open(source, 'r')
-        namespace = os.path.basename(source)[0:-5]
+        namespace = namespace or os.path.basename(source)[0:-5]
 
     content = source_io.read()
 
-    return namespace, content, source
+    return namespace, content
 
 
 if __name__ == '__main__':
@@ -125,7 +126,7 @@ if __name__ == '__main__':
 
     if options.validate or options.validate_dir:
         if options.validate:
-            name, content, source = get_config_input(*args)
+            name, content = get_config_input(*args)
             result = validate(name, content)
         elif options.validate_dir is not None:
             result = validate_dir(options.validate_dir)

--- a/bin/tronfig
+++ b/bin/tronfig
@@ -2,7 +2,9 @@
 from __future__ import with_statement
 import logging
 import os
+import shutil
 import tempfile
+import traceback
 import sys
 
 from tron.commands import cmd_utils
@@ -14,32 +16,24 @@ from tron.config import schema, manager, ConfigError
 log = logging.getLogger('tronfig')
 
 
-def set_options_from_args(options, args):
-    if args and args[-1] == '-':
-        options.from_stdin = True
-        args = args[:-1]
-    else:
-        options.from_stdin = False
-
-    options.config_name = args[0] if args else schema.MASTER_NAMESPACE
-
-
 def parse_options():
-    usage  = "usage: %prog [<name>] [options] [-]"
+    usage  = "usage: %prog [options] [<name>] [-|path]"
     parser = cmd_utils.build_option_parser(usage)
 
     parser.add_option("-p", "--print", action="store_true", dest="print_config",
                       help="Print config to stdout, rather than uploading")
-    parser.add_option("-n", "--no-header", action="store_true", default=False,
-                      help="Print named config without a header")
     parser.add_option("-C", "--check", action="store_true", dest="check",
-                      help="Only check configuration, don't apply")
+                      help="Upload and check configuration, don't apply")
     parser.add_option("-d", "--delete", action="store_true",
                       help="Delete the configuration for this namespace")
+    parser.add_option("-V", "--validate", action="store_true", dest="validate",
+                      help="Only validate configuration, don't upload")
+    parser.add_option("-D", "--validate-dir",
+                      action="store",
+                      dest="validate_dir",
+                      help="Full validation of a folder, don't upload")
 
-    options, args = parser.parse_args()
-    set_options_from_args(options, args)
-    return options
+    return parser.parse_args()
 
 
 def upload_config(client, config_name, contents, config_hash, check=False):
@@ -58,33 +52,12 @@ def upload_config(client, config_name, contents, config_hash, check=False):
     return True
 
 
-def edit_config(contents):
-    fi = tempfile.NamedTemporaryFile(suffix='.yaml')
-    fi.write(contents)
-    fi.flush()
-
-    editor = os.getenv('EDITOR') or os.getenv('VISUAL') or 'vim'
-    while os.system("%s %s" % (editor, fi.name)):
-        response = raw_input(
-            "Editor returned an error. Continue editing? (y/n): ")
-        if response[:1].lower() == 'n':
-            return
-
-    with open(fi.name) as upload_file:
-        return upload_file.read()
-
-
-def validate(config_name, config_content):
+def validate(config_name, config_content, source=None):
     try:
         config_data = manager.from_string(config_content)
         config_parse.validate_fragment(config_name, config_data)
-        return True
     except ConfigError, e:
-        log.error(e)
-
-
-def print_config(client, config_name, no_header):
-    print client.config(config_name, no_header=no_header)['config']
+        return str(e)
 
 
 def delete_config(client, config_name):
@@ -103,51 +76,79 @@ def delete_config(client, config_name):
     raise SystemExit("tronfig deletion failed")
 
 
-def update_from_stdin(client, config_name, check=False):
-    config_content = sys.stdin.read()
-    config_hash = client.config(config_name)['hash']
-    if validate(config_name, config_content):
-        if upload_config(
-                client, config_name, config_content, config_hash, check=check):
-            return
-    raise SystemExit("tronfig failed")
+def validate_dir(path):
+    try:
+        manifest_dir = tempfile.mkdtemp()
+        manifest = manager.ManifestFile(manifest_dir)
+        manifest.create()
+        for fname in os.listdir(path):
+            if fname.endswith(".yaml"):
+                namespace = fname[0:-5]
+                manifest.add(namespace, os.path.join(path, fname))
+
+        config_manager = manager.ConfigManager(path, manifest)
+        config_manager.load()
+    except ConfigError, e:
+        traceback.print_exc()
+        return str(e)
+    finally:
+        if manifest_dir:
+            shutil.rmtree(manifest_dir)
 
 
-def update_with_editor(client, config_name):
-    if not sys.stdout.isatty():
-        raise SystemExit("No editing possible.")
+def get_config_input(namespace, source=None):
+    if source is None:
+        source = namespace
+        namespace = schema.MASTER_NAMESPACE
 
-    response        = client.config(config_name)
-    config_content  = response['config']
-    config_hash     = response['hash']
-    while True:
-        config_content = edit_config(config_content)
-        if not config_content:
-            log.warn("Cancelling edit.")
-            return
+    if source == '-':
+        source_io = sys.stdin
+    else:
+        source_io = open(source, 'r')
 
-        if validate(config_name, config_content):
-            if upload_config(client, config_name, config_content, config_hash):
-                return
+    content = source_io.read()
 
-        response = raw_input(
-            "There are errors in your configuration. Continue editing? (y/n): ")
-        if response[:1].lower() == 'n':
-            return
+    return namespace, content, source
 
 
 if __name__ == '__main__':
-    options = parse_options()
+    options, args = parse_options()
     cmd_utils.setup_logging(options)
     cmd_utils.load_config(options)
-    client = Client(options.server)
-    config_name = options.config_name
 
+    if options.validate or options.validate_dir:
+        if options.validate:
+            name, content, source = get_config_input(*args)
+            result = validate(name, content, source)
+        elif options.validate_dir is not None:
+            result = validate_dir(options.validate_dir)
+
+        if not result:
+            print "OK"
+            sys.exit(0)
+        else:
+            print result
+            sys.exit(1)
+
+    client = Client(options.server)
     if options.print_config:
-        print_config(client, config_name, options.no_header)
+        print client.config(config_name)['config']
     elif options.delete:
         delete_config(client, config_name)
     elif options.from_stdin:
         update_from_stdin(client, config_name, check=options.check)
     else:
-        update_with_editor(client, config_name)
+        name, content, source = get_config_input(*args)
+        config_hash = client.config(name)['hash']
+
+        result = validate(name, content, source)
+        if result:
+            print result
+            sys.exit(1)
+
+        if upload_config(
+                client, name, content, config_hash, check=check):
+            sys.exit(0)
+
+        print "Uploading failed"
+        sys.exit(1)

--- a/bin/tronfig
+++ b/bin/tronfig
@@ -23,15 +23,21 @@ def parse_options():
     parser.add_option("-p", "--print", action="store_true", dest="print_config",
                       help="Print config to stdout, rather than uploading")
     parser.add_option("-C", "--check", action="store_true", dest="check",
-                      help="Upload and check configuration, don't apply")
+                      help="Upload and check configuration, don't apply, "
+                           "useful when you want to verify if tron daemon "
+                           "will accept your configuration.")
     parser.add_option("-d", "--delete", action="store_true",
                       help="Delete the configuration for this namespace")
     parser.add_option("-V", "--validate", action="store_true", dest="validate",
-                      help="Only validate configuration, don't upload")
+                      help="Only validate configuration, don't upload, "
+                           "useful for verifying config locally. If namespace "
+                           "is not specified, it will be derived from file "
+                           "name, if any.")
     parser.add_option("-D", "--validate-dir",
                       action="store",
                       dest="validate_dir",
-                      help="Full validation of a folder, don't upload")
+                      help="Full validation of a folder, don't upload, "
+                           "same as -V but checks for more edge-cases")
 
     return parser.parse_args()
 
@@ -52,7 +58,7 @@ def upload_config(client, config_name, contents, config_hash, check=False):
     return True
 
 
-def validate(config_name, config_content, source=None):
+def validate(config_name, config_content):
     try:
         config_data = manager.from_string(config_content)
         config_parse.validate_fragment(config_name, config_data)
@@ -99,12 +105,13 @@ def validate_dir(path):
 def get_config_input(namespace, source=None):
     if source is None:
         source = namespace
-        namespace = schema.MASTER_NAMESPACE
 
     if source == '-':
         source_io = sys.stdin
+        namespace = schema.MASTER_NAMESPACE
     else:
         source_io = open(source, 'r')
+        namespace = os.path.basename(source)[0:-5]
 
     content = source_io.read()
 
@@ -119,7 +126,7 @@ if __name__ == '__main__':
     if options.validate or options.validate_dir:
         if options.validate:
             name, content, source = get_config_input(*args)
-            result = validate(name, content, source)
+            result = validate(name, content)
         elif options.validate_dir is not None:
             result = validate_dir(options.validate_dir)
 
@@ -131,17 +138,18 @@ if __name__ == '__main__':
             sys.exit(1)
 
     client = Client(options.server)
+
     if options.print_config:
+        name, content = get_config_input(*args)
         print client.config(config_name)['config']
     elif options.delete:
+        name = args[0]
         delete_config(client, config_name)
-    elif options.from_stdin:
-        update_from_stdin(client, config_name, check=options.check)
     else:
-        name, content, source = get_config_input(*args)
+        name, content = get_config_input(*args)
         config_hash = client.config(name)['hash']
 
-        result = validate(name, content, source)
+        result = validate(name, content)
         if result:
             print result
             sys.exit(1)

--- a/bin/tronfig
+++ b/bin/tronfig
@@ -88,8 +88,9 @@ def validate_dir(path):
         manifest = manager.ManifestFile(manifest_dir)
         manifest.create()
         for fname in os.listdir(path):
-            if fname.endswith(".yaml"):
-                namespace = fname[0:-5]
+            name, ext = os.path.splitext(fname)
+            if ext == 'yaml':
+                namespace = name
                 manifest.add(namespace, os.path.join(path, fname))
 
         config_manager = manager.ConfigManager(path, manifest)
@@ -109,10 +110,13 @@ def get_config_input(namespace, source=None):
 
     if source == '-':
         source_io = sys.stdin
-        namespace = namespace or schema.MASTER_NAMESPACE
+        if not namespace:
+            namespace = schema.MASTER_NAMESPACE
     else:
         source_io = open(source, 'r')
-        namespace = namespace or os.path.basename(source)[0:-5]
+        if not namespace:
+            name, _ = os.path.splitext(os.path.basename(source))
+            namespace = name
 
     content = source_io.read()
 

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -143,9 +143,13 @@ class ValidateSSHOptions(Validator):
 
     validators = {
         'agent':                    valid_bool,
+        # TODO: move this config and validations outside master namespace
+        # 'identities':               build_list_of_type_validator(
+        #                                 valid_identity_file, allow_empty=True),
         'identities':               build_list_of_type_validator(
-                                        valid_identity_file, allow_empty=True),
-        'known_hosts_file':         valid_known_hosts_file,
+                                        valid_string, allow_empty=True),
+        # 'known_hosts_file':         valid_known_hosts_file,
+        'known_hosts_file':         valid_string,
         'connect_timeout':          config_utils.valid_int,
         'idle_connection_timeout':  config_utils.valid_int,
         'jitter_min_load':          config_utils.valid_int,

--- a/tron/config/manager.py
+++ b/tron/config/manager.py
@@ -85,9 +85,9 @@ class ConfigManager(object):
 
     DEFAULT_HASH = hash_digest("")
 
-    def __init__(self, config_path):
+    def __init__(self, config_path, manifest=None):
         self.config_path = config_path
-        self.manifest = ManifestFile(config_path)
+        self.manifest = manifest or ManifestFile(config_path)
 
     def build_file_path(self, name):
         name = name.replace('.', '_').replace(os.path.sep, '_')


### PR DESCRIPTION
- add `-V` option to validate a single namespace file
- add `-D` option to do a full validation of a config directory
- comment out some validations for options that we intend to move out of master namespace into separate config file
- drop code related to editing namespaces directly