### PR TITLE
remove unicode_literal package since it causes unicode issue

### DIFF
--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -3,7 +3,6 @@ Web Services Interface used by command-line clients and web frontend to
 view current state, event history and send commands to trond.
 """
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import datetime
 import logging


### PR DESCRIPTION
The error message is as follows: https://fluffy.yelpcorp.com/i/kKCSLBKnW4gWT1K7fFvXXJgPN6hh7fW1.html

Or anyone has better idea about how to address this