### PR TITLE
Improve example cluster startup, and fix one remaining unicode error

### DIFF
--- a/example-cluster/README.md
+++ b/example-cluster/README.md
@@ -6,13 +6,12 @@ in the tronfig which gets deployed.
 # To Run
 
 ```
-$ docker-compose run master
+$ tox -e example-cluster
 ```
 
 # To start Tron (from inside the master container)
 
 ```
 $ cd /work
-$ pip install -e .
-$ ./bin/trond --nodaemon -c /var/lib/tron/tronfig
+$ ./example-cluster/start.sh
 ```

--- a/example-cluster/start.sh
+++ b/example-cluster/start.sh
@@ -1,4 +1,5 @@
 #/bin/sh
 
+pip install -e .
 eval $(ssh-agent)
 USER=root trond -c tronfig/ -l logging.conf --nodaemon -v

--- a/tox.ini
+++ b/tox.ini
@@ -25,3 +25,8 @@ commands=
 	dot -Tpng -odocs/images/action.png action.dot
 	dot -Tpng -odocs/images/service_instance.png service_instance.dot
 	sphinx-build -b html -d docs/_build docs docs/_build/html
+
+[testenv:example-cluster]
+deps = docker-compose>=1.10.0
+commands=
+    docker-compose -f example-cluster/docker-compose.yml run master

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -438,7 +438,7 @@ class RootResource(resource.Resource):
         self.putChild('', self)
 
     def render_GET(self, request):
-        request.redirect(request.prePathURL() + 'web')
+        request.redirect(request.prePathURL() + b'web')
         request.finish()
         return server.NOT_DONE_YET
 


### PR DESCRIPTION
Adding a tox env for the example cluster to make it easier to start. I was getting errors on my devbox with the old commands because I had an old version of docker-compose.

Also, there was one unicode error left, since it doesn't use the `respond` helper. Just adding `b'` here for completeness. After this change, `curl localhost:8089` works.