### PR TITLE
reconfigure jobs if monitoring setting has been updated

### DIFF
--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -65,6 +65,7 @@ class Job(Observable, Observer):
         'action_runner',
         'max_runtime',
         'allow_overlap',
+        'monitoring',
     ]
 
     # TODO: use config object


### PR DESCRIPTION
test it through running example-cluster, changing monitoring configuration, and curl the job via api.