### PR TITLE
add stuck status for jobs

### DIFF
--- a/bin/check_tron_jobs.py
+++ b/bin/check_tron_jobs.py
@@ -136,11 +136,9 @@ def get_relevant_action(action_runs):
 def compute_check_result_for_job(client, job):
     kwargs = {
         "name": "check_tron_job.{}".format(job['name']),
-        "team": 'noop',
-        "notification_email": job['monitoring'].get('notification_email', 'unspecified'),
-        "runbook": job['monitoring'].get('runbook', "unspecified"),
         "source": "tron",
     }
+    kwargs.update(job['monitoring'])
     status = job["status"]
     if status == "disabled":
         kwargs["output"] = "OK: {} is disabled and won't be checked.".format(

--- a/bin/check_tron_jobs.py
+++ b/bin/check_tron_jobs.py
@@ -66,6 +66,9 @@ def compute_check_result_for_job_runs(client, job, job_content):
     if last_state == "succeeded":
         prefix = "OK"
         status = 0
+    if last_state == "queued" or last_state == "cancelled":
+        prefix = "STUCK"
+        status = 1
     elif last_state == "failed":
         prefix = "CRIT"
         status = 2
@@ -106,7 +109,7 @@ def pretty_print_actions(action_run):
 
 def get_relevant_run(job_runs):
     for run in job_runs['runs']:
-        if run.get('state', 'unknown') in ["failed", "succeeded"]:
+        if run.get('state', 'unknown') in ["failed", "succeeded", "queued", "cancelled"]:
             return run
     return None
 
@@ -122,7 +125,7 @@ def compute_check_result_for_job(client, job):
     kwargs = {
         "name": "check_tron_job.{}".format(job['name']),
         "team": 'noop',
-        "notification_email": "kwa+checktron@yelp.com",
+        "notification_email": job['monitoring'].get('notification_email', 'unspecified'),
         "runbook": job['monitoring'].get('runbook', "unspecified"),
         "source": "tron",
     }

--- a/bin/check_tron_jobs.py
+++ b/bin/check_tron_jobs.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import logging
 import sys
+import time
 
 from pysensu_yelp import send_event
 
@@ -114,12 +115,14 @@ def get_relevant_run(job_runs):
 
 
 def is_job_stuck(job_runs):
+    next_run_time = None
     for run in job_runs['runs']:
-        run_state = run.get('state', 'unknown')
-        if run_state in ["running"]:
-            return False
-        if run_state in ["queued", "cancelled"]:
-            return True
+        if run.get('state', 'unknown') == "running":
+            if next_run_time:
+                difftime = time.strptime(next_run_time, '%Y-%m-%d %H:%M:%S')
+                if time.time() > time.mktime(difftime):
+                    return True
+        next_run_time = run.get('run_time', None)
     return False
 
 

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -23,7 +23,22 @@ class CheckJobsTestCase(TestCase):
         print("%s", actual)
         assert_equal(actual["state"], "failed")
 
-    def test_get_relevant_run_picks_the_one_that_queued(self):
+    def test_is_job_no_stuck(self):
+        job_runs = {
+            'status': 'running', 'next_run': None, 'runs': [
+                {
+                    'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': 'sleep 30m', 'requirements': [], 'run_num': '66', 'exit_status': None, 'stdout': None,
+                    'start_time': None, 'id': 'MASTER.kwatest.66.purposestuck', 'action_name': 'purposestuck', 'state': 'running', 'command': None, 'end_time': None, 'stderr': None, 'duration': '', 'job_name': 'MASTER.kwatest',
+                },
+                {
+                    'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': 'sleep 30m', 'requirements': [], 'run_num': '65', 'exit_status': None, 'stdout': None, 'start_time': '2018-02-14 17:10:09',
+                    'id': 'MASTER.kwatest.65.purposestuck', 'action_name': 'purposestuck', 'state': 'cancelled', 'command': 'sleep 30m', 'end_time': None, 'stderr': None, 'duration': '0:04:34.912704', 'job_name': 'MASTER.kwatest',
+                },
+            ],
+        }
+        assert_equal(check_tron_jobs.is_job_stuck(job_runs), False)
+
+    def test_is_job_stuck(self):
         job_runs = {
             'status': 'running', 'next_run': None, 'runs': [
                 {
@@ -36,23 +51,4 @@ class CheckJobsTestCase(TestCase):
                 },
             ],
         }
-        actual = check_tron_jobs.get_relevant_run(job_runs)
-        print("%s", actual)
-        assert_equal(actual["state"], "queued")
-
-    def test_get_relevant_run_picks_the_one_that_cancelled(self):
-        job_runs = {
-            'status': 'running', 'next_run': None, 'runs': [
-                {
-                    'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': 'sleep 30m', 'requirements': [], 'run_num': '66', 'exit_status': None, 'stdout': None,
-                    'start_time': None, 'id': 'MASTER.kwatest.66.purposestuck', 'action_name': 'purposestuck', 'state': 'cancelled', 'command': None, 'end_time': None, 'stderr': None, 'duration': '', 'job_name': 'MASTER.kwatest',
-                },
-                {
-                    'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': 'sleep 30m', 'requirements': [], 'run_num': '65', 'exit_status': None, 'stdout': None, 'start_time': '2018-02-14 17:10:09',
-                    'id': 'MASTER.kwatest.65.purposestuck', 'action_name': 'purposestuck', 'state': 'running', 'command': 'sleep 30m', 'end_time': None, 'stderr': None, 'duration': '0:04:34.912704', 'job_name': 'MASTER.kwatest',
-                },
-            ],
-        }
-        actual = check_tron_jobs.get_relevant_run(job_runs)
-        print("%s", actual)
-        assert_equal(actual["state"], "cancelled")
+        assert_equal(check_tron_jobs.is_job_stuck(job_runs), True)

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import time
+
 import check_tron_jobs
 from testify import assert_equal
 from testify import TestCase
@@ -27,12 +29,10 @@ class CheckJobsTestCase(TestCase):
         job_runs = {
             'status': 'running', 'next_run': None, 'runs': [
                 {
-                    'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': 'sleep 30m', 'requirements': [], 'run_num': '66', 'exit_status': None, 'stdout': None,
-                    'start_time': None, 'id': 'MASTER.kwatest.66.purposestuck', 'action_name': 'purposestuck', 'state': 'running', 'command': None, 'end_time': None, 'stderr': None, 'duration': '', 'job_name': 'MASTER.kwatest',
+                    'id': 'MASTER.test.2', 'state': 'scheduled', 'run_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time() + 600)),
                 },
                 {
-                    'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': 'sleep 30m', 'requirements': [], 'run_num': '65', 'exit_status': None, 'stdout': None, 'start_time': '2018-02-14 17:10:09',
-                    'id': 'MASTER.kwatest.65.purposestuck', 'action_name': 'purposestuck', 'state': 'cancelled', 'command': 'sleep 30m', 'end_time': None, 'stderr': None, 'duration': '0:04:34.912704', 'job_name': 'MASTER.kwatest',
+                    'id': 'MASTER.test.1', 'state': 'running', 'run_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time() - 600)),
                 },
             ],
         }
@@ -42,12 +42,10 @@ class CheckJobsTestCase(TestCase):
         job_runs = {
             'status': 'running', 'next_run': None, 'runs': [
                 {
-                    'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': 'sleep 30m', 'requirements': [], 'run_num': '66', 'exit_status': None, 'stdout': None,
-                    'start_time': None, 'id': 'MASTER.kwatest.66.purposestuck', 'action_name': 'purposestuck', 'state': 'queued', 'command': None, 'end_time': None, 'stderr': None, 'duration': '', 'job_name': 'MASTER.kwatest',
+                    'id': 'MASTER.test.1', 'state': 'queued', 'run_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time() - 600)),
                 },
                 {
-                    'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': 'sleep 30m', 'requirements': [], 'run_num': '65', 'exit_status': None, 'stdout': None, 'start_time': '2018-02-14 17:10:09',
-                    'id': 'MASTER.kwatest.65.purposestuck', 'action_name': 'purposestuck', 'state': 'running', 'command': 'sleep 30m', 'end_time': None, 'stderr': None, 'duration': '0:04:34.912704', 'job_name': 'MASTER.kwatest',
+                    'id': 'MASTER.test.2', 'state': 'running', 'run_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time() - 1200)),
                 },
             ],
         }

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -3,18 +3,56 @@ from __future__ import unicode_literals
 
 import check_tron_jobs
 from testify import assert_equal
+from testify import TestCase
 
 
-def check_relevant_action_runs_picks_the_one_that_failed():
-    action_runs = [
-        {
-            'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': '/bin/false', 'requirements': [], 'run_num': '582', 'exit_status': 1, 'stdout': None, 'start_time': '2018-02-05 17:40:00',
-            'id': 'MASTER.kwatest.582.action1', 'action_name': 'action1', 'state': 'failed', 'command': '/bin/false', 'end_time': '2018-02-05 17:40:00', 'stderr': None, 'duration': '0:00:00.065018', 'job_name': 'MASTER.kwatest',
-        },
-        {
-            'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': '/bin/true', 'requirements': [], 'run_num': '582', 'exit_status': 0, 'stdout': None, 'start_time': '2018-02-05 17:40:00',
-            'id': 'MASTER.kwatest.582.action2', 'action_name': 'action2', 'state': 'succeeded', 'command': '/bin/true', 'end_time': '2018-02-05 17:40:00', 'stderr': None, 'duration': '0:00:00.046243', 'job_name': 'MASTER.kwatest',
-        },
-    ]
-    actual = check_tron_jobs.get_relevant_action(action_runs)
-    assert_equal(actual["status"], "failed")
+class CheckJobsTestCase(TestCase):
+
+    def test_check_relevant_action_runs_picks_the_one_that_failed(self):
+        action_runs = [
+            {
+                'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': '/bin/false', 'requirements': [], 'run_num': '582', 'exit_status': 1, 'stdout': None, 'start_time': '2018-02-05 17:40:00',
+                'id': 'MASTER.kwatest.582.action1', 'action_name': 'action1', 'state': 'failed', 'command': '/bin/false', 'end_time': '2018-02-05 17:40:00', 'stderr': None, 'duration': '0:00:00.065018', 'job_name': 'MASTER.kwatest',
+            },
+            {
+                'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': '/bin/true', 'requirements': [], 'run_num': '582', 'exit_status': 0, 'stdout': None, 'start_time': '2018-02-05 17:40:00',
+                'id': 'MASTER.kwatest.582.action2', 'action_name': 'action2', 'state': 'succeeded', 'command': '/bin/true', 'end_time': '2018-02-05 17:40:00', 'stderr': None, 'duration': '0:00:00.046243', 'job_name': 'MASTER.kwatest',
+            },
+        ]
+        actual = check_tron_jobs.get_relevant_action(action_runs)
+        print("%s", actual)
+        assert_equal(actual["state"], "failed")
+
+    def test_get_relevant_run_picks_the_one_that_queued(self):
+        job_runs = {
+            'status': 'running', 'next_run': None, 'runs': [
+                {
+                    'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': 'sleep 30m', 'requirements': [], 'run_num': '66', 'exit_status': None, 'stdout': None,
+                    'start_time': None, 'id': 'MASTER.kwatest.66.purposestuck', 'action_name': 'purposestuck', 'state': 'queued', 'command': None, 'end_time': None, 'stderr': None, 'duration': '', 'job_name': 'MASTER.kwatest',
+                },
+                {
+                    'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': 'sleep 30m', 'requirements': [], 'run_num': '65', 'exit_status': None, 'stdout': None, 'start_time': '2018-02-14 17:10:09',
+                    'id': 'MASTER.kwatest.65.purposestuck', 'action_name': 'purposestuck', 'state': 'running', 'command': 'sleep 30m', 'end_time': None, 'stderr': None, 'duration': '0:04:34.912704', 'job_name': 'MASTER.kwatest',
+                },
+            ],
+        }
+        actual = check_tron_jobs.get_relevant_run(job_runs)
+        print("%s", actual)
+        assert_equal(actual["state"], "queued")
+
+    def test_get_relevant_run_picks_the_one_that_cancelled(self):
+        job_runs = {
+            'status': 'running', 'next_run': None, 'runs': [
+                {
+                    'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': 'sleep 30m', 'requirements': [], 'run_num': '66', 'exit_status': None, 'stdout': None,
+                    'start_time': None, 'id': 'MASTER.kwatest.66.purposestuck', 'action_name': 'purposestuck', 'state': 'cancelled', 'command': None, 'end_time': None, 'stderr': None, 'duration': '', 'job_name': 'MASTER.kwatest',
+                },
+                {
+                    'node': {'username': 'batch', 'hostname': 'localhost', 'name': 'localhost', 'port': 22}, 'raw_command': 'sleep 30m', 'requirements': [], 'run_num': '65', 'exit_status': None, 'stdout': None, 'start_time': '2018-02-14 17:10:09',
+                    'id': 'MASTER.kwatest.65.purposestuck', 'action_name': 'purposestuck', 'state': 'running', 'command': 'sleep 30m', 'end_time': None, 'stderr': None, 'duration': '0:04:34.912704', 'job_name': 'MASTER.kwatest',
+                },
+            ],
+        }
+        actual = check_tron_jobs.get_relevant_run(job_runs)
+        print("%s", actual)
+        assert_equal(actual["state"], "cancelled")


### PR DESCRIPTION
If a job is scheduled to run now, but there are still jobs running, couple of scenarios might happen:
    1. if allow_overlap is True, it runs anyway
    2. if queueing is True, it's marked as queued
    3. if queueing is False, it's marked as cancelled
Currently, we treat  (2) and (3) as job is stuck for some reason and send event to sensu. Let me know if you have other thought about the definition of stuck.

Make test works. And I also tested it through kwatest at devc and playground.
  