### PR TITLE
Document owner/notes/summary. Fixes #99

### DIFF
--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -78,6 +78,15 @@ Optional Fields
     Note: This requires an :ref:`action_runners` to be configured. If
     `action_runner` is none max_runtime does nothing.
 
+**owner** (default **""**)
+    A free-form string for annotating the owner of a job. Example: "ads" or "john".
+
+**notes** (default **""**)
+    A free-form string for putting notes about a job. Example: "Not idempotent!"
+
+**summary** (default **""**)
+    A free-form string for adding a summary of what the job does. Example: "Helps frob the flux capacitor"
+
 
 .. _job_actions:
 

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -55,17 +55,20 @@ class Job(Observable, Observer):
 
     # These attributes determine equality between two Job objects
     equality_attributes = [
+        'action_graph',
+        'action_runner',
+        'all_nodes',
+        'allow_overlap',
+        'max_runtime',
+        'monitoring',
         'name',
+        'node_pool',
+        'notes',
+        'output_path',
+        'owner',
         'queueing',
         'scheduler',
-        'node_pool',
-        'all_nodes',
-        'action_graph',
-        'output_path',
-        'action_runner',
-        'max_runtime',
-        'allow_overlap',
-        'monitoring',
+        'summary',
     ]
 
     # TODO: use config object


### PR DESCRIPTION
@mikepea added this feature in 2015, but we don't use it.

Do you think we actually do need it? I would rather we get rid of the code if we don't need it. (especially now that we have the "monitoring" section)