### PR TITLE
Ignore unknown ActionRuns

### DIFF
--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -687,6 +687,10 @@ class ActionRunCollectionIsRunBlockedTestCase(TestCase):
         self.run_map['action_name'].machine.state = ActionRun.STATE_FAILED
         assert self.collection._is_run_blocked(self.run_map['second_name'])
 
+    def test_is_run_blocked_required_actions_missing(self):
+        del self.run_map['action_name']
+        assert not self.collection._is_run_blocked(self.run_map['second_name'])
+
 
 if __name__ == "__main__":
     run()

--- a/tox.ini
+++ b/tox.ini
@@ -31,3 +31,4 @@ commands=
 deps = docker-compose>=1.10.0
 commands=
     docker-compose -f example-cluster/docker-compose.yml run master
+    docker-compose -f example-cluster/docker-compose.yml down

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -427,7 +427,7 @@ class ActionRunCollection(object):
         )
 
     def action_runs_for_actions(self, actions):
-        return (self.run_map[a.name] for a in actions)
+        return (self.run_map[a.name] for a in actions if a.name in self.run_map)
 
     def get_action_runs_with_cleanup(self):
         return self.run_map.itervalues()


### PR DESCRIPTION
To fix the issue where Tron can't restore the state for some old job runs because the action dependencies have changed. Described in more detail in https://jira.yelpcorp.com/browse/TRON-210.

action_runs_for_actions is only used in _is_run_blocked, to check the state of required actions. If a "required" action isn't in the action map, that action didn't exist when that job ran, so it's not really required and we can ignore it.

The real problem is that Tron assumes the current action graph applies to all job runs, but that seems much harder to fix.

Plus one tiny change to the example cluster so it will clean up after you exit - realized I've just been leaving these containers around.