### PR TITLE
store the actionrun id in the status output by action_runner

### DIFF
--- a/bin/action_runner.py
+++ b/bin/action_runner.py
@@ -5,22 +5,19 @@ Write pid and stdout/stderr to a standard location before execing a command.
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import argparse
 import contextlib
 import logging
 import os
 import subprocess
 import sys
 
-from tron import yaml
-
+import yaml
 
 log = logging.getLogger("tron.action_runner")
 
 
 STATUS_FILE = 'status'
-
-
-opener = open
 
 
 class StatusFile(object):
@@ -29,55 +26,75 @@ class StatusFile(object):
     def __init__(self, filename):
         self.filename = filename
 
-    def write(self, command, proc):
-        with opener(self.filename, 'w') as fh:
-            yaml.dump(self.get_content(command, proc), fh)
-
-    def get_content(self, command, proc):
+    def get_content(self, run_id, command, proc):
         return {
+            'run_id':       run_id,
             'command':      command,
             'pid':          proc.pid,
             'return_code':  proc.returncode,
         }
 
     @contextlib.contextmanager
-    def wrap(self, command, proc):
-        self.write(command, proc)
-        try:
-            yield
-        finally:
-            self.write(command, proc)
-
-
-class NoFile(object):
-
-    @classmethod
-    @contextlib.contextmanager
-    def wrap(self, _command, _proc):
-        yield
+    def wrap(self, command, run_id, proc):
+        with open(self.filename, 'w') as fh:
+            yaml.safe_dump(
+                self.get_content(
+                    run_id=run_id,
+                    command=command,
+                    proc=proc,
+                ), fh,
+            )
+            try:
+                yield
+            finally:
+                yaml.safe_dump(
+                    self.get_content(
+                        run_id=run_id,
+                        command=command,
+                        proc=proc,
+                    ), fh,
+                )
 
 
 def get_status_file(output_path):
-    if not os.path.isdir(output_path):
+    if os.path.isdir(output_path):
+        if not os.access(output_path, os.W_OK):
+            raise OSError("Output dir %s not writable" % output_path)
+        return StatusFile(os.path.join(output_path, STATUS_FILE))
+    else:
         try:
             os.makedirs(output_path)
         except OSError:
-            log.warn("Output path %s does not exist", output_path)
-            return NoFile
-    return StatusFile(os.path.join(output_path, STATUS_FILE))
+            raise OSError("Could not create output dir %s" % output_path)
+        return StatusFile(os.path.join(output_path, STATUS_FILE))
 
 
-def register(output_path, command, proc):
+def run_proc(output_path, command, run_id, proc):
     status_file = get_status_file(output_path)
-    with status_file.wrap(command, proc):
+    with status_file.wrap(
+        command=command,
+        run_id=run_id,
+        proc=proc,
+    ):
         proc.wait()
     sys.exit(proc.returncode)
 
 
-def parse_args(args):
-    if len(args) != 3:
-        raise SystemExit("Requires both output_path and command.")
-    return args[1:]
+def parse_args():
+    parser = argparse.ArgumentParser(description='Action Runner for Tron')
+    parser.add_argument(
+        'output_dir',
+        help='an integer for the accumulator',
+    )
+    parser.add_argument(
+        'command',
+        help='the command to run',
+    )
+    parser.add_argument(
+        'run_id',
+        help='run_id of the process',
+    )
+    return parser.parse_args()
 
 
 def run_command(command):
@@ -88,6 +105,11 @@ def run_command(command):
 
 if __name__ == "__main__":
     logging.basicConfig()
-    output_path, command = parse_args(sys.argv)
-    proc = run_command(command)
-    register(output_path, command, proc)
+    args = parse_args()
+    proc = run_command(args.command)
+    run_proc(
+        output_path=args.output_dir,
+        run_id=args.run_id,
+        command=args.command,
+        proc=proc,
+    )

--- a/tests/actioncommand_test.py
+++ b/tests/actioncommand_test.py
@@ -172,8 +172,8 @@ class SubprocessActionRunnerFactoryTestCase(TestCase):
     def test_build_command(self):
         id, command, exec_name = 'id', 'do a thing', 'exec_name'
         actual = self.factory.build_command(id, command, exec_name)
-        expected = '%s/%s "%s/%s" "%s"' % (
-            self.exec_path, exec_name, self.status_path, id, command,
+        expected = '%s/%s "%s/%s" "%s" "%s"' % (
+            self.exec_path, exec_name, self.status_path, id, command, id,
         )
         assert_equal(actual, expected)
 

--- a/tests/actioncommand_test.py
+++ b/tests/actioncommand_test.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import shlex
+
 import mock
 from testify import assert_equal
 from testify import setup
@@ -169,13 +171,19 @@ class SubprocessActionRunnerFactoryTestCase(TestCase):
         assert_equal(action_command.stdout, serializer.open.return_value)
         assert_equal(action_command.stderr, serializer.open.return_value)
 
-    def test_build_command(self):
-        id, command, exec_name = 'id', 'do a thing', 'exec_name'
+    def test_build_command_complex_quoting(self):
+        id = 'id'
+        command = '/bin/foo -c "foo" --foo "bar"'
+        exec_name = "action_runner.py"
         actual = self.factory.build_command(id, command, exec_name)
-        expected = '%s/%s "%s/%s" "%s" "%s"' % (
-            self.exec_path, exec_name, self.status_path, id, command, id,
+        assert_equal(
+            shlex.split(actual), [
+                "%s/%s" % (self.exec_path, exec_name),
+                "%s/%s" % (self.status_path, id),
+                command,
+                id,
+            ],
         )
-        assert_equal(actual, expected)
 
     def test_build_stop_action_command(self):
         id, command = 'id', 'do a thing'

--- a/tests/bin/action_runner_test.py
+++ b/tests/bin/action_runner_test.py
@@ -11,8 +11,6 @@ from testify import setup
 from testify import setup_teardown
 from testify import TestCase
 
-from tests.testingutils import autospec_method
-
 
 class StatusFileTestCase(TestCase):
 
@@ -21,22 +19,13 @@ class StatusFileTestCase(TestCase):
         self.filename = tempfile.NamedTemporaryFile().name
         self.status_file = action_runner.StatusFile(self.filename)
 
-    @mock.patch('action_runner.opener', autospec=True)
-    @mock.patch('action_runner.yaml', autospec=True)
-    def test_write(self, mock_yaml, mock_open):
-        command, proc = 'do this', mock.Mock()
-        autospec_method(self.status_file.get_content)
-        self.status_file.write(command, proc)
-        self.status_file.get_content.assert_called_with(command, proc)
-        mock_yaml.dump.assert_called_with(
-            self.status_file.get_content.return_value,
-            mock_open.return_value.__enter__.return_value,
-        )
-
     def test_get_content(self):
-        command, proc = 'do this', mock.Mock()
-        content = self.status_file.get_content(command, proc)
+        command, proc, run_id = 'do this', mock.Mock(), 'Job.test.1'
+        content = self.status_file.get_content(
+            command=command, proc=proc, run_id=run_id,
+        )
         expected = dict(
+            run_id=run_id,
             command=command, pid=proc.pid,
             return_code=proc.returncode,
         )
@@ -51,40 +40,56 @@ class RegisterTestCase(TestCase):
     def patch_sys(self):
         with contextlib.nested(
             mock.patch('action_runner.os.path.isdir', autospec=True),
-            mock.patch('action_runner.os.makedirs', autospec=True),
+            mock.patch('action_runner.os.access', autospec=True),
             mock.patch('action_runner.StatusFile', autospec=True),
         ) as (
             self.mock_isdir,
-            self.mock_makedirs,
+            self.mock_access,
             self.mock_status_file,
         ):
             self.output_path = '/bogus/path/does/not/exist'
             self.command = 'command'
+            self.run_id = 'Job.test.1'
             self.proc = mock.Mock()
             yield
 
-    def test_get_status_file_dir_does_not_exist_created(self):
+    def test_get_status_file_dir_does_not_exist(self):
         self.mock_isdir.return_value = False
-        status_file = action_runner.get_status_file(self.output_path)
-        assert_equal(status_file, self.mock_status_file.return_value)
-        self.mock_status_file.assert_called_with(
-            self.output_path + '/' + action_runner.STATUS_FILE,
+        self.mock_access.return_value = True
+        with mock.patch('action_runner.os.makedirs') as m:
+            action_runner.get_status_file(self.output_path)
+            m.assert_called_with(self.output_path)
+
+    def test_get_status_file_dir_does_not_exist_create_fails(self):
+        self.mock_isdir.return_value = False
+        self.mock_access.return_value = True
+        with mock.patch('action_runner.os.makedirs') as m:
+            m.side_effect = OSError
+            self.failUnlessRaises(
+                OSError, action_runner.get_status_file, self.output_path,
+            )
+
+    def test_get_status_file_exists_not_writable(self):
+        self.mock_isdir.return_value = True
+        self.mock_access.return_value = False
+        self.failUnlessRaises(
+            OSError, action_runner.get_status_file, self.output_path,
         )
 
-    def test_get_status_file_dir_does_not_exist_create_failed(self):
-        self.mock_isdir.return_value = False
-        self.mock_makedirs.side_effect = OSError
-        status_file = action_runner.get_status_file(self.output_path)
-        assert_equal(status_file, action_runner.NoFile)
-
     @mock.patch('action_runner.sys.exit', autospec=True)
-    def test_register(self, mock_sys_exit):
-        action_runner.register(self.output_path, self.command, self.proc)
+    def test_run_proc(self, mock_sys_exit):
+        self.mock_isdir.return_value = True
+        self.mock_access.return_value = True
+        action_runner.run_proc(
+            self.output_path, self.command, self.run_id, self.proc,
+        )
         self.mock_status_file.assert_called_with(
             self.output_path + '/' + action_runner.STATUS_FILE,
         )
         self.mock_status_file.return_value.wrap.assert_called_with(
-            self.command, self.proc,
+            command=self.command,
+            run_id=self.run_id,
+            proc=self.proc,
         )
         self.proc.wait.assert_called_with()
         mock_sys_exit.assert_called_with(self.proc.returncode)

--- a/tron/actioncommand.py
+++ b/tron/actioncommand.py
@@ -196,7 +196,7 @@ class SubprocessActionRunnerFactory(object):
     def build_command(self, id, command, exec_name):
         status_path = os.path.join(self.status_path, id)
         runner_path = os.path.join(self.exec_path, exec_name)
-        return '''%s "%s" "%s"''' % (runner_path, status_path, command)
+        return '''%s "%s" "%s" "%s"''' % (runner_path, status_path, command, id)
 
     def build_stop_action_command(self, id, command):
         command = self.build_command(id, command, self.status_exec_name)

--- a/tron/actioncommand.py
+++ b/tron/actioncommand.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import logging
 import os
 
+from six.moves import shlex_quote
+
 from tron.config import schema
 from tron.serialize import filehandler
 from tron.utils import state
@@ -196,7 +198,12 @@ class SubprocessActionRunnerFactory(object):
     def build_command(self, id, command, exec_name):
         status_path = os.path.join(self.status_path, id)
         runner_path = os.path.join(self.exec_path, exec_name)
-        return '''%s "%s" "%s" "%s"''' % (runner_path, status_path, command, id)
+        return "%s %s %s %s" % (
+            shlex_quote(runner_path),
+            shlex_quote(status_path),
+            shlex_quote(command),
+            shlex_quote(id),
+        )
 
     def build_stop_action_command(self, id, command):
         command = self.build_command(id, command, self.status_exec_name)

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -267,7 +267,9 @@ class ActionRun(Observer):
         """Create a new ActionCommand instance to send to the node."""
         serializer = filehandler.OutputStreamSerializer(self.output_path)
         self.action_command = self.action_runner.create(
-            self.id, self.command, serializer,
+            id=self.id,
+            command=self.command,
+            serializer=serializer,
         )
         self.watch(self.action_command)
         return self.action_command


### PR DESCRIPTION
- changes action_runner to use argparse
- add the run_id as an arg to go in the status file
- just use pyyaml rather than the tron version, so that you don't need the tron package installed to use it. I'm open to reverting this, it mostly makes it easier to test (and the performance impact will be nbd for the action_runner)

here's the lines from the state file that the action_runner left behind

```
root@26a95ee742b5:/tmp/tron/MASTER.test.9085.first# cat status
{command: echo hi >> out && sleep 20, pid: 8540, return_code: null, run_id: MASTER.test.9085.first}
{command: echo hi >> out && sleep 20, pid: 8540, return_code: 0, run_id: MASTER.test.9085.first}
```