### PR TITLE
improving stuck job checking when runtime of job run unsorted

### DIFF
--- a/bin/check_tron_jobs.py
+++ b/bin/check_tron_jobs.py
@@ -64,20 +64,25 @@ def compute_check_result_for_job_runs(client, job, job_content):
     action_run_details = client.action_runs(action_run_id.url, num_lines=10)
 
     if is_job_stuck(job_content):
-        prefix = "Job still running when next job is scheduled to run (stuck?)"
+        prefix = "WARN"
+        annotation = "Job still running when next job is scheduled to run (stuck?)"
         status = 1
     elif last_state == "succeeded":
         prefix = "OK"
+        annotation = ""
         status = 0
     elif last_state == "failed":
         prefix = "CRIT"
+        annotation = ""
         status = 2
     else:
         prefix = "UNKNOWN"
+        annotation = ""
         status = 3
 
     kwargs["output"] = (
-        "{}: {}'s last relevant run (run {}) {}.\n\n"
+        "{}: {}\n"
+        "{}'s last relevant run (run {}) {}.\n\n"
         "Here is the last action:"
         "{}\n\n"
         "And the job run view:\n"
@@ -85,7 +90,7 @@ def compute_check_result_for_job_runs(client, job, job_content):
         "Here are is the whole job view for context:\n"
         "{}"
     ).format(
-        prefix, job['name'], relevant_job_run['id'], last_state,
+        prefix, annotation, job['name'], relevant_job_run['id'], last_state,
         pretty_print_actions(action_run_details),
         pretty_print_job_run(relevant_job_run),
         pretty_print_job(job_content),

--- a/bin/check_tron_jobs.py
+++ b/bin/check_tron_jobs.py
@@ -64,7 +64,7 @@ def compute_check_result_for_job_runs(client, job, job_content):
     action_run_details = client.action_runs(action_run_id.url, num_lines=10)
 
     if is_job_stuck(job_content):
-        prefix = "STUCK"
+        prefix = "Job still running when next job is scheduled to run (stuck?)"
         status = 1
     elif last_state == "succeeded":
         prefix = "OK"
@@ -116,7 +116,7 @@ def get_relevant_run(job_runs):
 
 def is_job_stuck(job_runs):
     next_run_time = None
-    for run in job_runs['runs']:
+    for run in sorted(job_runs['runs'], key=lambda k: k['run_time'], reverse=True):
         if run.get('state', 'unknown') == "running":
             if next_run_time:
                 difftime = time.strptime(next_run_time, '%Y-%m-%d %H:%M:%S')

--- a/bin/check_tron_jobs.py
+++ b/bin/check_tron_jobs.py
@@ -87,7 +87,7 @@ def compute_check_result_for_job_runs(client, job, job_content):
         "{}\n\n"
         "And the job run view:\n"
         "{}\n\n"
-        "Here are is the whole job view for context:\n"
+        "Here is the whole job view for context:\n"
         "{}"
     ).format(
         prefix, annotation, job['name'], relevant_job_run['id'], last_state,

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -21,8 +21,7 @@ class CheckJobsTestCase(TestCase):
                 'id': 'MASTER.kwatest.582.action2', 'action_name': 'action2', 'state': 'succeeded', 'command': '/bin/true', 'end_time': '2018-02-05 17:40:00', 'stderr': None, 'duration': '0:00:00.046243', 'job_name': 'MASTER.kwatest',
             },
         ]
-        actual = check_tron_jobs.get_relevant_action(action_runs)
-        print("%s", actual)
+        actual = check_tron_jobs.get_relevant_action(action_runs, 'failed')
         assert_equal(actual["state"], "failed")
 
     def test_is_job_no_stuck(self):
@@ -36,7 +35,8 @@ class CheckJobsTestCase(TestCase):
                 },
             ],
         }
-        assert_equal(check_tron_jobs.is_job_stuck(job_runs), False)
+        run = check_tron_jobs.is_job_stuck(job_runs)
+        assert_equal(run, None)
 
     def test_is_job_stuck(self):
         job_runs = {
@@ -49,7 +49,8 @@ class CheckJobsTestCase(TestCase):
                 },
             ],
         }
-        assert_equal(check_tron_jobs.is_job_stuck(job_runs), True)
+        run = check_tron_jobs.is_job_stuck(job_runs)
+        assert_equal(run['id'], 'MASTER.test.1')
 
     def test_is_job_stuck_when_runtime_not_sorted(self):
         job_runs = {
@@ -62,4 +63,5 @@ class CheckJobsTestCase(TestCase):
                 },
             ],
         }
-        assert_equal(check_tron_jobs.is_job_stuck(job_runs), True)
+        run = check_tron_jobs.is_job_stuck(job_runs)
+        assert_equal(run['id'], 'MASTER.test.2')

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -42,10 +42,23 @@ class CheckJobsTestCase(TestCase):
         job_runs = {
             'status': 'running', 'next_run': None, 'runs': [
                 {
-                    'id': 'MASTER.test.1', 'state': 'queued', 'run_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time() - 600)),
+                    'id': 'MASTER.test.2', 'state': 'queued', 'run_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time() - 600)),
                 },
                 {
-                    'id': 'MASTER.test.2', 'state': 'running', 'run_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time() - 1200)),
+                    'id': 'MASTER.test.1', 'state': 'running', 'run_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time() - 1200)),
+                },
+            ],
+        }
+        assert_equal(check_tron_jobs.is_job_stuck(job_runs), True)
+
+    def test_is_job_stuck_when_runtime_not_sorted(self):
+        job_runs = {
+            'status': 'running', 'next_run': None, 'runs': [
+                {
+                    'id': 'MASTER.test.2', 'state': 'running', 'run_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time() - 600)),
+                },
+                {
+                    'id': 'MASTER.test.1', 'state': 'scheduled', 'run_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
                 },
             ],
         }


### PR DESCRIPTION
add one unit test for the scenario that user manually start a job and it's stuck.
make test pass