### PR TITLE
Fix tronview bug and include six in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'pysensu-yelp',
         'python-daemon',
         'lockfile>=0.7',
+        'six>=1.11.0',
         'SQLAlchemy>=1.0.15',
         'yelp-clog',
     ],

--- a/tests/commands/display_test.py
+++ b/tests/commands/display_test.py
@@ -75,21 +75,6 @@ class DisplayJobRunsTestCase(TestCase):
             ),
         ]
 
-        self.action_run = dict(
-            id='something.23.other',
-            name='other',
-            state='FAIL',
-            node=mock.MagicMock(),
-            command='echo 123',
-            raw_command='echo 123',
-            run_time='2012-01-20 23:11:23',
-            start_time='2012-01-20 23:11:23',
-            end_time='2012-02-21 23:10:10',
-            duration='2 days',
-            stdout=[],
-            stderr=[],
-        )
-
     def test_format(self):
         out = DisplayJobRuns().format(self.data)
         lines = out.split('\n')
@@ -103,44 +88,12 @@ class DisplayJobsTestCase(TestCase):
         self.data = [
             dict(
                 name='important_things', status='running',
-                scheduler=mock.MagicMock(), last_success='unknown', owner='alice',
+                scheduler=mock.MagicMock(), last_success=None, owner='alice',
             ),
             dict(
-                name='other_thing', status='success',
+                name='other_thing', status='enabled',
                 scheduler=mock.MagicMock(), last_success='2012-01-23 10:23:23',
-                action_names=['other', 'first'],
-                node_pool=['blam'], owner=['bob', 'ted'],
-            ),
-        ]
-        self.run_data = [
-            dict(
-                id='something.23', state='FAIL', node='machine4',
-                run_time='2012-01-20 23:11:23',
-                start_time='2012-01-20 23:11:23',
-                end_time='2012-02-21 23:10:10',
-                duration='2 days',
-                runs=[dict(
-                    id='something.23.other',
-                    name='other',
-                    state='FAIL',
-                    node=mock.MagicMock(),
-                    command='echo 123',
-                    raw_command='echo 123',
-                    run_time='2012-01-20 23:11:23',
-                    start_time='2012-01-20 23:11:23',
-                    end_time='2012-02-21 23:10:10',
-                    duration='2 days',
-                    stdout=[],
-                    stderr=[],
-                )],
-            ),
-            dict(
-                id='something.55', state='QUE', node='machine3',
-                run_time='2012-01-20 23:11:23',
-                start_time='2012-01-20 23:11:23',
-                end_time='',
-                duration='',
-                runs=[],
+                owner='',
             ),
         ]
 

--- a/tron/commands/display.py
+++ b/tron/commands/display.py
@@ -139,7 +139,7 @@ class TableDisplay(object):
         return value.ljust(length)
 
     def format_value(self, field_idx, value):
-        return value
+        return str(value)
 
     def output(self):
         out = "\n".join(self.out)
@@ -385,9 +385,6 @@ class DisplayJobs(TableDisplay):
     def format_value(self, field_idx, value):
         if self.fields[field_idx] == 'scheduler':
             value = display_scheduler(value)
-        elif self.fields[field_idx] == 'owner':
-            if isinstance(value, list):
-                value = ', '.join(value)
 
         return super(DisplayJobs, self).format_value(field_idx, value)
 


### PR DESCRIPTION
The cast in format_value ensures that all values (including None, which caused TRON-217) are strings. It used to cast all values with `unicode()`, but that was taken out in the python3 conversion. Using str() now. I know this is bytes for python2, but the value gets converted to unicode elsewhere and tronview still works with this change, so meh?

Updated the tests for display to cover that case, and took out some data that wasn't being used.