### PR TITLE
rmove notes/summary/owner

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -204,9 +204,6 @@ services:
                     name='MASTER.test_job0',
                     namespace='MASTER',
                     node='node0',
-                    owner='',
-                    summary='',
-                    notes='',
                     monitoring={},
                     schedule=ConfigIntervalScheduler(
                         timedelta=datetime.timedelta(0, 20), jitter=None,
@@ -236,9 +233,6 @@ services:
                     namespace='MASTER',
                     node='node0',
                     enabled=True,
-                    owner='',
-                    summary='',
-                    notes='',
                     monitoring={},
                     schedule=schedule_parse.ConfigDailyScheduler(
                         days={1, 3, 5},
@@ -272,9 +266,6 @@ services:
                     namespace='MASTER',
                     node='node1',
                     enabled=True,
-                    owner='',
-                    summary='',
-                    notes='',
                     monitoring={},
                     schedule=schedule_parse.ConfigDailyScheduler(
                         days=set(),
@@ -303,9 +294,6 @@ services:
                     node='node1',
                     schedule=ConfigConstantScheduler(),
                     enabled=True,
-                    owner='',
-                    summary='',
-                    notes='',
                     monitoring={},
                     actions=FrozenDict({
                         'action3_1': schema.ConfigAction(
@@ -338,9 +326,6 @@ services:
                     name='MASTER.test_job4',
                     namespace='MASTER',
                     node='nodePool',
-                    owner='',
-                    summary='',
-                    notes='',
                     monitoring={},
                     schedule=schedule_parse.ConfigDailyScheduler(
                         days=set(),
@@ -376,9 +361,6 @@ services:
                         monitor_interval=20,
                         monitor_retries=5,
                         restart_delay=None,
-                        owner='',
-                        summary='',
-                        notes='',
                         count=2,
                     ),
                 },
@@ -456,13 +438,6 @@ jobs:
         name: "test_job2"
         node: node1
         schedule: "daily 16:30:00"
-        owner: "bob@example.com"
-        summary: "Flobbles the jibber service into submission"
-        notes: |
-          This is a multiple line notes section for
-          giving information about this job.
-
-          Second sentence.
         monitoring: {}
         actions:
             -
@@ -512,13 +487,6 @@ services:
         count: 20
         pid_file: "/var/run/%(name)s-%(instance_number)s.pid"
         monitor_interval: 40
-        owner: "bob@example.com"
-        summary: "Jibber service, handles dequeueing submitted flobbles"
-        notes: |
-          This is a multiple line notes section for
-          giving information about this job.
-
-          Second sentence.
 """
 
     def test_attributes(self):
@@ -528,9 +496,6 @@ services:
                     name='test_job0',
                     namespace='test_namespace',
                     node='node0',
-                    owner='',
-                    summary='',
-                    notes='',
                     monitoring={},
                     schedule=ConfigIntervalScheduler(
                         timedelta=datetime.timedelta(0, 20),
@@ -561,9 +526,6 @@ services:
                     namespace='test_namespace',
                     node='node0',
                     enabled=True,
-                    owner='',
-                    summary='',
-                    notes='',
                     monitoring={},
                     schedule=schedule_parse.ConfigDailyScheduler(
                         days={1, 3, 5},
@@ -599,9 +561,6 @@ services:
                     namespace='test_namespace',
                     node='node1',
                     enabled=True,
-                    owner='bob@example.com',
-                    summary='Flobbles the jibber service into submission',
-                    notes='This is a multiple line notes section for\ngiving information about this job.\n\nSecond sentence.\n',
                     monitoring={},
                     schedule=schedule_parse.ConfigDailyScheduler(
                         days=set(),
@@ -632,9 +591,6 @@ services:
                     node='node1',
                     schedule=ConfigConstantScheduler(),
                     enabled=True,
-                    owner='',
-                    summary='',
-                    notes='',
                     monitoring={},
                     actions=FrozenDict({
                         'action3_1': schema.ConfigAction(
@@ -667,9 +623,6 @@ services:
                     name='test_job4',
                     namespace='test_namespace',
                     node='NodePool',
-                    owner='',
-                    summary='',
-                    notes='',
                     monitoring={},
                     schedule=schedule_parse.ConfigDailyScheduler(
                         days=set(),
@@ -700,9 +653,6 @@ services:
                         namespace='test_namespace',
                         name='service0',
                         node='NodePool',
-                        owner='',
-                        summary='',
-                        notes='',
                         pid_file='/var/run/%(name)s-%(instance_number)s.pid',
                         command='service_command0',
                         monitor_interval=20,
@@ -714,9 +664,6 @@ services:
                         namespace='test_namespace',
                         name='service1',
                         node='NodePool',
-                        owner='bob@example.com',
-                        summary='Jibber service, handles dequeueing submitted flobbles',
-                        notes='This is a multiple line notes section for\ngiving information about this job.\n\nSecond sentence.\n',
                         pid_file='/var/run/%(name)s-%(instance_number)s.pid',
                         command='service_command1',
                         monitor_interval=40.0,
@@ -1112,9 +1059,6 @@ class ValidateJobsAndServicesTestCase(TestCase):
                 name='MASTER.test_job0',
                 namespace='MASTER',
                 node='node0',
-                owner='',
-                summary='',
-                notes='',
                 monitoring={},
                 schedule=ConfigIntervalScheduler(
                     timedelta=datetime.timedelta(0, 20), jitter=None,
@@ -1146,9 +1090,6 @@ class ValidateJobsAndServicesTestCase(TestCase):
                 name='MASTER.test_service0',
                 namespace='MASTER',
                 node='node0',
-                owner='',
-                summary='',
-                notes='',
                 pid_file='/var/run/%(name)s-%(instance_number)s.pid',
                 command='service_command0',
                 monitor_interval=20,

--- a/tron/api/adapter.py
+++ b/tron/api/adapter.py
@@ -243,9 +243,6 @@ class JobAdapter(ReprAdapter):
         'runs',
         'max_runtime',
         'action_graph',
-        'owner',
-        'summary',
-        'notes',
         'monitoring',
     ]
 
@@ -264,15 +261,6 @@ class JobAdapter(ReprAdapter):
 
     def get_name(self):
         return self._obj.get_name()
-
-    def get_owner(self):
-        return self._obj.get_owner()
-
-    def get_summary(self):
-        return self._obj.get_summary()
-
-    def get_notes(self):
-        return self._obj.get_notes()
 
     def get_monitoring(self):
         return self._obj.get_monitoring()
@@ -359,9 +347,6 @@ class ServiceAdapter(ReprAdapter):
         'live_count',
         'monitor_interval',
         'restart_delay',
-        'owner',
-        'summary',
-        'notes',
         'events',
     ]
 
@@ -374,15 +359,6 @@ class ServiceAdapter(ReprAdapter):
 
     def get_count(self):
         return self._obj.config.count
-
-    def get_owner(self):
-        return self._obj.config.owner
-
-    def get_summary(self):
-        return self._obj.config.summary
-
-    def get_notes(self):
-        return self._obj.config.notes
 
     def get_state(self):
         return self._obj.get_state()

--- a/tron/commands/display.py
+++ b/tron/commands/display.py
@@ -284,8 +284,6 @@ class DisplayServices(TableDisplay):
 
     detail_labels = [
         ('Service',             'name'),
-        ('Owner',               'owner'),
-        ('Summary',             'summary'),
         ('Enabled',             'enabled'),
         ('State',               'state'),
         ('Max instances',       'count'),
@@ -295,7 +293,6 @@ class DisplayServices(TableDisplay):
         ('Monitor interval',    'monitor_interval'),
         ('Restart delay',       'restart_delay'),
         ('Restart delay',       'restart_delay'),
-        ('Notes',               'notes'),
     ]
 
     colors = {
@@ -365,8 +362,6 @@ class DisplayJobs(TableDisplay):
 
     detail_labels = [
         ('Job',                 'name'),
-        ('Owner',               'owner'),
-        ('Summary',             'summary'),
         ('State',               'status'),
         ('Scheduler',           'scheduler'),
         ('Max runtime',         'max_runtime'),
@@ -374,7 +369,6 @@ class DisplayJobs(TableDisplay):
         ('Run on all nodes',    'all_nodes'),
         ('Allow overlapping',   'allow_overlap'),
         ('Queue overlapping',   'queueing'),
-        ('Notes',               'notes'),
     ]
 
     colors = {

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -312,10 +312,7 @@ class ValidateJob(Validator):
         'queueing':             True,
         'allow_overlap':        False,
         'max_runtime':          None,
-        'notes':                '',
         'monitoring':           {},
-        'owner':                '',
-        'summary':              '',
     }
 
     validators = {
@@ -330,9 +327,6 @@ class ValidateJob(Validator):
         'enabled':              valid_bool,
         'allow_overlap':        valid_bool,
         'max_runtime':          config_utils.valid_time_delta,
-        'owner':                valid_string,
-        'summary':              valid_string,
-        'notes':                valid_string,
         'monitoring':           valid_dict,
     }
 
@@ -391,9 +385,6 @@ class ValidateService(Validator):
         'count':                1,
         'monitor_retries':      5,
         'restart_delay':        None,
-        'notes':                '',
-        'owner':                '',
-        'summary':              '',
     }
 
     validators = {
@@ -405,9 +396,6 @@ class ValidateService(Validator):
         'count':                valid_int,
         'node':                 valid_node_name,
         'restart_delay':        valid_float,
-        'owner':                valid_string,
-        'summary':              valid_string,
-        'notes':                valid_string,
     }
 
     def cast(self, in_dict, config_context):

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -119,9 +119,6 @@ ConfigJob = config_object_factory(
         'actions',              # FrozenDict of ConfigAction
         'namespace',            # str
     ], [
-        'owner',                # str
-        'summary',              # str
-        'notes',                # str
         'monitoring',           # dict
         'queueing',             # bool
         'run_limit',            # int
@@ -166,9 +163,6 @@ ConfigService = config_object_factory(
         'monitor_interval',     # float
         'namespace',            # str
     ], [
-        'owner',                # str
-        'summary',              # str
-        'notes',                # str
         'restart_delay',        # float
         'monitor_retries',      # int
         'count',                # int

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -71,16 +71,12 @@ class Job(Observable, Observer):
     # TODO: use config object
     def __init__(
         self, name, scheduler, queueing=True, all_nodes=False,
-        owner='', summary='', notes='', monitoring=None,
-        node_pool=None, enabled=True, action_graph=None,
+        monitoring=None, node_pool=None, enabled=True, action_graph=None,
         run_collection=None, parent_context=None, output_path=None,
         allow_overlap=None, action_runner=None, max_runtime=None,
     ):
         super(Job, self).__init__()
         self.name = name
-        self.owner = owner
-        self.summary = summary
-        self.notes = notes
         self.monitoring = monitoring
         self.action_graph = action_graph
         self.scheduler = scheduler
@@ -112,9 +108,6 @@ class Job(Observable, Observer):
 
         return cls(
             name=job_config.name,
-            owner=job_config.owner,
-            summary=job_config.summary,
-            notes=job_config.notes,
             monitoring=job_config.monitoring,
             queueing=job_config.queueing,
             all_nodes=job_config.all_nodes,
@@ -155,15 +148,6 @@ class Job(Observable, Observer):
 
     def get_name(self):
         return self.name
-
-    def get_owner(self):
-        return self.owner
-
-    def get_summary(self):
-        return self.summary
-
-    def get_notes(self):
-        return self.notes
 
     def get_monitoring(self):
         return self.monitoring


### PR DESCRIPTION
I've searched at tronfig and tronfig-notprod repos, only job "hello-world" at devc uses notes/summary/owner. If I got ship it for this, I would update that job as well as validate_tronfig.py at tronfig-notprod before this one being merged.