### PR TITLE
remove owner from tronview display

### DIFF
--- a/tests/commands/display_test.py
+++ b/tests/commands/display_test.py
@@ -24,15 +24,15 @@ class DisplayServicesTestCase(TestCase):
         self.data = [
             dict(
                 name="My Service",      state="stopped",
-                live_count="4", owner="alice", enabled=True,
+                live_count="4", enabled=True,
             ),
             dict(
                 name="Another Service", state="running",
-                live_count="2", owner="bob",   enabled=False,
+                live_count="2", enabled=False,
             ),
             dict(
                 name="Yet another",     state="running",
-                live_count="1", owner="ted",   enabled=True,
+                live_count="1", enabled=True,
             ),
         ]
         self.display = DisplayServices()
@@ -88,12 +88,11 @@ class DisplayJobsTestCase(TestCase):
         self.data = [
             dict(
                 name='important_things', status='running',
-                scheduler=mock.MagicMock(), last_success=None, owner='alice',
+                scheduler=mock.MagicMock(), last_success=None,
             ),
             dict(
                 name='other_thing', status='enabled',
                 scheduler=mock.MagicMock(), last_success='2012-01-23 10:23:23',
-                owner='',
             ),
         ]
 

--- a/tron/commands/display.py
+++ b/tron/commands/display.py
@@ -276,9 +276,9 @@ def format_action_run_details(content, stdout=True, stderr=True):
 
 class DisplayServices(TableDisplay):
 
-    columns = ['Name',  'State',    'Count',      'Owner']
-    fields = ['name',  'state',    'live_count', 'owner']
-    widths = [50,      12,          7,           30]
+    columns = ['Name',  'State',    'Count']
+    fields = ['name',  'state',    'live_count']
+    widths = [50,      12,          7]
     title = 'services'
     resize_fields = ['name']
 
@@ -354,9 +354,9 @@ class DisplayJobRuns(TableDisplay):
 
 class DisplayJobs(TableDisplay):
 
-    columns = ['Name',  'State',    'Scheduler',    'Last Success',  'Owner']
-    fields = ['name',  'status',   'scheduler',    'last_success',  'owner']
-    widths = [50,       10,         20,             22,             30]
+    columns = ['Name',  'State',    'Scheduler',    'Last Success']
+    fields = ['name',  'status',   'scheduler',    'last_success']
+    widths = [50,       10,         20,             22]
     title = 'jobs'
     resize_fields = ['name']
 


### PR DESCRIPTION
tronview is broken in tronplayground right now - this fixes

```
robj@tronplayground-uswest1adevc:~  % tronview
Traceback (most recent call last):
  File "/usr/bin/tronview", line 150, in <module>
    main()
  File "/usr/bin/tronview", line 135, in main
    output = view_all(options, client)
  File "/usr/bin/tronview", line 70, in view_all
    display.DisplayJobs().format(client.jobs()),
  File "/opt/venvs/tron/local/lib/python2.7/site-packages/tron/commands/display.py", line 191, in format
    self.out.append(self.format_row(row))
  File "/opt/venvs/tron/local/lib/python2.7/site-packages/tron/commands/display.py", line 127, in format_row
    for i, value in enumerate(self.sorted_fields(fields))
  File "/opt/venvs/tron/local/lib/python2.7/site-packages/tron/commands/display.py", line 122, in sorted_fields
    return [values[name] for name in self.fields]
KeyError: u'owner'
```