### PR TITLE
Upgrade to argparse

### DIFF
--- a/bin/check_tron_jobs.py
+++ b/bin/check_tron_jobs.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import logging
+import time
 
 from pysensu_yelp import send_event
 

--- a/bin/check_tron_jobs.py
+++ b/bin/check_tron_jobs.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import logging
-import sys
-import time
 
 from pysensu_yelp import send_event
 
@@ -17,19 +15,18 @@ from tron.commands.client import get_object_type_from_identifier
 log = logging.getLogger('check_tron_jobs')
 
 
-def parse_options():
-    usage = ""
-    parser = cmd_utils.build_option_parser(usage)
-    parser.add_option(
+def parse_cli():
+    parser = cmd_utils.build_option_parser()
+    parser.add_argument(
         "--dry-run", action="store_true", default=False,
-        help="Don't actually send alerts out. Defaults to %default",
+        help="Don't actually send alerts out. Defaults to %(default)s",
     )
-    parser.add_option(
+    parser.add_argument(
         "--job", default=None,
         help="Check a particular job. If unset checks all jobs",
     )
-    options, args = parser.parse_args(sys.argv)
-    return options, args[1:]
+    args = parser.parse_args()
+    return args
 
 
 def compute_check_result_for_job_runs(client, job, job_content):
@@ -185,19 +182,19 @@ def check_job_result(job, client, dry_run):
 
 
 def main():
-    options, args = parse_options()
-    cmd_utils.setup_logging(options)
-    cmd_utils.load_config(options)
-    client = Client(options.server)
+    args = parse_cli()
+    cmd_utils.setup_logging(args)
+    cmd_utils.load_config(args)
+    client = Client(args.server)
 
-    if options.job is None:
+    if args.job is None:
         jobs = client.jobs(include_job_runs=True)
         for job in jobs:
-            check_job_result(job=job, client=client, dry_run=options.dry_run)
+            check_job_result(job=job, client=client, dry_run=args.dry_run)
     else:
-        job_url = client.get_url(options.job)
+        job_url = client.get_url(args.job)
         job = client.job_runs(job_url)
-        check_job_result(job=job, client=client, dry_run=options.dry_run)
+        check_job_result(job=job, client=client, dry_run=args.dry_run)
 
 
 if __name__ == '__main__':

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -8,9 +8,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import argparse
 import datetime
 import logging
-import optparse
 import sys
 import urlparse
 
@@ -38,49 +38,55 @@ COMMAND_HELP = (
 log = logging.getLogger('tronctl')
 
 
-class TronCtlOptionParser(optparse.OptionParser):
-    def format_epilog(self, formatter):
-        # We want to include some extra helpful info
-        result = [formatter.format_heading("Commands")]
-        formatter.indent()
-        for cmd_name, desc in COMMAND_HELP:
-            text = ''.join((cmd_name.ljust(20), desc.ljust(40)))
-            result.append(formatter._format_text(text))
-            result.append('\n')
-
+def command_help_epilog():
+    # We want to include some extra helpful info
+    result = ["commands:", "\n"]
+    for cmd_name, desc in COMMAND_HELP:
+        result.append('  ')
+        text = ''.join((cmd_name.ljust(15), desc.ljust(40)))
+        result.append(text)
         result.append('\n')
-        return ''.join(result)
+    return ''.join(result)
 
 
-def parse_date(option, opt_str, value, parser):
-    parser.values.run_date = datetime.datetime.strptime(value, "%Y-%m-%d")
+def parse_date(date_string):
+    return datetime.datetime.strptime(date_string, "%Y-%m-%d")
 
 
-def parse_options():
-    usage = "usage: %prog [options] <command> [<job | job run | action>]"
+def parse_cli():
     parser = cmd_utils.build_option_parser(
-        usage, parser_class=TronCtlOptionParser,
+        parser_class=argparse.ArgumentParser,
+        epilog=command_help_epilog(),
     )
 
-    parser.add_option(
-        "--run-date", action="callback", callback=parse_date,
-        type="string", dest="run_date",
+    parser.add_argument(
+        "--run-date",
+        type=parse_date, dest="run_date",
         help="For job starts, what should run date be set to",
     )
+    parser.add_argument(
+        'command',
+        help='Tronctl command to run',
+        choices=[row[0] for row in COMMAND_HELP],
+    )
+    parser.add_argument(
+        'ids',
+        nargs='*',
+        # TODO: this right?
+        help='job name, job run id, or action id',
+    )
 
-    options, args = parser.parse_args(sys.argv)
-    if len(args) < 2:
-        parser.error("Missing command")
+    args = parser.parse_args()
 
-    return options, args[1:]
+    return args
 
 
-def edit(options, command, uri):
-    data = {'command': command}
-    if command == "start" and options.run_date:
-        data['run_time'] = str(options.run_date)
+def edit(args, uri):
+    data = {'command': args.command}
+    if args.command == "start" and args.run_date:
+        data['run_time'] = str(args.run_date)
 
-    uri = urlparse.urljoin(options.server, uri)
+    uri = urlparse.urljoin(args.server, uri)
     response = client.request(uri, data=data)
 
     if response.error:
@@ -90,10 +96,10 @@ def edit(options, command, uri):
     return True
 
 
-def control_objects(options, command, object_identifiers):
-    tron_client = client.Client(options.server)
+def control_objects(args):
+    tron_client = client.Client(args.server)
     url_index = tron_client.index()
-    for identifier in object_identifiers:
+    for identifier in args.ids:
         try:
             tron_id = client.get_object_type_from_identifier(
                 url_index, identifier,
@@ -101,23 +107,24 @@ def control_objects(options, command, object_identifiers):
         except ValueError as e:
             raise SystemExit("Error: %s" % e)
 
-        yield edit(options, command, tron_id.url)
+        yield edit(args, tron_id.url)
 
 
 def main():
     """run tronctl"""
-    options, args = parse_options()
-    cmd_utils.setup_logging(options)
-    cmd_utils.load_config(options)
+    args = parse_cli()
+    cmd_utils.setup_logging(args)
+    cmd_utils.load_config(args)
 
-    command = args.pop(0)
-    if not args:
+    print(args)
+    if not args.ids:
+        # TODO: this comment sucks, wtf does that mean? get rid of it
         # our only non-object commands are for enabling and disabling jobs, so
         # just direct those commands here
-        if not edit(options, command, client.get_job_url('')):
+        if not edit(args, client.get_job_url('')):
             sys.exit(ExitCode.fail)
     else:
-        if not all(control_objects(options, command, args)):
+        if not all(control_objects(args)):
             sys.exit(ExitCode.fail)
 
 

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -72,7 +72,6 @@ def parse_cli():
     parser.add_argument(
         'ids',
         nargs='*',
-        # TODO: this right?
         help='job name, job run id, or action id',
     )
 
@@ -116,9 +115,7 @@ def main():
     cmd_utils.setup_logging(args)
     cmd_utils.load_config(args)
 
-    print(args)
     if not args.ids:
-        # TODO: this comment sucks, wtf does that mean? get rid of it
         # our only non-object commands are for enabling and disabling jobs, so
         # just direct those commands here
         if not edit(args, client.get_job_url('')):

--- a/bin/trond
+++ b/bin/trond
@@ -3,9 +3,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import optparse
+import argparse
 import os
-import sys
 
 import pkg_resources
 
@@ -22,97 +21,99 @@ DEFAULT_PIDFILE = 'tron.pid'
 DEFAULT_PIDPATH = '/var/run/' + DEFAULT_PIDFILE
 
 
-def parse_options():
-    parser = optparse.OptionParser(version="%%prog %s" % tron.__version__)
+def parse_cli():
+    parser = argparse.ArgumentParser()
 
-    parser.add_option(
-        "-w", "--working-dir", default=DEFAULT_WORKING_DIR,
-        help="Working directory for the Tron daemon, default %default",
+    parser.add_argument(
+        '--version', action='version', version="%s %s" % (parser.prog, tron.__version__),
     )
 
-    parser.add_option(
+    parser.add_argument(
+        "-w", "--working-dir", default=DEFAULT_WORKING_DIR,
+        help="Working directory for the Tron daemon, default %(default)s",
+    )
+
+    parser.add_argument(
         "-c", "--config-path", default=DEFAULT_CONF_PATH,
         help="File path to the Tron configuration file",
     )
 
-    parser.add_option(
+    parser.add_argument(
         "--nodaemon", action="store_true", default=False,
-        help="Disable daemonizing, default %default",
+        help="Disable daemonizing, default %(default)s",
     )
 
-    parser.add_option(
+    parser.add_argument(
         "--pid-file",
         help="File path to PID file, defaults to %s if working directory "
         "is default. Otherwise defaults to <working dir>/%s" %
         (DEFAULT_PIDPATH, DEFAULT_PIDFILE),
     )
 
-    logging_group = optparse.OptionGroup(parser, "Logging")
-    logging_group.add_option(
+    logging_group = parser.add_argument_group('logging', '')
+    logging_group.add_argument(
         "--log-conf", "-l",
         help="File path to a custom logging.conf",
     )
 
-    logging_group.add_option(
+    logging_group.add_argument(
         "-v", "--verbose", action="count", default=0,
         help="Verbose logging. Repeat for more verbosity.",
     )
 
-    logging_group.add_option(
+    logging_group.add_argument(
         "--debug", action="store_true",
         help="Debug mode, extra error reporting, no daemonizing",
     )
-    parser.add_option_group(logging_group)
 
-    api_group = optparse.OptionGroup(parser, "Web Service API")
-    api_group.add_option(
+    api_group = parser.add_argument_group('Web Service API', '')
+    api_group.add_argument(
         "--port", "-P", dest="listen_port", type=int,
-        help="TCP port number to listen on, default %default",
+        help="TCP port number to listen on, default %(default)s",
         default=cmd_utils.DEFAULT_PORT,
     )
 
-    api_group.add_option(
+    api_group.add_argument(
         "--host", "-H", dest="listen_host",
-        help="Hostname to listen on, default %default",
+        help="Hostname to listen on, default %(default)s",
         default=cmd_utils.DEFAULT_HOST,
     )
 
     requirement = pkg_resources.Requirement.parse("tron")
-    api_group.add_option(
+    api_group.add_argument(
         "--web-path",
         default=pkg_resources.resource_filename(
             requirement, 'tronweb',
         ),
-        help="Path to static web resources, default %default.",
+        help="Path to static web resources, default %(default)s.",
     )
-    parser.add_option_group(api_group)
 
-    options, args = parser.parse_args(sys.argv)
-    options.working_dir = os.path.abspath(options.working_dir)
+    args = parser.parse_args()
+    args.working_dir = os.path.abspath(args.working_dir)
 
-    if options.log_conf:
-        options.log_conf = os.path.join(options.working_dir, options.log_conf)
-        if not os.path.exists(options.log_conf):
+    if args.log_conf:
+        args.log_conf = os.path.join(args.working_dir, args.log_conf)
+        if not os.path.exists(args.log_conf):
             parser.error(
                 "Logging config file not found: %s" %
-                options.log_conf,
+                args.log_conf,
             )
 
-    if not options.pid_file:
-        if options.working_dir == DEFAULT_WORKING_DIR:
-            options.pid_file = DEFAULT_PIDPATH
+    if not args.pid_file:
+        if args.working_dir == DEFAULT_WORKING_DIR:
+            args.pid_file = DEFAULT_PIDPATH
         else:
-            options.pid_file = DEFAULT_PIDFILE
+            args.pid_file = DEFAULT_PIDFILE
 
-    options.pid_file = os.path.join(options.working_dir, options.pid_file)
-    options.config_path = os.path.join(
-        options.working_dir, options.config_path,
+    args.pid_file = os.path.join(args.working_dir, args.pid_file)
+    args.config_path = os.path.join(
+        args.working_dir, args.config_path,
     )
 
-    if options.debug:
-        options.nodaemon = True
+    if args.debug:
+        args.nodaemon = True
 
-    return options
+    return args
 
 
 def create_default_config(config_path):
@@ -121,34 +122,34 @@ def create_default_config(config_path):
     manager.create_new_config(config_path, default)
 
 
-def setup_environment(options):
+def setup_environment(args):
     """Setup the working directory and config environment."""
-    if not os.path.exists(options.working_dir):
-        os.makedirs(options.working_dir)
+    if not os.path.exists(args.working_dir):
+        os.makedirs(args.working_dir)
 
-    if (not os.path.isdir(options.working_dir) or
-            not os.access(options.working_dir, os.R_OK | os.W_OK | os.X_OK)):
-        msg = "Error, can't access working directory %s" % options.working_dir
+    if (not os.path.isdir(args.working_dir) or
+            not os.access(args.working_dir, os.R_OK | os.W_OK | os.X_OK)):
+        msg = "Error, can't access working directory %s" % args.working_dir
         raise SystemExit(msg)
 
     # Attempt to create a default config if config is missing
-    if not os.path.exists(options.config_path):
+    if not os.path.exists(args.config_path):
         try:
-            create_default_config(options.config_path)
+            create_default_config(args.config_path)
         except OSError as e:
             msg = "Error creating default configuration at %s: %s"
-            raise SystemExit(msg % (options.config_path, e))
+            raise SystemExit(msg % (args.config_path, e))
 
-    if not os.access(options.config_path, os.R_OK | os.W_OK):
+    if not os.access(args.config_path, os.R_OK | os.W_OK):
         msg = "Error opening configuration %s: Missing Permissions"
-        raise SystemExit(msg % options.config_path)
+        raise SystemExit(msg % args.config_path)
 
 
 def main():
-    options = parse_options()
+    args = parse_cli()
 
-    setup_environment(options)
-    trond = trondaemon.TronDaemon(options)
+    setup_environment(args)
+    trond = trondaemon.TronDaemon(args)
     trond.run()
 
 

--- a/bin/tronfig
+++ b/bin/tronfig
@@ -24,38 +24,39 @@ from tron.config import schema
 log = logging.getLogger('tronfig')
 
 
-def parse_options():
-    usage = "usage: %prog [options] [<name>] [-|path]"
-    parser = cmd_utils.build_option_parser(usage)
+def parse_cli():
+    parser = cmd_utils.build_option_parser()
 
-    parser.add_option(
+    parser.add_argument(
         "-p", "--print", action="store_true", dest="print_config",
         help="Print config to stdout, rather than uploading",
     )
-    parser.add_option(
+    parser.add_argument(
         "-C", "--check", action="store_true", dest="check",
         help="Upload and check configuration, don't apply, "
              "useful when you want to verify if tron daemon "
              "will accept your configuration.",
     )
-    parser.add_option(
+    parser.add_argument(
         "-d", "--delete", action="store_true",
         help="Delete the configuration for this namespace",
     )
-    parser.add_option(
+    parser.add_argument(
         "-V", "--validate", action="store_true", dest="validate",
         help="Only validate configuration, don't upload, "
              "useful for verifying config locally. If namespace "
              "is not specified, it will be derived from file "
              "name, if any.",
     )
-    parser.add_option(
+    parser.add_argument(
         "-D", "--validate-dir",
         action="store",
         dest="validate_dir",
         help="Full validation of a folder, don't upload, "
              "same as -V but checks for more edge-cases",
     )
+    parser.add_argument('name')
+    parser.add_argument('source')
 
     return parser.parse_args()
 
@@ -145,16 +146,16 @@ def get_config_input(namespace, source=None):
 
 
 if __name__ == '__main__':
-    options, args = parse_options()
-    cmd_utils.setup_logging(options)
-    cmd_utils.load_config(options)
+    args = parse_cli()
+    cmd_utils.setup_logging(args)
+    cmd_utils.load_config(args)
 
-    if options.validate or options.validate_dir:
-        if options.validate:
-            name, content = get_config_input(*args)
+    if args.validate or args.validate_dir:
+        if args.validate:
+            name, content = get_config_input(args.name, args.source)
             result = validate(name, content)
-        elif options.validate_dir is not None:
-            result = validate_dir(options.validate_dir)
+        elif args.validate_dir is not None:
+            result = validate_dir(args.validate_dir)
 
         if not result:
             print("OK")
@@ -163,17 +164,15 @@ if __name__ == '__main__':
             print(result)
             sys.exit(1)
 
-    client = Client(options.server)
+    client = Client(args.server)
 
-    if options.print_config:
-        name = args[0]
-        print(client.config(name)['config'])
-    elif options.delete:
-        name = args[0]
-        delete_config(client, name)
+    if args.print_config:
+        print(client.config(args.name)['config'])
+    elif args.delete:
+        delete_config(client, args.name)
     else:
-        name, content = get_config_input(*args)
-        config_hash = client.config(name)['hash']
+        content = get_config_input(args.name, args.source)
+        config_hash = client.config(args.name)['hash']
 
         result = validate(name, content)
         if result:
@@ -181,7 +180,7 @@ if __name__ == '__main__':
             sys.exit(1)
 
         if upload_config(
-                client, name, content, config_hash, check=options.check,
+                client, name, content, config_hash, check=args.check,
         ):
             sys.exit(0)
 

--- a/bin/tronfig
+++ b/bin/tronfig
@@ -55,7 +55,6 @@ def parse_cli():
         help="Full validation of a folder, don't upload, "
              "same as -V but checks for more edge-cases",
     )
-    parser.add_argument('name')
     parser.add_argument('source')
 
     return parser.parse_args()
@@ -125,20 +124,14 @@ def validate_dir(path):
             shutil.rmtree(manifest_dir)
 
 
-def get_config_input(namespace, source=None):
-    if source is None:
-        source = namespace
-        namespace = None
-
+def get_config_input(source):
     if source == '-':
         source_io = sys.stdin
-        if not namespace:
-            namespace = schema.MASTER_NAMESPACE
+        namespace = schema.MASTER_NAMESPACE
     else:
         source_io = open(source, 'r')
-        if not namespace:
-            name, _ = os.path.splitext(os.path.basename(source))
-            namespace = name
+        name, _ = os.path.splitext(os.path.basename(source))
+        namespace = name
 
     content = source_io.read()
 
@@ -152,7 +145,7 @@ if __name__ == '__main__':
 
     if args.validate or args.validate_dir:
         if args.validate:
-            name, content = get_config_input(args.name, args.source)
+            name, content = get_config_input(args.source)
             result = validate(name, content)
         elif args.validate_dir is not None:
             result = validate_dir(args.validate_dir)
@@ -167,12 +160,12 @@ if __name__ == '__main__':
     client = Client(args.server)
 
     if args.print_config:
-        print(client.config(args.name)['config'])
+        print(client.config(args.source)['config'])
     elif args.delete:
-        delete_config(client, args.name)
+        delete_config(client, args.source)
     else:
-        content = get_config_input(args.name, args.source)
-        config_hash = client.config(args.name)['hash']
+        content = get_config_input(args.source)
+        config_hash = client.config(args.source)['hash']
 
         result = validate(name, content)
         if result:

--- a/bin/tronview
+++ b/bin/tronview
@@ -14,39 +14,38 @@ from tron.commands.client import TronObjectType
 from tron.commands.cmd_utils import ExitCode
 
 
-def parse_options():
-    usage = "usage: %prog [options] [<job | job run | action | service>]"
-    parser = cmd_utils.build_option_parser(usage)
-    parser.add_option(
-        "--numshown", "-n", type="int", dest="num_displays",
+def parse_cli():
+    parser = cmd_utils.build_option_parser()
+    parser.add_argument(
+        "--numshown", "-n", type=int, dest="num_displays",
         help="Max number of jobs/job-runs shown", default=10,
     )
-    parser.add_option(
+    parser.add_argument(
         "--color", "-c", action="store_true",
         dest="display_color", help="Display in color",
         default=None,
     )
-    parser.add_option(
+    parser.add_argument(
         "--nocolor", action="store_false",
         dest="display_color", help="Display without color",
         default=None,
     )
-    parser.add_option(
+    parser.add_argument(
         "--stdout", "-o", action="count", dest="stdout",
         help="Solely displays stdout", default=0,
     )
-    parser.add_option(
+    parser.add_argument(
         "--stderr", "-e", action="count", dest="stderr",
         help="Solely displays stderr", default=0,
     )
-    parser.add_option(
+    parser.add_argument(
         "--events", action="store_true", dest="show_events",
         help="Show events for the specified entity",
         default=False,
     )
 
-    options, args = parser.parse_args(sys.argv)
-    return options, args[1:]
+    args = parser.parse_args()
+    return args
 
 
 def console_height():
@@ -59,9 +58,9 @@ def display_events(data):
     return display.DisplayEvents().format(data)
 
 
-def view_all(options, client):
+def view_all(args, client):
     """Retreive jobs and services and display them."""
-    if options.show_events:
+    if args.show_events:
         return display_events(client.events())
 
     return "".join([
@@ -71,17 +70,17 @@ def view_all(options, client):
     ])
 
 
-def view_job(options, job_id, client):
+def view_job(args, job_id, client):
     """Retrieve details of the specified job and display"""
-    if options.show_events:
+    if args.show_events:
         return display_events(client.object_events(job_id.url))
 
-    job_content = client.job(job_id.url, count=options.num_displays)
+    job_content = client.job(job_id.url, count=args.num_displays)
     return display.format_job_details(job_content)
 
 
-def view_job_run(options, job_run_id, client):
-    if options.show_events:
+def view_job_run(args, job_run_id, client):
+    if args.show_events:
         return display_events(client.object_events(job_run_id.url))
 
     actions = client.job_runs(job_run_id.url)
@@ -89,16 +88,16 @@ def view_job_run(options, job_run_id, client):
     return display_action.format(actions)
 
 
-def view_action_run(options, act_run_id, client):
+def view_action_run(args, act_run_id, client):
     content = client.action_runs(
-        act_run_id.url, num_lines=options.num_displays,
+        act_run_id.url, num_lines=args.num_displays,
     )
     return display.format_action_run_details(content)
 
 
-def view_service(options, service_id, client):
+def view_service(args, service_id, client):
     """Retrieve details of the specified service and display"""
-    if options.show_events:
+    if args.show_events:
         return display_events(client.object_events(service_id.url))
 
     service_content = client.service(service_id.url)
@@ -113,35 +112,35 @@ obj_type_to_view_map = {
 }
 
 
-def get_view_output(name, options, client):
+def get_view_output(name, args, client):
     url_index = client.index()
     tron_id = get_object_type_from_identifier(url_index, name)
 
     if tron_id.type not in obj_type_to_view_map:
         return
-    return obj_type_to_view_map[tron_id.type](options, tron_id, client)
+    return obj_type_to_view_map[tron_id.type](args, tron_id, client)
 
 
 def main():
     """run tronview"""
-    options, args = parse_options()
-    cmd_utils.setup_logging(options)
-    cmd_utils.load_config(options)
+    args = parse_cli()
+    cmd_utils.setup_logging(args)
+    cmd_utils.load_config(args)
 
-    display.Color.toggle(options.display_color)
-    client = Client(options.server)
+    display.Color.toggle(args.display_color)
+    client = Client(args.server)
 
     if not args:
-        output = view_all(options, client)
+        output = view_all(args, client)
     else:
-        output = get_view_output(args[0], options, client)
+        output = get_view_output(args.name, args, client)
 
     if not output:
-        print("Unrecognized identifier: %s" % args[0], file=sys.stderr)
+        print("Unrecognized identifier: %s" % args.name, file=sys.stderr)
         sys.exit(ExitCode.fail)
 
     if sys.stdout.isatty() and len(output.split('\n')) > console_height():
-        display.view_with_less(output, options.display_color)
+        display.view_with_less(output, args.display_color)
     else:
         print(output)
 

--- a/bin/tronview
+++ b/bin/tronview
@@ -43,6 +43,11 @@ def parse_cli():
         help="Show events for the specified entity",
         default=False,
     )
+    parser.add_argument(
+        'name',
+        nargs='*',
+        help='job name',
+    )
 
     args = parser.parse_args()
     return args

--- a/bin/tronview
+++ b/bin/tronview
@@ -45,7 +45,7 @@ def parse_cli():
     )
     parser.add_argument(
         'name',
-        nargs='*',
+        nargs='?',
         help='job name',
     )
 
@@ -135,7 +135,7 @@ def main():
     display.Color.toggle(args.display_color)
     client = Client(args.server)
 
-    if not args:
+    if not args.name:
         output = view_all(args, client)
     else:
         output = get_view_output(args.name, args, client)

--- a/example-cluster/README.md
+++ b/example-cluster/README.md
@@ -15,3 +15,12 @@ $ tox -e example-cluster
 $ cd /work
 $ ./example-cluster/start.sh
 ```
+
+# To test tronview, tronctl, etc
+First, start Tron in a container using the above steps. Then in a different terminal,
+you will attach to that running container. There you will be able to run `tronctl`,
+`tronview` and others against the Trond master in the example cluster.
+
+```
+$ sudo docker exec -it `docker ps | grep examplecluster_master | cut -d' ' -f1` /bin/bash
+```

--- a/tests/commands/cmd_utils_test.py
+++ b/tests/commands/cmd_utils_test.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import argparse
 import contextlib
 
 import mock
@@ -8,7 +9,6 @@ from testify import assert_equal
 from testify import setup_teardown
 from testify import TestCase
 
-import tron
 from tron.commands import cmd_utils
 
 
@@ -45,20 +45,24 @@ class BuildOptionParserTestCase(TestCase):
         """
         parser_class = mock.Mock()
         usage = 'Something'
+        epilog = 'Something'
         parser = cmd_utils.build_option_parser(
-            usage, parser_class=parser_class,
+            usage=usage, parser_class=parser_class, epilog=epilog,
         )
         assert_equal(parser, parser_class.return_value)
         parser_class.assert_called_with(
-            usage, version="%%prog %s" % tron.__version__,
+            usage=usage, formatter_class=argparse.RawDescriptionHelpFormatter, epilog=epilog,
         )
-        assert_equal(parser.add_option.call_count, 3)
+        assert_equal(parser.add_argument.call_count, 4)
 
-        options = [call[1] for call in parser.add_option.mock_calls]
-        expected = [('-v', '--verbose'), ('--server',), ('-s', '--save')]
-        assert_equal(options, expected)
+        args = [call[1] for call in parser.add_argument.mock_calls]
+        expected = [
+            ('--version',), ('-v', '--verbose'),
+            ('--server',), ('-s', '--save'),
+        ]
+        assert_equal(args, expected)
 
         defaults = [
-            call[2].get('default') for call in parser.add_option.mock_calls
+            call[2].get('default') for call in parser.add_argument.mock_calls
         ]
-        assert_equal(defaults, [None, None, None])
+        assert_equal(defaults, [None, None, None, None])

--- a/tron/commands/cmd_utils.py
+++ b/tron/commands/cmd_utils.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import with_statement
 
+import argparse
 import logging
-import optparse
 import os
 import sys
 
@@ -40,18 +40,26 @@ DEFAULT_CONFIG = {
 opener = open
 
 
-def build_option_parser(usage, parser_class=optparse.OptionParser):
-    parser = parser_class(usage, version="%%prog %s" % tron.__version__)
+def build_option_parser(usage=None, parser_class=argparse.ArgumentParser, epilog=None):
+    parser = parser_class(
+        usage=usage,
+        epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        '--version', action='version',
+        version="%s %s" % (parser.prog, tron.__version__),
+    )
 
-    parser.add_option(
+    parser.add_argument(
         "-v", "--verbose", action="count",
         help="Verbose logging", default=None,
     )
-    parser.add_option(
+    parser.add_argument(
         "--server", default=None,
-        help="Url including scheme, host and port, Default: %default",
+        help="Url including scheme, host and port, Default: %(default)s",
     )
-    parser.add_option(
+    parser.add_argument(
         "-s", "--save", action="store_true", dest="save_config",
         help="Save options used on this job for next time.",
     )


### PR DESCRIPTION
This needs to be done before we can add tab completion to Tron.

Sorry for the large review. Because of how each script used optparse on its own, in addition to sourcing "cmd_utils.py" which used it, all these had to be upgraded at the same time instead of one by one 😕

`tox` runs cleanly, as does the example cluster. I did some manual testing of the argument parsing by attaching to the trond master container in the example_cluster, and running the tron scripts in there. I also added a section to the example_cluster README explaining  how to do this.