### PR TITLE
Only localize datetimes when they lack tzinfo

### DIFF
--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -171,6 +171,7 @@ class GeneralSchedulerLongJobRunTest(GeneralSchedulerTimeTestBase):
 class GeneralSchedulerDSTTest(testingutils.MockTimeTestCase):
 
     now = datetime.datetime(2011, 11, 6, 1, 10, 0)
+    now_utc = timeutils.current_time(tz=pytz.timezone('UTC'))
 
     def hours_until_time(self, run_time, sch):
         tz = sch.time_zone
@@ -244,6 +245,21 @@ class GeneralSchedulerDSTTest(testingutils.MockTimeTestCase):
         self._assert_range(s1b - s1a, 23.99, 24.11)
         self._assert_range(s2b - s2a, 23.99, 24.11)
         self._assert_range(s1a - s2a, -0.61, -0.59)
+
+    def test_handles_tz_specific_jobs_with_tz_specific_start_time(self):
+        sch = scheduler.GeneralScheduler(time_zone=pytz.timezone('UTC'))
+        next_run_time = sch.next_run_time(self.now_utc)
+        assert_equal(next_run_time.hour, 0)
+
+    def test_handles_unsetting_the_time_zone(self):
+        sch = scheduler.GeneralScheduler(time_zone=None)
+        next_run_time = sch.next_run_time(self.now_utc)
+        assert_equal(next_run_time.hour, 0)
+
+    def test_handles_changing_the_time_zone(self):
+        sch = scheduler.GeneralScheduler(time_zone=pytz.timezone('US/Pacific'))
+        next_run_time = sch.next_run_time(self.now_utc)
+        assert_equal(next_run_time.hour, 8)
 
 
 def parse_groc(config):


### PR DESCRIPTION
This fixes this stacktrace:
```
  File "/opt/venvs/tron/local/lib/python2.7/site-packages/twisted/internet/base.py", line 805, in runUntilCurrent
    call.func(*call.args, **call.kw)
  File "/opt/venvs/tron/local/lib/python2.7/site-packages/tron/core/job.py", line 338, in run_job
    self.schedule()
  File "/opt/venvs/tron/local/lib/python2.7/site-packages/tron/core/job.py", line 293, in schedule
    self.create_and_schedule_runs()
  File "/opt/venvs/tron/local/lib/python2.7/site-packages/tron/core/job.py", line 260, in create_and_schedule_runs
    for job_run in self.get_runs_to_schedule(ignore_last_run_time):
  File "/opt/venvs/tron/local/lib/python2.7/site-packages/tron/core/job.py", line 387, in get_runs_to_schedule
    next_run_time = self.job.scheduler.next_run_time(last_run_time)
  File "/opt/venvs/tron/local/lib/python2.7/site-packages/tron/scheduler.py", line 186, in next_run_time
    start_time = self.time_zone.localize(start_time, is_dst=None)
  File "/opt/venvs/tron/local/lib/python2.7/site-packages/pytz/__init__.py", line 226, in localize
    raise ValueError('Not naive datetime (tzinfo is already set)')
exceptions.ValueError: Not naive datetime (tzinfo is already set)
```

And I tried to cover other situations of adding and changing the timezone of jobs that have existing localized times. 

I'm worried though, because I think as written all of the special DST-specific logic is bypassed when the next run time has a tz set. Maybe that is a good thing?