### PR TITLE
Chl/tron 224 detect jobs not scheduled

### DIFF
--- a/bin/check_tron_jobs.py
+++ b/bin/check_tron_jobs.py
@@ -62,7 +62,7 @@ def compute_check_result_for_job_runs(client, job, job_content):
     )
     action_run_details = client.action_runs(action_run_id.url, num_lines=10)
 
-    if last_state == "succeeded" or last_state == "waiting_run_done":
+    if last_state == "succeeded" or last_state == "waiting_for_first_run":
         prefix = "OK"
         annotation = ""
         status = 0
@@ -127,7 +127,7 @@ def get_relevant_run_and_state(job_runs):
     for run in job_runs['runs']:
         if run.get('state', 'unknown') in ["failed", "succeeded"]:
             return run, run.get('state', 'unknown')
-    return job_runs['runs'][0], "waiting_run_done"
+    return job_runs['runs'][0], "waiting_for_first_run"
 
 
 def is_job_scheduled(job_runs):

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'six>=1.11.0',
         'SQLAlchemy>=1.0.15',
         'yelp-clog',
+        'enum34>=1.1.6',
     ],
     packages=find_packages(exclude=['tests.*', 'tests']) + ['tronweb'],
     scripts=glob.glob('bin/*'),

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -65,3 +65,17 @@ class CheckJobsTestCase(TestCase):
         }
         run = check_tron_jobs.is_job_stuck(job_runs)
         assert_equal(run['id'], 'MASTER.test.2')
+
+    def test_no_job_scheduled_or_queuing(self):
+        job_runs = {
+            'status': 'running', 'next_run': None, 'runs': [
+                {
+                    'id': 'MASTER.test.2', 'state': 'succeeded', 'end_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time() - 600)),
+                },
+                {
+                    'id': 'MASTER.test.1', 'state': 'succeeded', 'end_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time() - 1200)),
+                },
+            ],
+        }
+        run = check_tron_jobs.is_no_job_scheduled(job_runs)
+        assert_equal(run, None)

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import time
 
 import check_tron_jobs
+from check_tron_jobs import State
 from testify import assert_equal
 from testify import TestCase
 
@@ -90,4 +91,4 @@ class CheckJobsTestCase(TestCase):
         }
         run, state = check_tron_jobs.get_relevant_run_and_state(job_runs)
         assert_equal(run['id'], 'MASTER.test.1')
-        assert_equal(state, 'waiting_for_first_run')
+        assert_equal(state, State.WAITING_FOR_FIRST_RUN)

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -90,4 +90,4 @@ class CheckJobsTestCase(TestCase):
         }
         run, state = check_tron_jobs.get_relevant_run_and_state(job_runs)
         assert_equal(run['id'], 'MASTER.test.1')
-        assert_equal(state, 'waiting_run_done')
+        assert_equal(state, 'waiting_for_first_run')

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -68,7 +68,7 @@ class CheckJobsTestCase(TestCase):
 
     def test_no_job_scheduled_or_queuing(self):
         job_runs = {
-            'status': 'running', 'next_run': None, 'runs': [
+            'status': 'succeeded', 'next_run': None, 'runs': [
                 {
                     'id': 'MASTER.test.2', 'state': 'succeeded', 'end_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time() - 600)),
                 },
@@ -77,5 +77,17 @@ class CheckJobsTestCase(TestCase):
                 },
             ],
         }
-        run = check_tron_jobs.is_no_job_scheduled(job_runs)
+        run = check_tron_jobs.is_job_scheduled(job_runs)
         assert_equal(run, None)
+
+    def test_job_is_scheduled_not_run(self):
+        job_runs = {
+            'status': 'scheduled', 'next_run': None, 'runs': [
+                {
+                    'id': 'MASTER.test.1', 'state': 'scheduled', 'run_time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time() + 1200)),
+                },
+            ],
+        }
+        run, state = check_tron_jobs.get_relevant_run_and_state(job_runs)
+        assert_equal(run['id'], 'MASTER.test.1')
+        assert_equal(state, 'waiting_run_done')


### PR DESCRIPTION
Sensu would alert if these no job run is scheduled or queued, and it won't alert if the only run is scheduled but not run yet (might be scheduled to run sometime in the future.)
Also, check if any kwargs of Sensu is missing before calling send_event. 