### PR TITLE
Move tron documentation to readthedocs.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Tron - Batch Scheduling System
 ==============================
 
 [![Build Status](https://travis-ci.org/Yelp/Tron.svg?branch=master)](https://travis-ci.org/Yelp/Tron)
+[![Documentation Status](https://readthedocs.org/projects/tron/badge/?version=latest)](http://tron.readthedocs.io/en/latest/?badge=latest)
 
 Tron is a centralized system for managing periodic batch processes and services
 across a cluster. If you find [cron](http://en.wikipedia.org/wiki/Cron) or
@@ -12,9 +13,9 @@ Install with:
 
     > sudo pip install tron
 
-Or look at the [tutorial](https://pythonhosted.org/tron/tutorial.html).
+Or look at the [tutorial](http://tron.readthedocs.io/en/latest/tutorial.html).
 
-The full documentation is available [on PyPI](http://pythonhosted.org/tron/).
+The full documentation is available [on ReadTheDocs](http://tron.readthedocs.io/en/latest/).
 
 Versions / Roadmap
 ------------------
@@ -34,7 +35,7 @@ a general solution for other companies.
 Contributing
 ------------
 
-Read [Working on Tron](https://pythonhosted.org/tron/developing.html) and
+Read [Working on Tron](http://tron.readthedocs.io/en/latest/developing.html) and
 start sending pull requests!
 
 Any issues should be posted [on

--- a/docs/man/tronfig.1
+++ b/docs/man/tronfig.1
@@ -64,7 +64,7 @@ Read new config from \fBstdin\fP.
 .sp
 By default tron will run with a blank configuration file. The config file is
 saved to \fB<working_dir>/config/\fP by default. See the full documentation at
-\fI\%http://pythonhosted.org/tron/config.html\fP.
+\fI\%http://tron.readthedocs.io/en/latest/config.html\fP.
 .SH BUGS
 .sp
 Post bugs to \fI\%http://www.github.com/yelp/tron/issues\fP.

--- a/docs/man_tronfig.rst
+++ b/docs/man_tronfig.rst
@@ -42,7 +42,7 @@ Configuration
 
 By default tron will run with a blank configuration file. The config file is
 saved to ``<working_dir>/config/`` by default. See the full documentation at
-http://pythonhosted.org/tron/config.html.
+http://tron.readthedocs.io/en/latest/config.html.
 
 
 Bugs

--- a/tox.ini
+++ b/tox.ini
@@ -20,13 +20,15 @@ ignore = E501,E265,E241,E704
 [testenv:docs]
 deps =
   --requirement={toxinidir}/dev/req_dev.txt
-whitelist_externals=dot
+whitelist_externals=
+    dot
+    mkdir
 commands=
-	python tools/state_diagram.py
+    python tools/state_diagram.py
     mkdir -p docs/images
-	dot -Tpng -odocs/images/action.png action.dot
-	dot -Tpng -odocs/images/service_instance.png service_instance.dot
-	sphinx-build -b html -d docs/_build docs docs/_build/html
+    dot -Tpng -odocs/images/action.png action.dot
+    dot -Tpng -odocs/images/service_instance.png service_instance.dot
+    sphinx-build -b html -d docs/_build docs docs/_build/html
 
 [testenv:example-cluster]
 deps = docker-compose>=1.10.0

--- a/tron/config/schema/tronfig_schema.json
+++ b/tron/config/schema/tronfig_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "description": "http://pythonhosted.org/tron/config.html",
+  "description": "http://tron.readthedocs.io/en/latest/config.html",
   "type": "object",
   "additionalProperties": false,
   "properties": {


### PR DESCRIPTION
I tried to update the documentation on pythonhosted.org, but it rejected me and said it was deprecated and told me to use readthedocs.

I activated it and enabled the webhook and would like to make this transition.