### PR TITLE
Added a 'make dev' target to iterate faster with local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,14 @@ DOCKER_RUN = docker run -t -e SSH_AUTH_SOCK -v $(CURDIR):/work:rw
 UID:=$(shell id -u)
 GID:=$(shell id -g)
 
-.PHONY : all clean tests docs
+.PHONY : all clean tests docs dev
 
 -usage:
 	@echo "make test - Run tests"
 	@echo "make package_trusty_deb - Generate trusty package"
 	@echo "make release - Prepare debian info for new release"
 	@echo "make clean - Get rid of scratch and byte files"
+	@echo "make dev - Get a local copy of trond running in debug mode in the foreground"
 
 docker_%:
 	@echo "Building docker image for $*"
@@ -40,6 +41,9 @@ _itest_%:
 
 itest_%: test deb_% _itest_%
 	@echo "Package for $* looks good"
+
+dev:
+	.tox/py27/bin/trond --debug --working-dir=dev -l logging.conf --host=$(shell hostname -f)
 
 # Release
 

--- a/dev/config/MASTER.yaml
+++ b/dev/config/MASTER.yaml
@@ -1,0 +1,15 @@
+---
+
+ssh_options:
+   agent: False
+
+nodes:
+  - hostname: localhost
+
+jobs:
+    - name: "test"
+      node: localhost
+      schedule: "interval 20seconds"
+      actions:
+        - name: "first"
+          command: "echo hi"

--- a/dev/config/_manifest.yaml
+++ b/dev/config/_manifest.yaml
@@ -1,0 +1,1 @@
+{MASTER: config/MASTER.yaml}

--- a/dev/logging.conf
+++ b/dev/logging.conf
@@ -18,19 +18,19 @@ qualname=twisted
 propagate=0
 
 [logger_tron]
-level=WARN
+level=DEBUG
 handlers=stdoutHandler
 qualname=tron
 propagate=0
 
 [logger_tron.api.www.access]
-level=INFO
+level=DEBUG
 handlers=accessHandler
 qualname=tron.api.www.access
 propagate=0
 
 [logger_tron.serialize.runstate.statemanager]
-level=WARN
+level=DEBUG
 handlers=stdoutHandler
 qualname=tron.serialize.runstate.statemanager
 propagate=0

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -40,12 +40,7 @@ sample configuration file with a few test cases. To run a development intsance
 of Tron create a working directory and start
 :command:`trond` using the following::
 
-    $ mkdir wd
-    $ cp dev/dev-logging.conf wd/
-    $ bin/trond -w wd --nodaemon -l dev-logging.conf
-
-
-A sample testing config file is available at ``tests/data/test_config.yaml``
+    $ make dev
 
 
 Running the Tests


### PR DESCRIPTION
I used this technique to make it easier to develop the frontend stuff.

It is lighter weight than the example cluster.