### PR TITLE
First pass at tab complete

### DIFF
--- a/bin/tronctl
+++ b/bin/tronctl
@@ -13,6 +13,8 @@ import logging
 import sys
 import urlparse
 
+import argcomplete
+
 from tron.commands import client
 from tron.commands import cmd_utils
 from tron.commands.cmd_utils import ExitCode
@@ -71,8 +73,9 @@ def parse_cli():
         'id',
         nargs='*',
         help='job name, job run id, or action id',
-    )
+    ).completer = cmd_utils.tron_jobs_completer
 
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     return args

--- a/bin/tronview
+++ b/bin/tronview
@@ -7,7 +7,6 @@ import os
 import sys
 
 import argcomplete
-import requests
 
 from tron.commands import cmd_utils
 from tron.commands import display
@@ -50,16 +49,16 @@ def parse_cli():
         'name',
         nargs='?',
         help='job name | job run id | action id',
-    ).completer = tron_jobs_available
+    ).completer = tron_jobs_completer
 
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
     return args
 
 
-def tron_jobs_available(prefix, parsed_args, **kwargs):
-    resource = "%s/api/jobs" % cmd_utils.get_default_server()
-    return (job['name'] for job in requests.get(resource).json()['jobs'] if job['name'].startswith(prefix))
+def tron_jobs_completer(prefix, parsed_args, **kwargs):
+    default_client = Client(cmd_utils.get_default_server())
+    return (job['name'] for job in default_client.jobs() if job['name'].startswith(prefix))
 
 
 def console_height():

--- a/bin/tronview
+++ b/bin/tronview
@@ -49,16 +49,11 @@ def parse_cli():
         'name',
         nargs='?',
         help='job name | job run id | action id',
-    ).completer = tron_jobs_completer
+    ).completer = cmd_utils.tron_jobs_completer
 
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
     return args
-
-
-def tron_jobs_completer(prefix, parsed_args, **kwargs):
-    default_client = Client(cmd_utils.get_default_server())
-    return (job['name'] for job in default_client.jobs() if job['name'].startswith(prefix))
 
 
 def console_height():

--- a/bin/tronview
+++ b/bin/tronview
@@ -6,6 +6,9 @@ from __future__ import unicode_literals
 import os
 import sys
 
+import argcomplete
+import requests
+
 from tron.commands import cmd_utils
 from tron.commands import display
 from tron.commands.client import Client
@@ -47,10 +50,16 @@ def parse_cli():
         'name',
         nargs='?',
         help='job name | job run id | action id',
-    )
+    ).completer = tron_jobs_available
 
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
     return args
+
+
+def tron_jobs_available(prefix, parsed_args, **kwargs):
+    resource = "%s/api/jobs" % cmd_utils.get_default_server()
+    return (job['name'] for job in requests.get(resource).json()['jobs'] if job['name'].startswith(prefix))
 
 
 def console_height():

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "Development Status :: 4 - Beta",
     ],
     install_requires=[
+        'argcomplete >= 0.8.1',
         'humanize >= 0.5.0',
         'Twisted >=10.0.0, <=12.3',
         'PyYAML>=3.0',
@@ -38,6 +39,7 @@ setup(
         'pysensu-yelp',
         'python-daemon',
         'lockfile>=0.7',
+        'requests == 2.18.4',
         'six>=1.11.0',
         'SQLAlchemy>=1.0.15',
         'yelp-clog',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'pysensu-yelp',
         'python-daemon',
         'lockfile>=0.7',
-        'requests == 2.18.4',
         'six>=1.11.0',
         'SQLAlchemy>=1.0.15',
         'yelp-clog',

--- a/tron/commands/cmd_utils.py
+++ b/tron/commands/cmd_utils.py
@@ -12,6 +12,7 @@ import sys
 
 import tron
 from tron import yaml
+from tron.commands.client import Client
 
 
 log = logging.getLogger("tron.commands")
@@ -42,6 +43,11 @@ opener = open
 
 def get_default_server():
     return DEFAULT_CONFIG['server']
+
+
+def tron_jobs_completer(prefix, parsed_args, **kwargs):
+    default_client = Client(get_default_server())
+    return (job['name'] for job in default_client.jobs() if job['name'].startswith(prefix))
 
 
 def build_option_parser(usage=None, epilog=None):

--- a/tron/commands/cmd_utils.py
+++ b/tron/commands/cmd_utils.py
@@ -40,6 +40,10 @@ DEFAULT_CONFIG = {
 opener = open
 
 
+def get_default_server():
+    return DEFAULT_CONFIG['server']
+
+
 def build_option_parser(usage=None, epilog=None):
     parser = argparse.ArgumentParser(
         usage=usage,


### PR DESCRIPTION
This is a first iteration of tab complete. It parses the output of the /api/jobs endpoint of the default server.

We have {{args.server}} that will hold the tron server to use. It can optionally be specified with {{--server}}, or it will take the default of localhost. But, i cant use this variable, because at the time argcomplete is called, the {{args}} var has not been populated.

So instead, i added a helper function to give the default server as its hardcoded in tron/command/cmd_utils.py .

But is this default what we're using going forward? My understanding is eventually we want devs to be able to {{tronview}} from their devbox. Having the default as localhost wouldn't allow this.