### PR TITLE
Allow tab complete to read from cached file

### DIFF
--- a/bin/generate_tron_tab_completion_cache
+++ b/bin/generate_tron_tab_completion_cache
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+"""
+print a list of all the tron jobs, to be saved as a cache for tab completion
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argcomplete
+
+from tron.commands import cmd_utils
+from tron.commands.client import Client
+
+
+def main():
+    parser = cmd_utils.build_option_parser()
+    argcomplete.autocomplete(parser)
+    args = parser.parse_args()
+    cmd_utils.load_config(args)
+
+    client = Client(args.server)
+    jobs = [job['name'] for job in client.jobs()]
+    for job in jobs:
+        print(job)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/tron_tabcomplete.sh
+++ b/bin/tron_tabcomplete.sh
@@ -1,0 +1,8 @@
+if [[ -n ${ZSH_VERSION-} ]]; then
+	autoload -U +X bashcompinit && bashcompinit
+fi
+
+# This magic eval enables tab-completion for tron commands
+# http://argcomplete.readthedocs.io/en/latest/index.html#synopsis
+eval "$(/opt/venvs/tron/bin/register-python-argcomplete tronview)"
+eval "$(/opt/venvs/tron/bin/register-python-argcomplete tronctl)"

--- a/debian/tron.links
+++ b/debian/tron.links
@@ -3,3 +3,4 @@ opt/venvs/tron/bin/tronctl usr/bin/tronctl
 opt/venvs/tron/bin/trond usr/bin/trond
 opt/venvs/tron/bin/tronfig usr/bin/tronfig
 opt/venvs/tron/bin/tronview usr/bin/tronview
+opt/venvs/tron/bin/tron_tabcomplete.sh etc/bash_completion.d/tron.bash

--- a/debian/tron.links
+++ b/debian/tron.links
@@ -3,4 +3,5 @@ opt/venvs/tron/bin/tronctl usr/bin/tronctl
 opt/venvs/tron/bin/trond usr/bin/trond
 opt/venvs/tron/bin/tronfig usr/bin/tronfig
 opt/venvs/tron/bin/tronview usr/bin/tronview
+opt/venvs/tron/bin/generate_tron_tab_completion_cache usr/bin/generate_tron_tab_completion_cache
 opt/venvs/tron/bin/tron_tabcomplete.sh etc/bash_completion.d/tron.bash

--- a/tron/commands/cmd_utils.py
+++ b/tron/commands/cmd_utils.py
@@ -37,6 +37,7 @@ DEFAULT_CONFIG = {
     'display_color':    False,
 }
 
+TAB_COMPLETE_FILE = '/etc/tron/tron_tab_completions'
 
 opener = open
 
@@ -46,8 +47,13 @@ def get_default_server():
 
 
 def tron_jobs_completer(prefix, parsed_args, **kwargs):
-    default_client = Client(get_default_server())
-    return (job['name'] for job in default_client.jobs() if job['name'].startswith(prefix))
+    if os.path.isfile(TAB_COMPLETE_FILE):
+        with opener(TAB_COMPLETE_FILE, 'r') as f:
+            jobs = f.readlines()
+        return (job.strip('\n\r') for job in jobs if job.startswith(prefix))
+    else:
+        default_client = Client(get_default_server())
+        return (job['name'] for job in default_client.jobs() if job['name'].startswith(prefix))
 
 
 def build_option_parser(usage=None, epilog=None):


### PR DESCRIPTION
If tab complete cache file does not exist, it will fallback to hitting api

Also adds the debian links file to automatically enable tab completion

I'm cargo-culting the _tabcomplete.sh file from what we have in paasta. I think this might enable zsh autocompletion too? But i haven't tested it.

This is paired with the internal review r:285778 , which has the puppet code that populates this cache file.