### PR TITLE
Dont try to localize time with tzinfo

### DIFF
--- a/tron/utils/trontimespec.py
+++ b/tron/utils/trontimespec.py
@@ -275,7 +275,8 @@ class TimeSpecification(object):
                 for _ in range(24):
                     out += datetime.timedelta(minutes=60)
                     try:
-                        out = self.timezone.localize(out)
+                        if out.tzinfo is None:
+                            out = self.timezone.localize(out)
                     except NonExistentTimeError:
                         return None
         return to_timezone(out, tzinfo)


### PR DESCRIPTION
Fixes a crash when restoring a job with next run time non-existent in specified timezone.