### PR TITLE
Implement and use backward compatible Py2Shelf

### DIFF
--- a/tron/serialize/runstate/shelvestore.py
+++ b/tron/serialize/runstate/shelvestore.py
@@ -17,14 +17,10 @@ log = logging.getLogger(__name__)
 
 
 class Py2Shelf(shelve.Shelf):
-    def __init__(self, filename, flag='c', protocol=2, writeback=False, keyencoding='ascii'):
-        self.keyencoding = keyencoding
-
+    def __init__(self, filename, flag='c', protocol=2, writeback=False):
         if sys.version_info[0] == 3:
             shelve.Shelf.__init__(
-                self, dbm.open(
-                    filename, flag,
-                ), protocol, writeback, keyencoding,
+                self, dbm.open(filename, flag,), protocol, writeback, 'utf8',
             )
         else:
             shelve.Shelf.__init__(
@@ -35,7 +31,7 @@ class Py2Shelf(shelve.Shelf):
         try:
             value = self.cache[key]
         except KeyError:
-            f = BytesIO(self.dict[key.encode(self.keyencoding)])
+            f = BytesIO(self.dict[key.encode('utf8')])
             if sys.version_info[0] == 3:
                 value = pickle.load(f, encoding='bytes')
             else:
@@ -49,7 +45,7 @@ class Py2Shelf(shelve.Shelf):
             self.cache[key] = value
         f = BytesIO()
         pickle.dump(obj=value, file=f, protocol=self._protocol)
-        self.dict[key.encode(self.keyencoding)] = f.getvalue()
+        self.dict[key.encode('utf8')] = f.getvalue()
 
 
 class ShelveKey(object):
@@ -78,10 +74,7 @@ class ShelveStateStore(object):
 
     def __init__(self, filename):
         self.filename = filename
-        self.shelve = Py2Shelf(
-            self.filename,
-            keyencoding='utf8',
-        )
+        self.shelve = Py2Shelf(self.filename)
 
     def build_key(self, type, iden):
         return ShelveKey(type, iden)

--- a/tron/serialize/runstate/shelvestore.py
+++ b/tron/serialize/runstate/shelvestore.py
@@ -1,15 +1,55 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import dbm
 import logging
 import operator
+import pickle
 import shelve
+import sys
+from io import BytesIO
 
 from six.moves import filter
 from six.moves import zip
 
 
 log = logging.getLogger(__name__)
+
+
+class Py2Shelf(shelve.Shelf):
+    def __init__(self, filename, flag='c', protocol=2, writeback=False, keyencoding='ascii'):
+        self.keyencoding = keyencoding
+
+        if sys.version_info[0] == 3:
+            shelve.Shelf.__init__(
+                self, dbm.open(
+                    filename, flag,
+                ), protocol, writeback, keyencoding,
+            )
+        else:
+            shelve.Shelf.__init__(
+                self, dbm.open(filename, flag), protocol, writeback,
+            )
+
+    def __getitem__(self, key):
+        try:
+            value = self.cache[key]
+        except KeyError:
+            f = BytesIO(self.dict[key.encode(self.keyencoding)])
+            if sys.version_info[0] == 3:
+                value = pickle.load(f, encoding='bytes')
+            else:
+                value = pickle.load(f)
+            if self.writeback:
+                self.cache[key] = value
+        return value
+
+    def __setitem__(self, key, value):
+        if self.writeback:
+            self.cache[key] = value
+        f = BytesIO()
+        pickle.dump(obj=value, file=f, protocol=self._protocol)
+        self.dict[key.encode(self.keyencoding)] = f.getvalue()
 
 
 class ShelveKey(object):
@@ -38,7 +78,10 @@ class ShelveStateStore(object):
 
     def __init__(self, filename):
         self.filename = filename
-        self.shelve = shelve.open(self.filename)
+        self.shelve = Py2Shelf(
+            self.filename,
+            keyencoding='utf8',
+        )
 
     def build_key(self, type, iden):
         return ShelveKey(type, iden)


### PR DESCRIPTION
Restoring from state file created by Python 2 fails in Python 3 due to reasons.

P2Shelf extends the base Shelf class, replicates DbfilenameShelf and passes around arguments required to make it work in py3.

manually tested:

- loading py2 state in py3 and verifying returned values using ShelveStateStore interface
- modifying state in py3, loading it in py2 and verifying the change