### PR TITLE
use the resolved namespace in tronfig

### DIFF
--- a/bin/tronfig
+++ b/bin/tronfig
@@ -171,7 +171,7 @@ if __name__ == '__main__':
         delete_config(client, args.source)
     else:
         namespace, content = get_config_input(args.namespace, args.source)
-        config_hash = client.config(args.namespace)['hash']
+        config_hash = client.config(namespace)['hash']
         result = validate(namespace, content)
         if result:
             print(result)

--- a/itest.sh
+++ b/itest.sh
@@ -37,6 +37,7 @@ kill -0 $TRON_PID
 
 tronfig -p MASTER
 tronfig -n MASTER /work/example-cluster/tronfig/MASTER.yaml
+tronfig /work/example-cluster/tronfig/MASTER.yaml
 cat /work/example-cluster/tronfig/MASTER.yaml | tronfig -n MASTER -
 
 kill -9 $TRON_PID


### PR DESCRIPTION
fixes an issue where tronfig would fail without a namespace argument