### PR TITLE
Use bsddb3 directly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.tox
+.git
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tron.egg-info
 *.swo
 docs/_build/
 .idea
+tron.iml
 docs/images/
 *.dot
 tronweb/js/cs/*.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 ---
 language: python
 env:
-  - TENV=py27
-  - TENV=py36
+  - TARGET=tox_py27
+  - TARGET=tox_py36
+  - TARGET=itest_deb
 python:
   - 2.7
   - 3.6
@@ -11,13 +12,15 @@ before_install:
   - sudo apt-get install -y libdb5.3-dev
 
 install: pip install tox
-script: tox -e $TENV
+script: make $TARGET
 
 matrix:
   exclude:
-    - env: TENV=py36
+    - env: TARGET=py36
       python: 2.7
-    - env: TENV=py27
+    - env: TARGET=py27
+      python: 3.6
+    - env: TARGET=deb_itest
       python: 3.6
 
 deploy:
@@ -28,4 +31,4 @@ deploy:
     on:
       tags: true
       repo: Yelp/Tron
-      condition: $TENV == "py36"
+      condition: $TARGET == "tox_py36"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ script: make $TARGET
 
 matrix:
   exclude:
-    - env: TARGET=py36
+    - env: TARGET=tox_py36
       python: 2.7
-    - env: TARGET=py27
+    - env: TARGET=tox_py27
       python: 3.6
-    - env: TARGET=deb_itest
+    - env: TARGET=itest_deb
       python: 3.6
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - 3.6
 
 before_install:
-  - sudo apt-get install -y libdb5.1-dev
+  - sudo apt-get install -y libdb5.3-dev
 
 install: pip install tox
 script: tox -e $TENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ env:
 python:
   - 2.7
   - 3.6
+
+before_install:
+  - sudo apt-get install -y libdb5.1-dev
+
 install: pip install tox
 script: tox -e $TENV
 

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ tox_%:
 _itest_%:
 	$(DOCKER_RUN) ubuntu:$* /work/itest.sh
 
+itest_deb: itest_deb_trusty
+
 itest_deb_%: deb_% _itest_%
 	@echo "Package for $* looks good"
 

--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,18 @@ coffee_%:
 	'
 
 test:
-	tox
+	tox -e py27,py36
+
+tox_%:
+	tox -e $*
 
 _itest_%:
 	$(DOCKER_RUN) ubuntu:$* /work/itest.sh
 
-itest_%: test deb_% _itest_%
+itest_deb_%: deb_% _itest_%
 	@echo "Package for $* looks good"
+
+itest_%: test itest_deb_%
 
 dev:
 	.tox/py27/bin/trond --debug --working-dir=dev -l logging.conf --host=$(shell hostname -f)

--- a/README.md
+++ b/README.md
@@ -38,5 +38,11 @@ Contributing
 Read [Working on Tron](http://tron.readthedocs.io/en/latest/developing.html) and
 start sending pull requests!
 
-Any issues should be posted [on
-Github](http://github.com/Yelp/Tron/issues).
+Any issues should be posted [on Github](http://github.com/Yelp/Tron/issues).
+
+BerkeleyDB on Mac OS X
+----------------------
+
+    $ brew install berkeley-db
+    $ export BERKELEYDB_DIR=$(brew --cellar)/berkeley-db/<installed version>
+    $ export YES_I_HAVE_THE_RIGHT_TO_USE_THIS_BERKELEY_DB_VERSION=1

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: tron
 Section: admin
 Priority: optional
 Maintainer: Daniel Nephin <dnephin@yelp.com>
-Build-Depends: debhelper (>= 7), python2.7, libyaml-dev, libssl-dev, libffi-dev, dh-virtualenv
+Build-Depends: debhelper (>= 7), python2.7, libdb5.3-dev, libyaml-dev, libssl-dev, libffi-dev, dh-virtualenv
 Standards-Version: 3.8.3
 
 Package: tron
 Architecture: all
 Homepage: http://github.com/yelp/Tron
-Depends: python2.7, libyaml-0-2, libssl1.0.0, libffi6, ${shlibs:Depends}, ${misc:Depends}
+Depends: python2.7, libdb5.3, libyaml-0-2, libssl1.0.0, libffi6, ${shlibs:Depends}, ${misc:Depends}
 Description: Tron is a job scheduling, running and monitoring package.
   Designed to replace Cron for complex scheduling and dependencies.
   Provides:

--- a/dev/req_dev.txt
+++ b/dev/req_dev.txt
@@ -12,3 +12,4 @@ cryptography>=2.1.4
 Twisted>=17.0.0
 mock>=0.8
 pre-commit
+bsddb3

--- a/itest.sh
+++ b/itest.sh
@@ -51,7 +51,7 @@ from tron.serialize.runstate.shelvestore import ShelveStateStore, ShelveKey
 db = ShelveStateStore('/var/lib/tron/tron_state')
 key = ShelveKey('mcp_state', 'StateMetadata')
 res = db.restore([key])
-ts = res[u'create_time']
+ts = res[key][u'create_time']
 print("assert db time {} > start time {}".format(ts, int(os.environ['TRON_START_TIME'])))
 assert ts > int(os.environ['TRON_START_TIME'])
 EOF

--- a/itest.sh
+++ b/itest.sh
@@ -47,10 +47,11 @@ wait $TRON_PID
 
 /opt/venvs/tron/bin/python - <<EOF
 import os
-from tron.serialize.runstate.shelvestore import Py2Shelf, ShelveKey
-db = Py2Shelf('/var/lib/tron/tron_state')
-key = str(ShelveKey('mcp_state', 'StateMetadata').key)
-ts = db[key][u'create_time']
+from tron.serialize.runstate.shelvestore import ShelveStateStore, ShelveKey
+db = ShelveStateStore('/var/lib/tron/tron_state')
+key = ShelveKey('mcp_state', 'StateMetadata')
+res = db.restore([key])
+ts = res[u'create_time']
 print("assert db time {} > start time {}".format(ts, int(os.environ['TRON_START_TIME'])))
 assert ts > int(os.environ['TRON_START_TIME'])
 EOF

--- a/itest.sh
+++ b/itest.sh
@@ -47,9 +47,10 @@ wait $TRON_PID
 
 /opt/venvs/tron/bin/python - <<EOF
 import os
-from tron.serialize.runstate.shelvestore import Py2Shelf
+from tron.serialize.runstate.shelvestore import Py2Shelf, ShelveKey
 db = Py2Shelf('/var/lib/tron/tron_state')
-ts = db[b'mcp_state___StateMetadata'][u'create_time']
+key = str(ShelveKey('mcp_state', 'StateMetadata').key)
+ts = db[key][u'create_time']
 print("assert db time {} > start time {}".format(ts, int(os.environ['TRON_START_TIME'])))
 assert ts > int(os.environ['TRON_START_TIME'])
 EOF

--- a/itest.sh
+++ b/itest.sh
@@ -19,11 +19,13 @@ EOF
 rm -rf /var/lib/tron
 ln -s /work/example-cluster /var/lib/tron
 rm -f /var/lib/tron/tron.pid
+export TRON_START_TIME=$(date +%s)
+
 trond -v --nodaemon -c tronfig/ -l logging.conf &
 TRON_PID=$!
 
 for i in {1..5}; do
-    if curl localhost:8089/api/status; then
+    if curl localhost:8089/api/status 2>/dev/null; then
         break
     fi
     if [ "$i" == "5" ]; then
@@ -40,4 +42,14 @@ tronfig -n MASTER /work/example-cluster/tronfig/MASTER.yaml
 tronfig /work/example-cluster/tronfig/MASTER.yaml
 cat /work/example-cluster/tronfig/MASTER.yaml | tronfig -n MASTER -
 
-kill -9 $TRON_PID
+kill -SIGTERM $TRON_PID
+wait $TRON_PID
+
+/opt/venvs/tron/bin/python - <<EOF
+import os
+from tron.serialize.runstate.shelvestore import Py2Shelf
+db = Py2Shelf('/var/lib/tron/tron_state')
+ts = db[b'mcp_state___StateMetadata'][u'create_time']
+print("assert db time {} > start time {}".format(ts, int(os.environ['TRON_START_TIME'])))
+assert ts > int(os.environ['TRON_START_TIME'])
+EOF

--- a/osx-bdb.sh
+++ b/osx-bdb.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export BERKELEYDB_DIR=$(brew --prefix berkeley-db)
+export YES_I_HAVE_THE_RIGHT_TO_USE_THIS_BERKELEY_DB_VERSION=1

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'SQLAlchemy>=1.0.15',
         'yelp-clog',
         'enum34>=1.1.6',
+        'bsddb3',
     ],
     packages=find_packages(exclude=['tests.*', 'tests']) + ['tronweb'],
     scripts=glob.glob('bin/*'),

--- a/tests/serialize/runstate/shelvestore_test.py
+++ b/tests/serialize/runstate/shelvestore_test.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import os
-import shelve
 import shutil
 import tempfile
 
@@ -12,6 +11,7 @@ from testify import setup
 from testify import teardown
 from testify import TestCase
 
+from tron.serialize.runstate.shelvestore import Py2Shelf
 from tron.serialize.runstate.shelvestore import ShelveKey
 from tron.serialize.runstate.shelvestore import ShelveStateStore
 
@@ -39,7 +39,7 @@ class ShelveStateStoreTestCase(TestCase):
         self.store.save(key_value_pairs)
         self.store.cleanup()
 
-        stored_data = shelve.open(self.filename)
+        stored_data = Py2Shelf(self.filename)
         for key, value in key_value_pairs:
             assert_equal(stored_data[str(key.key)], value)
         stored_data.close()
@@ -48,12 +48,12 @@ class ShelveStateStoreTestCase(TestCase):
         self.store.cleanup()
         keys = [ShelveKey("thing", i) for i in range(5)]
         value = {'this': 'data'}
-        store = shelve.open(self.filename)
+        store = Py2Shelf(self.filename)
         for key in keys:
             store[str(key.key)] = value
         store.close()
 
-        self.store.shelve = shelve.open(self.filename)
+        self.store.shelve = Py2Shelf(self.filename)
         retrieved_data = self.store.restore(keys)
         for key in keys:
             assert_equal(retrieved_data[key], value)

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,11 @@ commands=
     dot -Tpng -odocs/images/action.png action.dot
     sphinx-build -b html -d docs/_build docs docs/_build/html
 
+[testenv:itest_deb]
+deps =
+usedevelop = false
+commands = make deb_trusty _itest_trusty
+
 [testenv:example-cluster]
 deps = docker-compose>=1.10.0
 commands=

--- a/tron/serialize/runstate/shelvestore.py
+++ b/tron/serialize/runstate/shelvestore.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import dbm
 import logging
 import operator
 import pickle
@@ -9,6 +8,7 @@ import shelve
 import sys
 from io import BytesIO
 
+import bsddb3
 from six.moves import filter
 from six.moves import zip
 
@@ -18,14 +18,11 @@ log = logging.getLogger(__name__)
 
 class Py2Shelf(shelve.Shelf):
     def __init__(self, filename, flag='c', protocol=2, writeback=False):
+        db = bsddb3.hashopen(filename, flag)
+        args = [self, db, protocol, writeback]
         if sys.version_info[0] == 3:
-            shelve.Shelf.__init__(
-                self, dbm.open(filename, flag,), protocol, writeback, 'utf8',
-            )
-        else:
-            shelve.Shelf.__init__(
-                self, dbm.open(filename, flag), protocol, writeback,
-            )
+            args.append('utf8')
+        shelve.Shelf.__init__(*args)
 
     def __getitem__(self, key):
         try:

--- a/yelp_package/trusty/Dockerfile
+++ b/yelp_package/trusty/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update > /dev/null && \
         gcc \
         python-dev \
         coffeescript \
+        libdb5.3-dev \
         libyaml-dev \
         libssl-dev \
         libffi-dev \

--- a/yelp_package/xenial/Dockerfile
+++ b/yelp_package/xenial/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update > /dev/null && \
         gcc \
         python-dev \
         coffeescript \
+        libdb5.3-dev \
         libyaml-dev \
         libssl-dev \
         libffi-dev \


### PR DESCRIPTION
Apparently i didn't test Py2Shelf enough.

Python 2 through some db-detection logic in `anydbm` defaults to using bsddb module that was deprecated and removed from Python 3. It is recommended to use `bsddb3` module instead.

Since all our states are BDB, let's just use that directly and eventually replace it with another storage mechanism.

This adds some linux dependencies and makes life on OSX harder. To run tests we now need to `brew install berkeley-db` and export some env vars before running tox. I've included `osx-bdb.sh` script with relevant exports and made a section about it in README.md.

Also added some folders to .dockerignore because uploading half a gigabyte to docker daemon is not fun.