### PR TITLE
Use PaaSTA config values in runs and create PaaSTA action run

### DIFF
--- a/tests/core/action_test.py
+++ b/tests/core/action_test.py
@@ -23,10 +23,24 @@ class TestAction(TestCase):
             name="ted",
             command="do something",
             node="first",
+            executor="ssh",
+            cluster="prod",
+            pool="default",
+            cpus=1,
+            mem=100,
+            service="bar",
+            deploy_group="test",
         )
         new_action = action.Action.from_config(config)
         assert_equal(new_action.name, config.name)
         assert_equal(new_action.command, config.command)
+        assert_equal(new_action.executor, config.executor)
+        assert_equal(new_action.cluster, config.cluster)
+        assert_equal(new_action.pool, config.pool)
+        assert_equal(new_action.cpus, config.cpus)
+        assert_equal(new_action.mem, config.mem)
+        assert_equal(new_action.service, config.service)
+        assert_equal(new_action.deploy_group, config.deploy_group)
         assert_equal(new_action.node_pool, None)
         assert_equal(new_action.required_actions, [])
 

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -71,6 +71,8 @@ class JobTestCase(TestCase):
             run_limit=20,
             actions={action.name: action},
             cleanup_action=None,
+            service='foo',
+            deploy_group='test',
         )
         scheduler = 'scheduler_token'
         parent_context = 'parent_context_token'
@@ -86,6 +88,8 @@ class JobTestCase(TestCase):
         )
         assert_equal(new_job.enabled, True)
         assert_equal(new_job.get_monitoring()["team"], "foo")
+        assert_equal(new_job.get_service(), 'foo')
+        assert_equal(new_job.get_deploy_group(), 'test')
         assert new_job.action_graph
 
     def test_update_from_job(self):

--- a/tests/core/jobrun_test.py
+++ b/tests/core/jobrun_test.py
@@ -34,6 +34,8 @@ def build_mock_job():
         output_path=mock.Mock(),
         context=mock.Mock(),
         action_runner=runner,
+        service='foo',
+        deploy_group='test',
     )
 
 
@@ -54,6 +56,8 @@ class JobRunTestCase(TestCase):
                 action_runs_with_cleanup=[],
                 get_startable_action_runs=lambda: [],
             ),
+            service='baz',
+            deploy_group='other',
         )
         autospec_method(self.job_run.watch)
         autospec_method(self.job_run.notify)
@@ -79,6 +83,8 @@ class JobRunTestCase(TestCase):
         assert_equal(run.run_num, run_num)
         assert_equal(run.node, mock_node)
         assert not run.manual
+        assert_equal(run.service, self.job.service)
+        assert_equal(run.deploy_group, self.job.deploy_group)
 
     def test_for_job_manual(self):
         run_num = 6
@@ -94,6 +100,8 @@ class JobRunTestCase(TestCase):
         assert_equal(state_data['run_num'], 7)
         assert not state_data['manual']
         assert_equal(state_data['run_time'], self.run_time)
+        assert_equal(state_data['service'], 'baz')
+        assert_equal(state_data['deploy_group'], 'other')
 
     def test_set_action_runs(self):
         self.job_run._action_runs = None
@@ -356,6 +364,8 @@ class JobRunFromStateTestCase(TestCase):
             'runs':             self.action_run_state_data,
             'cleanup_run':      None,
             'manual':           True,
+            'service':          'foo',
+            'deploy_group':     'test',
         }
         self.context = mock.Mock()
 
@@ -371,6 +381,8 @@ class JobRunFromStateTestCase(TestCase):
         assert_equal(run.output_path, self.output_path)
         assert run.context.next
         assert run.action_graph
+        assert_equal(run.service, self.state_data['service'])
+        assert_equal(run.deploy_group, self.state_data['deploy_group'])
 
     def test_from_state_node_no_longer_exists(self):
         run = jobrun.JobRun.from_state(

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -12,15 +12,43 @@ log = logging.getLogger(__name__)
 class Action(object):
     """A configurable data object for an Action."""
 
+    equality_attributes = [
+        'name',
+        'command',
+        'node_pool',
+        'is_cleanup',
+        'executor',
+        'cluster',
+        'pool',
+        'cpus',
+        'mem',
+        'service',
+        'deploy_group',
+    ]
+
     def __init__(
         self, name, command, node_pool, required_actions=None,
         dependent_actions=None,
+        executor=None,
+        cluster=None,
+        pool=None,
+        cpus=None,
+        mem=None,
+        service=None,
+        deploy_group=None,
     ):
         self.name = name
         self.command = command
         self.node_pool = node_pool
         self.required_actions = required_actions or []
         self.dependent_actions = dependent_actions or []
+        self.executor = executor
+        self.cluster = cluster
+        self.pool = pool
+        self.cpus = cpus
+        self.mem = mem
+        self.service = service
+        self.deploy_group = deploy_group
 
     @property
     def is_cleanup(self):
@@ -34,12 +62,19 @@ class Action(object):
             name=config.name,
             command=config.command,
             node_pool=node_repo.get_by_name(config.node),
+            executor=config.executor,
+            cluster=config.cluster,
+            pool=config.pool,
+            cpus=config.cpus,
+            mem=config.mem,
+            service=config.service,
+            deploy_group=config.deploy_group,
         )
 
     def __eq__(self, other):
         attributes_match = all(
             getattr(self, attr, None) == getattr(other, attr, None)
-            for attr in ['name', 'command', 'node_pool', 'is_cleanup']
+            for attr in self.equality_attributes
         )
         return attributes_match and all(
             self_act == other_act for (self_act, other_act)

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -14,6 +14,7 @@ from tron import command_context
 from tron import node
 from tron.actioncommand import ActionCommand
 from tron.actioncommand import NoActionRunnerFactory
+from tron.config.schema import ExecutorTypes
 from tron.core import action
 from tron.serialize import filehandler
 from tron.utils import iteration
@@ -64,34 +65,47 @@ class ActionRunFactory(object):
         """Create an ActionRun for a JobRun and Action."""
         run_node = action.node_pool.next() if action.node_pool else job_run.node
 
-        return ActionRun(
-            job_run.id,
-            action.name,
-            run_node,
-            action.command,
-            parent_context=job_run.context,
-            output_path=job_run.output_path.clone(),
-            cleanup=action.is_cleanup,
-            action_runner=action_runner,
-        )
+        args = {
+            'job_run_id': job_run.id,
+            'name': action.name,
+            'node': run_node,
+            'bare_command': action.command,
+            'parent_context': job_run.context,
+            'output_path': job_run.output_path.clone(),
+            'cleanup': action.is_cleanup,
+            'action_runner': action_runner,
+            'executor': action.executor,
+            'cluster': action.cluster,
+            'pool': action.pool,
+            'cpus': action.cpus,
+            'mem': action.mem,
+            'service': action.service or job_run.service,
+            'deploy_group': action.deploy_group or job_run.deploy_group,
+        }
+        if action.executor == ExecutorTypes.paasta:
+            return PaaSTAActionRun(**args)
+        return SSHActionRun(**args)
 
     @classmethod
     def action_run_from_state(cls, job_run, state_data, cleanup=False):
         """Restore an ActionRun for this JobRun from the state data."""
-        return ActionRun.from_state(
-            state_data,
-            job_run.context,
-            job_run.output_path.clone(),
-            job_run.node,
-            cleanup=cleanup,
-        )
+        args = {
+            'state_data': state_data,
+            'parent_context': job_run.context,
+            'output_path': job_run.output_path.clone(),
+            'job_run_node': job_run.node,
+            'cleanup': cleanup,
+        }
+
+        if state_data.get('executor') == ExecutorTypes.paasta:
+            return PaaSTAActionRun.from_state(**args)
+        return SSHActionRun.from_state(**args)
 
 
-class ActionRun(Observer):
-    """Tracks the state of a single run of an Action.
+class ActionRun(object):
+    """Base class for tracking the state of a single run of an Action.
 
-    ActionRuns observers ActionCommands they create and are observed by a
-    parent JobRun.
+    ActionRuns are observed by a parent JobRun.
     """
     STATE_CANCELLED = state.NamedEventState('cancelled')
     STATE_UNKNOWN = state.NamedEventState('unknown', short_name='UNKWN')
@@ -144,10 +158,27 @@ class ActionRun(Observer):
 
     # TODO: create a class for ActionRunId, JobRunId, Etc
     def __init__(
-        self, job_run_id, name, node, bare_command=None,
-        parent_context=None, output_path=None, cleanup=False,
-        start_time=None, end_time=None, run_state=STATE_SCHEDULED,
-        rendered_command=None, exit_status=None, action_runner=None,
+        self,
+        job_run_id,
+        name,
+        node,
+        bare_command=None,
+        parent_context=None,
+        output_path=None,
+        cleanup=False,
+        start_time=None,
+        end_time=None,
+        run_state=STATE_SCHEDULED,
+        rendered_command=None,
+        exit_status=None,
+        action_runner=None,
+        executor=None,
+        cluster=None,
+        pool=None,
+        cpus=None,
+        mem=None,
+        service=None,
+        deploy_group=None,
     ):
         self.job_run_id = job_run_id
         self.action_name = name
@@ -162,6 +193,13 @@ class ActionRun(Observer):
             self.STATE_SCHEDULED, delegate=self, force_state=run_state,
         )
         self.is_cleanup = cleanup
+        self.executor = executor
+        self.cluster = cluster
+        self.pool = pool
+        self.cpus = cpus
+        self.mem = mem
+        self.service = service
+        self.deploy_group = deploy_group
         self.output_path = output_path or filehandler.OutputPath()
         self.output_path.append(self.id)
         self.context = command_context.build_context(self, parent_context)
@@ -217,6 +255,13 @@ class ActionRun(Observer):
                 cls.STATE_SCHEDULED, state_data['state'],
             ),
             exit_status=state_data.get('exit_status'),
+            executor=state_data.get('executor', ExecutorTypes.ssh),
+            cluster=state_data.get('cluster'),
+            pool=state_data.get('pool'),
+            cpus=state_data.get('cpus'),
+            mem=state_data.get('mem'),
+            service=state_data.get('service'),
+            deploy_group=state_data.get('deploy_group'),
         )
 
         # Transition running to fail unknown because exit status was missed
@@ -243,58 +288,16 @@ class ActionRun(Observer):
             self.fail(-1)
             return
 
-        action_command = self.build_action_command()
-        try:
-            self.node.submit_command(action_command)
-        except node.Error as e:
-            log.warning("Failed to start %s: %r", self.id, e)
-            self.fail(-2)
-            return
+        return self.submit_command()
 
-        return True
+    def submit_command(self):
+        raise NotImplementedError()
 
     def stop(self):
-        stop_command = self.action_runner.build_stop_action_command(
-            self.id, 'terminate',
-        )
-        self.node.submit_command(stop_command)
+        raise NotImplementedError()
 
     def kill(self):
-        kill_command = self.action_runner.build_stop_action_command(
-            self.id, 'kill',
-        )
-        self.node.submit_command(kill_command)
-
-    def build_action_command(self):
-        """Create a new ActionCommand instance to send to the node."""
-        serializer = filehandler.OutputStreamSerializer(self.output_path)
-        self.action_command = self.action_runner.create(
-            id=self.id,
-            command=self.command,
-            serializer=serializer,
-        )
-        self.watch(self.action_command)
-        return self.action_command
-
-    def handle_action_command_state_change(self, action_command, event):
-        """Observe ActionCommand state changes."""
-        log.debug("Action command state change: %s", action_command.state)
-
-        if event == ActionCommand.RUNNING:
-            return self.machine.transition('started')
-
-        if event == ActionCommand.FAILSTART:
-            return self.fail(None)
-
-        if event == ActionCommand.EXITING:
-            if action_command.exit_status is None:
-                return self.fail_unknown()
-
-            if not action_command.exit_status:
-                return self.success()
-
-            return self.fail(action_command.exit_status)
-    handler = handle_action_command_state_change
+        raise NotImplementedError()
 
     def _done(self, target, exit_status=0):
         log.info(
@@ -333,6 +336,13 @@ class ActionRun(Observer):
             'rendered_command': self.rendered_command,
             'node_name':        self.node.get_name() if self.node else None,
             'exit_status':      self.exit_status,
+            'executor':         self.executor,
+            'cluster':          self.cluster,
+            'pool':             self.pool,
+            'cpus':             self.cpus,
+            'mem':              self.mem,
+            'service':          self.service,
+            'deploy_group':     self.deploy_group,
         }
 
     def render_command(self):
@@ -397,6 +407,96 @@ class ActionRun(Observer):
 
     def __str__(self):
         return "ActionRun: %s" % self.id
+
+
+class SSHActionRun(ActionRun, Observer):
+    """An ActionRun that executes the command on a node through SSH.
+    """
+
+    def submit_command(self):
+        action_command = self.build_action_command()
+        try:
+            self.node.submit_command(action_command)
+        except node.Error as e:
+            log.warning("Failed to start %s: %r", self.id, e)
+            self.fail(-2)
+            return
+        return True
+
+    def stop(self):
+        stop_command = self.action_runner.build_stop_action_command(
+            self.id, 'terminate',
+        )
+        self.node.submit_command(stop_command)
+
+    def kill(self):
+        kill_command = self.action_runner.build_stop_action_command(
+            self.id, 'kill',
+        )
+        self.node.submit_command(kill_command)
+
+    def build_action_command(self):
+        """Create a new ActionCommand instance to send to the node."""
+        serializer = filehandler.OutputStreamSerializer(self.output_path)
+        self.action_command = self.action_runner.create(
+            id=self.id,
+            command=self.command,
+            serializer=serializer,
+        )
+        self.watch(self.action_command)
+        return self.action_command
+
+    def handle_action_command_state_change(self, action_command, event):
+        """Observe ActionCommand state changes."""
+        log.debug("Action command state change: %s", action_command.state)
+
+        if event == ActionCommand.RUNNING:
+            return self.machine.transition('started')
+
+        if event == ActionCommand.FAILSTART:
+            return self.fail(None)
+
+        if event == ActionCommand.EXITING:
+            if action_command.exit_status is None:
+                return self.fail_unknown()
+
+            if not action_command.exit_status:
+                return self.success()
+
+            return self.fail(action_command.exit_status)
+    handler = handle_action_command_state_change
+
+
+class PaaSTAActionRun(ActionRun):
+    """An ActionRun that executes the command on a PaaSTA Mesos cluster.
+    """
+
+    def submit_command(self):
+        self.machine.transition('started')
+        stdout = filehandler.OutputStreamSerializer(
+            self.output_path,
+        ).open('.stdout')
+        stdout.write(
+            "Would have run command for service {service} from deploy group "
+            "{deploy_group} on cluster {cluster} in the {pool} pool, with "
+            "{cpus} cpus and {mem} MB memory.".format(
+                service=self.service,
+                deploy_group=self.deploy_group,
+                cluster=self.cluster,
+                pool=self.pool,
+                cpus=self.cpus,
+                mem=self.mem,
+            ),
+        )
+        self.success()
+        stdout.close()
+        return True
+
+    def stop(self):
+        pass
+
+    def kill(self):
+        pass
 
 
 class ActionRunCollection(object):

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -71,6 +71,8 @@ class Job(Observable, Observer):
         'allow_overlap',
         'monitoring',
         'time_zone',
+        'service',
+        'deploy_group',
     ]
 
     # TODO: use config object
@@ -80,6 +82,8 @@ class Job(Observable, Observer):
         run_collection=None, parent_context=None, output_path=None,
         allow_overlap=None, action_runner=None, max_runtime=None,
         time_zone=None,
+        service=None,
+        deploy_group=None,
     ):
         super(Job, self).__init__()
         self.name = name
@@ -95,6 +99,8 @@ class Job(Observable, Observer):
         self.action_runner = action_runner
         self.max_runtime = max_runtime
         self.time_zone = time_zone
+        self.service = service
+        self.deploy_group = deploy_group
         self.output_path = output_path or filehandler.OutputPath()
         self.output_path.append(name)
         self.event = event.get_recorder(self.name)
@@ -129,6 +135,8 @@ class Job(Observable, Observer):
             allow_overlap=job_config.allow_overlap,
             action_runner=action_runner,
             max_runtime=job_config.max_runtime,
+            service=job_config.service,
+            deploy_group=job_config.deploy_group,
         )
 
     def update_from_job(self, job):
@@ -162,6 +170,12 @@ class Job(Observable, Observer):
 
     def get_time_zone(self):
         return self.time_zone
+
+    def get_service(self):
+        return self.service
+
+    def get_deploy_group(self):
+        return self.deploy_group
 
     def get_runs(self):
         return self.runs

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -43,6 +43,8 @@ class JobRun(Observable, Observer):
         self, job_name, run_num, run_time, node, output_path=None,
         base_context=None, action_runs=None, action_graph=None,
         manual=None,
+        service=None,
+        deploy_group=None,
     ):
         super(JobRun, self).__init__()
         self.job_name = job_name
@@ -55,6 +57,8 @@ class JobRun(Observable, Observer):
         self._action_runs = None
         self.action_graph = action_graph
         self.manual = manual
+        self.service = service
+        self.deploy_group = deploy_group
         self.event = event.get_recorder(self.full_id)
         self.event.ok('created')
 
@@ -76,6 +80,8 @@ class JobRun(Observable, Observer):
             job.context,
             action_graph=job.action_graph,
             manual=manual,
+            service=job.service,
+            deploy_group=job.deploy_group,
         )
 
         action_runs = ActionRunFactory.build_action_run_collection(
@@ -103,6 +109,8 @@ class JobRun(Observable, Observer):
             manual=state_data.get('manual', False),
             output_path=output_path,
             base_context=context,
+            service=state_data.get('service'),
+            deploy_group=state_data.get('deploy_group'),
         )
         action_runs = ActionRunFactory.action_run_collection_from_state(
             job_run, state_data['runs'], state_data['cleanup_run'],
@@ -121,6 +129,8 @@ class JobRun(Observable, Observer):
             'runs':             self.action_runs.state_data,
             'cleanup_run':      self.action_runs.cleanup_action_state_data,
             'manual':           self.manual,
+            'service':          self.service,
+            'deploy_group':     self.deploy_group,
         }
 
     def _get_action_runs(self):


### PR DESCRIPTION
Passing all the new config values around. Major change is in actionrun: now ActionRun just handles the state machine, and the subclasses (SSH, PaaSTA) implement stuff related to commands.

PaaSTA action run just prints for now, check this output from the example cluster!
root@940d5614644a:/work# tronview MASTER.test.1597.second
Action Run          : MASTER.test.1597.second
State               : succeeded
Node                : tron@batch1
Command             : echo hi >> out
Bare command        : echo hi >> out
Start time          : 2018-03-23 22:37:59
End time            : 2018-03-23 22:37:59
Exit status         : 0
Requirements:

Stdout:
Would have run command for service foo from deploy group bla on cluster None in the None pool, with 5.0 cpus and None MB memory.

Stderr:`




