### PR TITLE
Do a better job at printing exceptions when there are command render problems

### DIFF
--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import logging
-import traceback
 
 import six
 from six.moves import filter
@@ -138,7 +137,7 @@ class ActionRun(Observer):
     }
 
     # Failed render command is false to ensure that it will fail when run
-    FAILED_RENDER = 'false'
+    FAILED_RENDER = 'false # Command failed to render correctly. See the Tron error log.'
 
     context_class = command_context.ActionRunContext
 
@@ -346,9 +345,9 @@ class ActionRun(Observer):
 
         try:
             self.rendered_command = self.render_command()
-        except Exception:
-            log.error("Failed generating rendering command\n%s" %
-                      traceback.format_exc())
+        except Exception as e:
+            log.error("Failed generating rendering command: %s: %s" %
+                      (e.__class__.__name__, e))
 
             # Return a command string that will always fail
             self.rendered_command = self.FAILED_RENDER

--- a/tron/mcp.py
+++ b/tron/mcp.py
@@ -53,9 +53,10 @@ class MasterControlProgram(object):
         self.event_recorder.ok("reconfigured")
         try:
             self._load_config(reconfigure=True)
-        except Exception:
+        except Exception as e:
             self.event_recorder.critical("reconfigure_failure")
-            log.exception("reconfigure failure")
+            log.exception("reconfigure failure: %s: %s" %
+                          (e.__class__.__name__, e))
             raise
 
     def _load_config(self, reconfigure=False):


### PR DESCRIPTION
The traceback doesn't show up in our error log for syslog reasons (multi-line). This makes it so we only have one line per error (so it will show up!)