### PR TITLE
Timezone date context bug

### DIFF
--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -418,6 +418,17 @@ class JobSchedulerManualStartTestCase(testingutils.MockTimeTestCase):
         assert_length(manual_runs, 1)
         self.manual_run.start.assert_called_once_with()
 
+    def test_manual_start_default_with_timezone(self):
+        self.job.time_zone = mock.Mock()
+        with mock.patch('tron.core.job.timeutils.current_time') as mock_current:
+            manual_runs = self.job_scheduler.manual_start()
+            mock_current.assert_called_with(tz=self.job.time_zone)
+            self.job.build_new_runs.assert_called_with(
+                mock_current.return_value, manual=True,
+            )
+        assert_length(manual_runs, 1)
+        self.manual_run.start.assert_called_once_with()
+
     def test_manual_start_with_run_time(self):
         run_time = datetime.datetime(2012, 3, 14, 15, 9, 26)
         manual_runs = self.job_scheduler.manual_start(run_time)

--- a/tests/utils/timeutils_test.py
+++ b/tests/utils/timeutils_test.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import datetime
 
+import pytz
 from testify import assert_equal
 from testify import setup
 from testify import TestCase
@@ -12,6 +13,35 @@ from tron.utils import timeutils
 from tron.utils.timeutils import DateArithmetic
 from tron.utils.timeutils import duration
 from tron.utils.timeutils import macro_timedelta
+
+
+class ToTimestampTestCase(TestCase):
+
+    def test_normal_time(self):
+        # One hour after the epoch
+        start_date = datetime.datetime(1970, 1, 1, 1)
+        assert_equal(timeutils.to_timestamp(start_date), 60 * 60)
+
+    def test_normal_time_with_timezone(self):
+        # 62 minutes after the epoch
+        start_date = pytz.utc.localize(datetime.datetime(1970, 1, 1, 1, 2))
+        assert_equal(timeutils.to_timestamp(start_date), 62 * 60)
+
+    def test_ambiguous_times(self):
+        pacific_tz = pytz.timezone("US/Pacific")
+        before_fall_back = timeutils.to_timestamp(
+            pacific_tz.localize(
+                datetime.datetime(2017, 11, 5, 1, 23),
+                is_dst=True,
+            ),
+        )
+        after_fall_back = timeutils.to_timestamp(
+            pacific_tz.localize(
+                datetime.datetime(2017, 11, 5, 1, 23),
+                is_dst=False,
+            ),
+        )
+        assert_equal(after_fall_back - before_fall_back, 60 * 60)
 
 
 class TimeDeltaTestCase(TestCase):
@@ -128,6 +158,20 @@ class TimeDeltaTestCase(TestCase):
             self.begin_feb_leap,
             datetime.datetime(year=2016, month=2, day=1),
             years=4,
+        )
+
+    def test_start_date_with_timezone(self):
+        pacific_tz = pytz.timezone("US/Pacific")
+        start_date = pacific_tz.localize(
+            datetime.datetime(year=2018, month=1, day=3, hour=13),
+        )
+        expected_end = pacific_tz.localize(
+            datetime.datetime(year=2018, month=1, day=1, hour=13),
+        )
+        self.check_delta(
+            start_date,
+            expected_end,
+            days=-2,
         )
 
 
@@ -269,3 +313,8 @@ class DateArithmeticTestCase(testingutils.MockTimeTestCase):
 
     def test_bad_date_format(self):
         assert DateArithmetic.parse('~~') is None
+
+
+class DateArithmeticWithTimezoneTestCase(DateArithmeticTestCase):
+
+    now = pytz.timezone("US/Pacific").localize(datetime.datetime(2012, 3, 20))

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -273,7 +273,7 @@ class JobScheduler(Observer):
 
     def manual_start(self, run_time=None):
         """Trigger a job run manually (instead of from the scheduler)."""
-        run_time = run_time or timeutils.current_time()
+        run_time = run_time or timeutils.current_time(tz=self.job.time_zone)
         manual_runs = list(self.job.build_new_runs(run_time, manual=True))
         for r in manual_runs:
             r.start()

--- a/tron/utils/timeutils.py
+++ b/tron/utils/timeutils.py
@@ -20,7 +20,7 @@ def current_timestamp():
 
 def to_timestamp(time_val):
     """Generate a unix timestamp for the given datetime instance"""
-    return time.mktime(time_val.timetuple())
+    return time.mktime(time_val.utctimetuple())
 
 
 def delta_total_seconds(td):
@@ -47,7 +47,8 @@ def macro_timedelta(start_date, years=0, months=0, days=0, hours=0):
     end_date = datetime.datetime(
         start_date.year + years, new_month, start_date.day, start_date.hour,
     )
-    delta += end_date - start_date
+    month_and_year_delta = end_date - start_date.replace(tzinfo=None)
+    delta += month_and_year_delta
 
     return delta
 
@@ -55,6 +56,9 @@ def macro_timedelta(start_date, years=0, months=0, days=0, hours=0):
 def duration(start_time, end_time=None):
     """Get a timedelta between end_time and start_time, where end_time defaults
     to now().
+
+    WARNING: mixing tz-aware and naive datetimes in start_time and end_time
+    will cause an error.
     """
     if not start_time:
         return None


### PR DESCRIPTION
macro_timedelta was failing if start date includes tzinfo. This was causing errors in DateArithmetic.
Made everything in timeutils handle timezones, and added tests.

Also changed manual_start to include tzinfo in the run_time if the job has it.