### PR TITLE
fix the action_status command

### DIFF
--- a/bin/action_runner.py
+++ b/bin/action_runner.py
@@ -84,7 +84,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Action Runner for Tron')
     parser.add_argument(
         'output_dir',
-        help='an integer for the accumulator',
+        help='The directory to store the state of the action run',
     )
     parser.add_argument(
         'command',
@@ -92,7 +92,7 @@ def parse_args():
     )
     parser.add_argument(
         'run_id',
-        help='run_id of the process',
+        help='run_id of the action',
     )
     return parser.parse_args()
 

--- a/bin/action_status.py
+++ b/bin/action_status.py
@@ -3,9 +3,9 @@
 Read values from a status file created by action_runner.py
 """
 from __future__ import absolute_import
+from __future__ import print_function
 from __future__ import unicode_literals
 
-import functools
 import logging
 import os
 import signal
@@ -13,42 +13,39 @@ import sys
 
 from tron import yaml
 
-
 log = logging.getLogger('tron.action_status')
-
 
 STATUS_FILE = 'status'
 
 
-def print_field(field, status_file):
-    sys.stdout.write(str(status_file[field]))
+def get_field(field, status_file):
+    lines = status_file.readlines()
+    content = yaml.load(lines[-1])
+    return content.get(field)
 
 
 def print_status_file(status_file):
-    yaml.dump(status_file, sys.stdout)
+    for line in status_file.readlines():
+        print(yaml.load(line))
 
 
 def send_signal(signal_num, status_file):
-    pid = status_file['pid']
-    try:
-        os.kill(pid, signal_num)
-    except OSError as e:
-        msg = "Failed to signal %s with %s: %s"
-        raise SystemExit(msg % (pid, signal_num, e))
+    pid = get_field('pid', status_file)
+    if pid:
+        try:
+            os.kill(pid, signal_num)
+        except OSError as e:
+            msg = "Failed to signal %s with %s: %s"
+            raise SystemExit(msg % (pid, signal_num, e))
 
 
 commands = {
     'print':        print_status_file,
-    'pid':          functools.partial(print_field, 'pid'),
-    'return_code':  functools.partial(print_field, 'return_code'),
-    'terminate':    functools.partial(send_signal, signal.SIGTERM),
-    'kill':         functools.partial(send_signal, signal.SIGKILL),
+    'pid': lambda statusfile: print(get_field('pid', statusfile)),
+    'return_code': lambda statusfile: print(get_field('return_code', statusfile)),
+    'terminate': lambda statusfile: send_signal(signal.SIGTERM. statusfile),
+    'kill': lambda statusfile: send_signal(signal.SIGKILL, statusfile),
 }
-
-
-def get_status_file(path):
-    with open(path, 'r') as fh:
-        return yaml.load(fh)
 
 
 def parse_args(args):
@@ -68,5 +65,5 @@ def run_command(command, status_file):
 if __name__ == "__main__":
     logging.basicConfig()
     path, command = parse_args(sys.argv)
-    status_file = get_status_file(os.path.join(path, STATUS_FILE))
-    run_command(command, status_file)
+    with open(os.path.join(path, STATUS_FILE)) as f:
+        run_command(command, f)

--- a/bin/action_status.py
+++ b/bin/action_status.py
@@ -6,10 +6,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import argparse
 import logging
 import os
 import signal
-import sys
 
 from tron import yaml
 
@@ -43,19 +43,26 @@ commands = {
     'print':        print_status_file,
     'pid': lambda statusfile: print(get_field('pid', statusfile)),
     'return_code': lambda statusfile: print(get_field('return_code', statusfile)),
-    'terminate': lambda statusfile: send_signal(signal.SIGTERM. statusfile),
+    'terminate': lambda statusfile: send_signal(signal.SIGTERM, statusfile),
     'kill': lambda statusfile: send_signal(signal.SIGKILL, statusfile),
 }
 
 
-def parse_args(args):
-    if len(args) != 3:
-        raise SystemExit("Field and path are required")
-
-    if args[2] not in commands:
-        raise SystemExit("Unknown command %s" % args[2])
-
-    return args[1:]
+def parse_args():
+    parser = argparse.ArgumentParser(description='Action Status for Tron')
+    parser.add_argument(
+        'output_dir',
+        help='The directory where the state of the action run is',
+    )
+    parser.add_argument(
+        'command',
+        help='the command to run',
+    )
+    parser.add_argument(
+        'run_id',
+        help='run_id of the action',
+    )
+    return parser.parse_args()
 
 
 def run_command(command, status_file):
@@ -64,6 +71,6 @@ def run_command(command, status_file):
 
 if __name__ == "__main__":
     logging.basicConfig()
-    path, command = parse_args(sys.argv)
-    with open(os.path.join(path, STATUS_FILE)) as f:
-        run_command(command, f)
+    args = parse_args()
+    with open(os.path.join(args.output_dir, STATUS_FILE)) as f:
+        run_command(args.command, f)

--- a/tests/bin/action_status_test.py
+++ b/tests/bin/action_status_test.py
@@ -15,7 +15,7 @@ class ActionStatusTestCase(TestCase):
 
     @setup_teardown
     def setup_status_file(self):
-        self.status_file = tempfile.NamedTemporaryFile()
+        self.status_file = tempfile.NamedTemporaryFile(mode='r+')
         self.status_content = {
             'pid': 1234,
             'return_code': None,

--- a/tests/bin/action_status_test.py
+++ b/tests/bin/action_status_test.py
@@ -1,23 +1,50 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import signal
+import tempfile
+
 import action_status
 import mock
+import yaml
+from testify import setup_teardown
 from testify import TestCase
 
 
 class ActionStatusTestCase(TestCase):
 
+    @setup_teardown
+    def setup_status_file(self):
+        self.status_file = tempfile.NamedTemporaryFile()
+        self.status_content = {
+            'pid': 1234,
+            'return_code': None,
+            'run_id': 'MASTER.foo.bar.1234',
+        }
+        self.status_file.write(yaml.safe_dump(self.status_content))
+        self.status_file.flush()
+        self.status_file.seek(0)
+        yield
+        self.status_file.close()
+
     @mock.patch('action_status.os.kill', autospec=True)
     def test_send_signal(self, mock_kill):
-        status_file = {'pid': 123}
-        signal_num = 7
-        action_status.send_signal(signal_num, status_file)
-        mock_kill.assert_called_with(status_file['pid'], signal_num)
+        action_status.send_signal(signal.SIGKILL, self.status_file)
+        mock_kill.assert_called_with(
+            self.status_content['pid'], signal.SIGKILL,
+        )
 
-    @mock.patch.dict(action_status.commands)
-    def test_run_command(self):
-        command, func, status_file = 'print', mock.Mock(), 'status_file'
-        action_status.commands['print'] = func
-        action_status.run_command(command, status_file)
-        func.assert_called_with(status_file)
+    def test_get_field_retrieves_last_entry(self):
+        self.status_file.seek(0, 2)
+        additional_status_content = {
+            'pid': 1234,
+            'return_code': 0,
+            'run_id': 'MASTER.foo.bar.1234',
+        }
+        self.status_file.write(yaml.safe_dump(additional_status_content))
+        self.status_file.flush()
+        self.status_file.seek(0)
+        assert action_status.get_field('return_code', self.status_file) == 0
+
+    def test_get_field_none(self):
+        assert action_status.get_field('return_code', self.status_file) is None


### PR DESCRIPTION
#action_runner produces lines of yaml, whilst this script assumed that the
status file is a single blob of yaml. fix action_status.py to

1) parse each line as yaml individually
2) take the last line as the source of truth for any fields to be
printed

```
(tron) robj@tronplayground-uswest1adevc:~  % python action_status.py /tmp/tron/MASTER.qui_test_timezones.234.sleep print
{'command': 'sleep 9m', 'pid': 3904, 'return_code': None, 'run_id': 'MASTER.qui_test_timezones.234.sleep'}
(tron) robj@tronplayground-uswest1adevc:~  % python action_status.py /tmp/tron/MASTER.qui_test_timezones.234.sleep pid
3904
(tron) robj@tronplayground-uswest1adevc:~  % python action_status.py /tmp/tron/MASTER.qui_test_timezones.234.sleep return_code
None
(tron) robj@tronplayground-uswest1adevc:~  % sudo /opt/venvs/tron/bin/python action_status.py /tmp/tron/MASTER.qui_test_timezones.234.sleep kill
(tron) robj@tronplayground-uswest1adevc:~  % echo $?
0

```