### PR TITLE
Added the action_runner for localhost on the example_cluster

### DIFF
--- a/example-cluster/config/MASTER.yaml
+++ b/example-cluster/config/MASTER.yaml
@@ -1,18 +1,24 @@
----
-
 ssh_options:
    agent: False
    identities:
-     - /work/example-cluster/insecure_key
+      - /work/example-cluster/insecure_key
+
+action_runner:
+    runner_type: "subprocess"
+    remote_status_path: "/tmp/tron"
+    remote_exec_path: "/work/bin/"
 
 nodes:
-  - hostname: batch1
-    username: tron
+   - hostname: localhost
+     username: tron
+
+time_zone: US/Eastern
 
 jobs:
-    - name: "test"
-      node: batch1
-      schedule: "interval 20seconds"
-      actions:
+   - name: "test"
+     node: localhost
+     schedule: "daily 17:00:00"
+     time_zone: "US/Pacific"
+     actions:
         - name: "first"
-          command: "echo hi >> out"
+          command: "sleep 5m"

--- a/example-cluster/docker-compose.yml
+++ b/example-cluster/docker-compose.yml
@@ -3,16 +3,12 @@ services:
   master:
     build:
       context: ../
-      dockerfile: yelp_package/trusty/Dockerfile
+      dockerfile: example-cluster/images/batch/Dockerfile
     volumes:
       - ../:/work
       - ./:/nail/tron
     links:
       - batch1
-      - batch2
   batch1:
     build:
-      context: images/batch
-  batch2:
-    build:
-      context: images/batch
+      context: ../

--- a/example-cluster/images/batch/Dockerfile
+++ b/example-cluster/images/batch/Dockerfile
@@ -1,10 +1,30 @@
-FROM library/ubuntu:14.04
+FROM ubuntu:trusty
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      ssh \
-      rsyslog
+        debhelper \
+        dpkg-dev \
+        devscripts \
+        wget \
+        gdebi-core \
+        git \
+        gcc \
+        python-dev \
+        coffeescript \
+        libdb5.3-dev \
+        libyaml-dev \
+        libssl-dev \
+        libffi-dev \
+        ssh \
+        rsyslog \
+        && apt-get clean > /dev/null
+
 RUN useradd -ms /bin/bash tron && mkdir -p /home/tron/.ssh
-ADD insecure_key.pub /home/tron
+ADD example-cluster/images/batch/insecure_key.pub /home/tron
 RUN cat /home/tron/insecure_key.pub > /home/tron/.ssh/authorized_keys
-ENTRYPOINT service ssh restart && tail -f /dev/null
+
+RUN wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
+RUN python /tmp/get-pip.py
+RUN pip install -U tox wheel setuptools
+
+WORKDIR /work

--- a/example-cluster/start.sh
+++ b/example-cluster/start.sh
@@ -2,4 +2,6 @@
 pip install -e .
 eval $(ssh-agent) || true
 export USER=root
+/etc/init.d/ssh start &
+rm -f /nail/tron/tron.pid
 exec trond -l logging.conf --nodaemon --working-dir=/nail/tron -v

--- a/example-cluster/tronfig/MASTER.yaml
+++ b/example-cluster/tronfig/MASTER.yaml
@@ -3,7 +3,16 @@ ssh_options:
    identities:
       - /work/example-cluster/insecure_key
 
+action_runner:
+    runner_type: "subprocess"
+    remote_status_path: "/tmp/tron"
+    remote_exec_path: "/work/bin/"
+
 nodes:
+   - hostname: localhost
+     username: tron
+# Note: the action runner is not available on batch1.
+# Comment out the action_runner config if you want to schedule things remotely
    - hostname: batch1
      username: tron
 
@@ -11,9 +20,9 @@ time_zone: US/Eastern
 
 jobs:
    - name: "test"
-     node: batch1
+     node: localhost
      schedule: "daily 17:00:00"
      time_zone: "US/Pacific"
      actions:
         - name: "first"
-          command: "echo hi >> out"
+          command: "sleep 5m"


### PR DESCRIPTION
This is a slight departure from how the example-cluster worked before.

Due to the (current) way that tron is installed here, I can't use the action_runner on remote boxes. 
But I can with localhost, which is "probably" good enough.

Heck, do we even need "distributed" scheduling in the example cluster? Or can we drop that complexity too? Is it enough for tron to try to schedule to localhost? It still exercises the ssh stuff. Who really cares if the hostname is localhost or is "batch1"?

But I think this may become more important as we invest more into the action_runner and action_status