### PR TITLE
Fix timestamp with timezone and remove flaky test

### DIFF
--- a/tests/utils/timeutils_test.py
+++ b/tests/utils/timeutils_test.py
@@ -17,11 +17,6 @@ from tron.utils.timeutils import macro_timedelta
 
 class ToTimestampTestCase(TestCase):
 
-    def test_normal_time(self):
-        # One hour after the epoch
-        start_date = datetime.datetime(1970, 1, 1, 1)
-        assert_equal(timeutils.to_timestamp(start_date), 60 * 60)
-
     def test_normal_time_with_timezone(self):
         # 62 minutes after the epoch
         start_date = pytz.utc.localize(datetime.datetime(1970, 1, 1, 1, 2))

--- a/tron/utils/timeutils.py
+++ b/tron/utils/timeutils.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import datetime
 import re
 import time
+from calendar import timegm
 
 
 def current_time(tz=None):
@@ -20,6 +21,9 @@ def current_timestamp():
 
 def to_timestamp(time_val):
     """Generate a unix timestamp for the given datetime instance"""
+    # TODO: replace with datetime.timestamp() after python3.6
+    if time_val.tzinfo:
+        return timegm(time_val.utctimetuple())
     return time.mktime(time_val.utctimetuple())
 
 


### PR DESCRIPTION
utctimetuple converts tz-aware datetimes to UTC, and gmtime converts UTC time tuples to timestamps.

utctimetuple does no conversion for naive datetimes, and mktime assumes that the timetuple is local.