### PR TITLE
install ssh-client for example-cluster/start.sh

### DIFF
--- a/yelp_package/trusty/Dockerfile
+++ b/yelp_package/trusty/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update > /dev/null && \
         libyaml-dev \
         libssl-dev \
         libffi-dev \
+        ssh-client \
         && apt-get clean > /dev/null
 
 RUN cd /tmp && \


### PR DESCRIPTION
Install ssh-client because it's used by example-cluster/start.sh