### PR TITLE
Don't delete file if namespace is incorrect

### DIFF
--- a/tests/config/manager_test.py
+++ b/tests/config/manager_test.py
@@ -172,6 +172,13 @@ class ConfigManagerTestCase(TestCase):
         self.manifest.delete.assert_called_with(name)
         mock_remove.assert_called_with(path)
 
+    @mock.patch('os.remove', autospec=True)
+    def test_delete_missing_namespace(self, mock_remove):
+        name = 'namespace'
+        self.manifest.get_file_name.return_value = None
+        self.manager.delete_config(name)
+        assert_equal(mock_remove.call_count, 0)
+
     @mock.patch('tron.config.manager.config_parse.ConfigContainer', autospec=True)
     def test_validate_with_fragment(self, mock_config_container):
         name = 'the_name'

--- a/tron/config/manager.py
+++ b/tron/config/manager.py
@@ -72,7 +72,7 @@ class ManifestFile(object):
     def delete(self, name):
         manifest = read(self.filename)
         if name not in manifest:
-            msg = "Name %s does not exist in manifest, cannot delete."
+            msg = "Namespace %s does not exist in manifest, cannot delete."
             log.info(msg % name)
             return
 
@@ -113,7 +113,12 @@ class ConfigManager(object):
         write_raw(filename, content)
 
     def delete_config(self, name):
-        filename = self.get_filename_from_manifest(name)
+        filename = self.manifest.get_file_name(name)
+        if not filename:
+            msg = "Namespace %s does not exist in manifest, cannot delete."
+            log.info(msg % name)
+            return
+
         self.manifest.delete(name)
         os.remove(filename)
 


### PR DESCRIPTION
Minor, but might as well avoid getting into an inconsistent state.

get_filename_from_manifest adds an entry to the manifest if the namespace is missing. We just want to exit instead.