### PR TITLE
Run the example_cluster under faketime 10x faster than real life

### DIFF
--- a/example-cluster/start.sh
+++ b/example-cluster/start.sh
@@ -1,7 +1,6 @@
 #/bin/sh
 pip install -e .
-eval $(ssh-agent) || true
 export USER=root
 /etc/init.d/ssh start &
 rm -f /nail/tron/tron.pid
-exec trond -l logging.conf --nodaemon --working-dir=/nail/tron -v
+exec faketime -f '+0.0y x10' trond -l logging.conf --nodaemon --working-dir=/nail/tron -v

--- a/example-cluster/tronfig/MASTER.yaml
+++ b/example-cluster/tronfig/MASTER.yaml
@@ -21,7 +21,7 @@ time_zone: US/Eastern
 jobs:
    - name: "test"
      node: localhost
-     schedule: "daily 17:00:00"
+     schedule: "cron * * * * *"
      time_zone: "US/Pacific"
      actions:
         - name: "first"

--- a/yelp_package/trusty/Dockerfile
+++ b/yelp_package/trusty/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update > /dev/null && \
         dpkg-dev \
         devscripts \
         wget \
+        faketime \
         gdebi-core \
         git \
         gcc \


### PR DESCRIPTION
A step closer to a kind of "prod smoketest" where we can see if a release can handle all the jobs on prod for real "for the next month".