### PR TITLE
Disconnect state version from release version

### DIFF
--- a/tron/serialize/runstate/statemanager.py
+++ b/tron/serialize/runstate/statemanager.py
@@ -8,7 +8,6 @@ from contextlib import contextmanager
 
 import six
 
-import tron
 from tron.config import schema
 from tron.core import job
 from tron.serialize import runstate
@@ -60,7 +59,8 @@ class StateMetadata(object):
     RunState interface as Jobs and Services.
     """
     name = 'StateMetadata'
-    version = tron.__version_info__
+    # version = tron.__version_info__
+    version = (0, 7, 0, 0)
 
     def __init__(self):
         self.state_data = {
@@ -76,11 +76,8 @@ class StateMetadata(object):
         if not metadata:
             return
 
-        version = metadata['version']
-        # Names (and state keys) changed in 0.5.2, requires migration
-        # see tools/migration/migrate_state_to_namespace
-        if version > cls.version or version < (0, 5, 2):
-            msg = "State for version %s, expected %s"
+        if metadata['version'][0] > cls.version[0]:
+            msg = "State version %s, expected <= %s"
             raise VersionMismatchError(
                 msg % (metadata['version'], cls.version),
             )

--- a/tron/serialize/runstate/statemanager.py
+++ b/tron/serialize/runstate/statemanager.py
@@ -59,7 +59,9 @@ class StateMetadata(object):
     RunState interface as Jobs and Services.
     """
     name = 'StateMetadata'
-    # version = tron.__version_info__
+
+    # State schema version, only first component counts,
+    # for backwards compatibility
     version = (0, 7, 0, 0)
 
     def __init__(self):
@@ -71,7 +73,7 @@ class StateMetadata(object):
     @classmethod
     def validate_metadata(cls, metadata):
         """Raises an exception if the metadata version is newer then
-        tron.__version__.
+        StateMetadata.version
         """
         if not metadata:
             return


### PR DESCRIPTION
Currently when state file is created, it can only be read by the same or more recent version of tron even if there were no changes to the schema. Let's assume current version is `0` and increment in future when backward-incompatible changes are made. This will allow current (and previous) releases of tron to read the state file.