### PR TITLE
Fix namespace with non-ascii crashing tronfig

### DIFF
--- a/bin/tronfig
+++ b/bin/tronfig
@@ -166,7 +166,11 @@ if __name__ == '__main__':
     client = Client(args.server)
 
     if args.print_config:
-        print(client.config(args.source)['config'])
+        # TODO: use maybe_encode()
+        content = client.config(args.source)['config']
+        if type(content) is not bytes:
+            content = content.encode('utf8')
+        print(content)
     elif args.delete:
         delete_config(client, args.source)
     else:

--- a/tron/config/manager.py
+++ b/tron/config/manager.py
@@ -45,7 +45,10 @@ def read_raw(path):
 
 
 def hash_digest(content):
-    return hashlib.sha1(content.encode('utf-8')).hexdigest()
+    # TODO: use maybe_encode()
+    if type(content) is not bytes:
+        content = content.encode('utf8')
+    return hashlib.sha1(content).hexdigest()
 
 
 class ManifestFile(object):


### PR DESCRIPTION
`tronfig -p` fails when namespace contains non-ascii characters.