### PR TITLE
Fix links in long_description (used on PyPI), use hyperlinks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,5 @@ setup(
     include_package_data=True,
     long_description="""Tron is a centralized system for managing periodic batch processes across a cluster. If you find cron or fcron to be insufficient for managing complex work flows across multiple computers, Tron might be for you.
 
-For more information, look at the tutorial (http://packages.python.org/tron/tutorial.html) or the full documentation (http://packages.python.org/tron).""",
+For more information, look at the `tutorial <http://tron.readthedocs.io/en/latest/tutorial.html>`_ or the `full documentation <http://tron.readthedocs.io/en/latest/index.html>`_.""",
 )


### PR DESCRIPTION
The documentation links on the [public PyPI](https://pypi.python.org/pypi/tron) are 404ing, let's fix them.