### PR TITLE
Recover unknown batches

### DIFF
--- a/bin/action_runner.py
+++ b/bin/action_runner.py
@@ -47,7 +47,7 @@ class StatusFile(object):
                 ),
                 fh,
                 explicit_start=True,
-                width='inf',
+                width=1000000,
             )
             try:
                 yield
@@ -60,7 +60,7 @@ class StatusFile(object):
                     ),
                     fh,
                     explicit_start=True,
-                    width='inf',
+                    width=1000000,
                 )
 
 

--- a/bin/action_runner.py
+++ b/bin/action_runner.py
@@ -11,6 +11,7 @@ import logging
 import os
 import subprocess
 import sys
+import time
 
 import yaml
 
@@ -31,6 +32,8 @@ class StatusFile(object):
             'command': command,
             'pid': proc.pid,
             'return_code': proc.returncode,
+            'runner_pid': os.getpid(),
+            'timestamp': time.time(),
         }
 
     @contextlib.contextmanager
@@ -44,6 +47,7 @@ class StatusFile(object):
                 ),
                 fh,
                 explicit_start=True,
+                width='inf',
             )
             try:
                 yield
@@ -56,6 +60,7 @@ class StatusFile(object):
                     ),
                     fh,
                     explicit_start=True,
+                    width='inf',
                 )
 
 

--- a/bin/recover_batch.py
+++ b/bin/recover_batch.py
@@ -61,7 +61,10 @@ if __name__ == "__main__":
 
     runner_pid = get_key_from_last_line(args.filepath, 'runner_pid')
     if not psutil.pid_exists(runner_pid):
-        log.info("action_runner pid %d no longer running; unable to recover batch" % runner_pid)
+        log.info(
+            "action_runner pid %d no longer running; unable to recover batch" %
+            runner_pid
+        )
         #TODO: should we kill the process here?
         sys.exit(1)
 

--- a/bin/recover_batch.py
+++ b/bin/recover_batch.py
@@ -41,7 +41,6 @@ def notify(ignored, filepath, mask):
         return_code = x.get('return_code')
         if return_code is not None:
             reactor.stop()
-            sys.exit(return_code)
 
 
 def get_key_from_last_line(filepath, key):

--- a/bin/recover_batch.py
+++ b/bin/recover_batch.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import argparse
+
+import yaml
+from twisted.internet import inotify
+from twisted.internet import reactor
+from twisted.python import filepath
+
+
+class StatusFileWatcher(object):
+    """
+    Watches the status file produced by action runners
+    """
+
+    def __init__(self, to_watch, callback):
+        notifier = inotify.INotify()
+        notifier.startReading()
+        notifier.watch(filepath.FilePath(to_watch), callbacks=[callback])
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Check if a action runner has exited; wait otherwise',
+    )
+    parser.add_argument('filepath', )
+    return parser.parse_args()
+
+
+def notify(ignored, filepath, mask):
+    with open(filepath.path) as f:
+        last_entry = f.readlines()[-1]
+        x = yaml.loads(last_entry)
+        return_code = x['return_code']
+        if return_code:
+            exit(return_code)
+
+
+def get_existing_return_code(filepath):
+    with open(filepath) as f:
+        lines = f.readlines()
+        if lines:
+            content = yaml.load(lines[-1])
+            if content['return_code'] is not None:
+                return content['return_code']
+            else:
+                return None
+        return None
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    existing_return_code = get_existing_return_code(args.filepath)
+    if existing_return_code is not None:
+        exit(existing_return_code)
+    watcher = StatusFileWatcher("/tmp", notify)
+    reactor.run()

--- a/bin/recover_batch.py
+++ b/bin/recover_batch.py
@@ -68,8 +68,5 @@ if __name__ == "__main__":
         #TODO: should we kill the process here?
         sys.exit(1)
 
-    if existing_return_code is not None:
-        sys.exit(1)
-
     watcher = StatusFileWatcher(args.filepath, notify)
     reactor.run()

--- a/bin/recover_batch.py
+++ b/bin/recover_batch.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import argparse
+import sys
 
 import yaml
 from twisted.internet import inotify
@@ -32,10 +33,11 @@ def parse_args():
 def notify(ignored, filepath, mask):
     with open(filepath.path) as f:
         last_entry = f.readlines()[-1]
-        x = yaml.loads(last_entry)
-        return_code = x['return_code']
-        if return_code:
-            exit(return_code)
+        x = yaml.load(last_entry)
+        return_code = x.get('return_code')
+        if return_code is not None:
+            reactor.stop()
+            sys.exit(return_code)
 
 
 def get_existing_return_code(filepath):
@@ -54,6 +56,6 @@ if __name__ == "__main__":
     args = parse_args()
     existing_return_code = get_existing_return_code(args.filepath)
     if existing_return_code is not None:
-        exit(existing_return_code)
-    watcher = StatusFileWatcher("/tmp", notify)
+        sys.exit(existing_return_code)
+    watcher = StatusFileWatcher(args.filepath, notify)
     reactor.run()

--- a/bin/tronrepl
+++ b/bin/tronrepl
@@ -181,7 +181,7 @@ def main():
         trond.options.config_path,
     )
     trond.mcp._load_config()
-    trond.mcp.restore_state()
+    trond.mcp.restore_state(trond.mcp.config.load().get_master().action_runner)
 
     mcp = trond.mcp  # noqa: F841
     store = mcp.state_watcher.state_manager._impl  # noqa: F841

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ docutils>=0.8.1
 ipdb
 ipython
 Jinja2>=2.6
+psutil
 pyasn1>=0.0.13
 pycrypto>=2.4
 Pygments>=1.4

--- a/tests/bin/action_runner_test.py
+++ b/tests/bin/action_runner_test.py
@@ -19,17 +19,23 @@ class StatusFileTestCase(TestCase):
 
     def test_get_content(self):
         command, proc, run_id = 'do this', mock.Mock(), 'Job.test.1'
-        content = self.status_file.get_content(
-            command=command,
-            proc=proc,
-            run_id=run_id,
-        )
-        expected = dict(
-            run_id=run_id,
-            command=command,
-            pid=proc.pid,
-            return_code=proc.returncode,
-        )
+        with mock.patch('action_runner.time.time', autospace=True) as faketime, \
+             mock.patch('action_runner.os.getpid', autospec=True) as fakepid:
+            faketime.return_value = 0
+            fakepid.return_value = 2
+            content = self.status_file.get_content(
+                command=command,
+                proc=proc,
+                run_id=run_id,
+            )
+            expected = dict(
+                run_id=run_id,
+                command=command,
+                pid=proc.pid,
+                return_code=proc.returncode,
+                runner_pid=2,
+                timestamp=0,
+            )
         assert_equal(content, expected)
 
 

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -92,6 +92,11 @@ class ActionRunFactoryTestCase(TestCase):
             'end_time': None,
             'command': 'do cleanup',
             'node_name': 'anode',
+            'action_runner':
+                {
+                    'status_path': '/tmp/foo',
+                    'exec_path': '/bin/foo'
+                }
         }
         collection = ActionRunFactory.action_run_collection_from_state(
             self.job_run,
@@ -232,9 +237,7 @@ class ActionRunTestCase(TestCase):
     @setup
     def setup_action_run(self):
         self.output_path = filehandler.OutputPath(tempfile.mkdtemp())
-        self.action_runner = mock.create_autospec(
-            actioncommand.NoActionRunnerFactory,
-        )
+        self.action_runner = actioncommand.NoActionRunnerFactory()
         self.command = "do command %(actionname)s"
         self.rendered_command = "do command action_name"
         self.action_run = ActionRun(

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -267,6 +267,7 @@ class JobSchedulerTestCase(TestCase):
     def test_restore_state_sets_job_runs(self):
         self.job.enabled = False
         mock_runs = [mock.Mock(), mock.Mock()]
+        mock_action_runner = mock.Mock()
         job_state_data = {'runs': mock_runs, 'enabled': True}
 
         self.job_scheduler._set_callback = lambda x: x
@@ -279,12 +280,13 @@ class JobSchedulerTestCase(TestCase):
             'tron.core.job.recovery.launch_recovery_actionruns_for_job_runs'
         ) as mock_launch_recovery:
             mock_launch_recovery.return_value = mock.Mock(autospec=True)
-            self.job_scheduler.restore_state(job_state_data, mock.Mock())
+            self.job_scheduler.restore_state(
+                job_state_data, mock_action_runner
+            )
             assert self.job.runs.runs == collections.deque(mock_runs)
-
-    def test_restore_job_state_launches_recovery_runs(self):
-        job_runs = []
-        job_state_data = {'runs': job_runs, 'enabled': True}
+            assert mock_launch_recovery.called_once_with(
+                job_runs=mock_runs, master_action_runner=mock_action_runner
+            )
 
     def test_disable(self):
         self.job_scheduler.disable()

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -157,8 +157,6 @@ class JobTestCase(TestCase):
         state_data = {'enabled': False, 'runs': job_runs}
         returned_runs = self.job.get_job_runs_from_state(state_data)
         assert not self.job.enabled
-        calls = [mock.call(returned_runs[i]) for i in range(0, len(job_runs))]
-        self.job.watch.assert_has_calls(calls)
 
     def test_build_new_runs(self):
         run_time = datetime.datetime(2012, 3, 14, 15, 9, 26)
@@ -287,6 +285,8 @@ class JobSchedulerTestCase(TestCase):
             assert mock_launch_recovery.called_once_with(
                 job_runs=mock_runs, master_action_runner=mock_action_runner
             )
+            calls = [mock.call(mock_runs[i]) for i in range(0, len(mock_runs))]
+            self.job.watch.assert_has_calls(calls)
 
     def test_disable(self):
         self.job_scheduler.disable()

--- a/tests/core/jobrun_test.py
+++ b/tests/core/jobrun_test.py
@@ -479,7 +479,6 @@ class JobRunCollectionTestCase(TestCase):
                 runs=[],
             ) for i in range(3, -1, -1)
         ]
-        run_collection = jobrun.JobRunCollection(20)
         action_graph = mock.create_autospec(actiongraph.ActionGraph)
         output_path = mock.create_autospec(filehandler.OutputPath)
         context = mock.Mock()

--- a/tests/core/jobrun_test.py
+++ b/tests/core/jobrun_test.py
@@ -467,8 +467,7 @@ class JobRunCollectionTestCase(TestCase):
         runs = jobrun.JobRunCollection.from_config(job_config)
         assert_equal(runs.run_limit, 20)
 
-    def test_restore_state(self):
-        run_collection = jobrun.JobRunCollection(20)
+    def test_job_runs_from_state(self):
         state_data = [
             dict(
                 run_num=i,
@@ -480,32 +479,20 @@ class JobRunCollectionTestCase(TestCase):
                 runs=[],
             ) for i in range(3, -1, -1)
         ]
+        run_collection = jobrun.JobRunCollection(20)
         action_graph = mock.create_autospec(actiongraph.ActionGraph)
         output_path = mock.create_autospec(filehandler.OutputPath)
         context = mock.Mock()
         node_pool = mock.create_autospec(node.NodePool)
-
-        restored_runs = run_collection.restore_state(
+        runs = jobrun.job_runs_from_state(
             state_data,
             action_graph,
             output_path,
             context,
             node_pool,
         )
-        assert_equal(run_collection.runs[0].run_num, 3)
-        assert_equal(run_collection.runs[3].run_num, 0)
-        assert_length(restored_runs, 4)
-
-    def test_restore_state_with_runs(self):
-        assert_raises(
-            ValueError,
-            self.run_collection.restore_state,
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
+        assert len(runs) == 4
+        assert all([type(job) == jobrun.JobRun for job in runs])
 
     def test_build_new_run(self):
         autospec_method(self.run_collection.remove_old_runs)

--- a/tests/core/recovery_test.py
+++ b/tests/core/recovery_test.py
@@ -74,12 +74,15 @@ class TestRecovery(TestCase):
             status_path='/tmp/foo',
             exec_path='/bin/foo',
         )
+        mock_node = mock.Mock()
         action_run = SSHActionRun(
             job_run_id="test.succeeded",
             name="test.succeeded",
-            node=Mock(),
+            node=mock_node,
             action_runner=action_runner
         )
+        res = recover_action_run(action_run, action_runner)
+        mock_node.submit_command.assert_called_once()
 
     def test_filter_recoverable_action_runs(self):
         assert filter_recoverable_action_runs(self.action_runs) == \

--- a/tests/core/recovery_test.py
+++ b/tests/core/recovery_test.py
@@ -1,0 +1,54 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from mock import Mock
+from testify import setup
+from testify import TestCase
+
+from tron.core.actionrun import ActionRun
+from tron.core.actionrun import SSHActionRun
+from tron.core.recovery import build_recovery_command
+from tron.core.recovery import filter_action_runs_needing_recovery
+from tron.core.recovery import recover_action_run
+
+
+class TestRecovery(TestCase):
+    @setup
+    def fake_action_runs(self):
+        mock_unknown_machine = Mock(autospec=True)
+        mock_ok_machine = Mock(autospec=True)
+
+        mock_unknown_machine.state = ActionRun.STATE_UNKNOWN
+        mock_ok_machine.state = ActionRun.STATE_SUCCEEDED
+        self.action_runs = [
+            SSHActionRun(
+                job_run_id="test.unknown",
+                name="test.unknown",
+                node=Mock(),
+                machine=mock_unknown_machine,
+            ),
+            SSHActionRun(
+                job_run_id="test.succeeded",
+                name="test.succeeded",
+                node=Mock(),
+                machine=mock_ok_machine,
+            ),
+        ]
+
+    def test_filter_action_runs_needing_recovery(self):
+        assert filter_action_runs_needing_recovery(self.action_runs) == \
+            [self.action_runs[0]]
+
+    def test_build_recovery_command(self):
+        assert build_recovery_command(
+            "/bin/foo",
+            "/tmp/foo",
+        ) == "/bin/foo /tmp/foo"
+
+    def test_recover_action_run_no_action_runner(self):
+        no_action_runner = SSHActionRun(
+            job_run_id="test.succeeded",
+            name="test.succeeded",
+            node=Mock(),
+        )
+        assert recover_action_run(no_action_runner) is None

--- a/tests/core/recovery_test.py
+++ b/tests/core/recovery_test.py
@@ -5,6 +5,7 @@ from mock import Mock
 from testify import setup
 from testify import TestCase
 
+from tron.actioncommand import SubprocessActionRunnerFactory
 from tron.core.actionrun import ActionRun
 from tron.core.actionrun import SSHActionRun
 from tron.core.recovery import build_recovery_command
@@ -51,4 +52,18 @@ class TestRecovery(TestCase):
             name="test.succeeded",
             node=Mock(),
         )
-        assert recover_action_run(no_action_runner) is None
+        assert recover_action_run(
+            no_action_runner, no_action_runner.action_runner
+        ) is None
+
+    def test_recover_action_run_action_runner(self):
+        action_runner = SubprocessActionRunnerFactory(
+            status_path='/tmp/foo',
+            exec_path='/bin/foo',
+        )
+        action_run = SSHActionRun(
+            job_run_id="test.succeeded",
+            name="test.succeeded",
+            node=Mock(),
+            action_runner=action_runner
+        )

--- a/tests/mcp_test.py
+++ b/tests/mcp_test.py
@@ -134,8 +134,11 @@ class MasterControlProgramRestoreStateTestCase(TestCase):
     def test_restore_state(self):
         job_state_data = {'1': 'things', '2': 'things'}
         self.mcp.state_watcher.restore.return_value = job_state_data
-        self.mcp.restore_state()
-        self.mcp.jobs.restore_state.assert_called_with(job_state_data)
+        action_runner = mock.Mock()
+        self.mcp.restore_state(action_runner)
+        self.mcp.jobs.restore_state.assert_called_with(
+            job_state_data, action_runner
+        )
 
 
 if __name__ == '__main__':

--- a/tests/utils/collections_test.py
+++ b/tests/utils/collections_test.py
@@ -37,15 +37,6 @@ class MappingCollectionsTestCase(TestCase):
         assert_not_in(name, self.collection)
         item.disable.assert_called_with()
 
-    def test_restore_state(self):
-        state_data = {'a': mock.Mock(), 'b': mock.Mock()}
-        self.collection.update({'a': mock.Mock(), 'b': mock.Mock()})
-        self.collection.restore_state(state_data)
-        for key in state_data:
-            self.collection[key].restore_state.assert_called_with(
-                state_data[key],
-            )
-
     def test_contains_item_false(self):
         mock_item, mock_func = mock.Mock(), mock.Mock()
         assert not self.collection.contains_item(mock_item, mock_func)

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -205,7 +205,7 @@ class ActionRun(object):
         self.exit_status = exit_status
         self.bare_command = maybe_decode(bare_command)
         self.rendered_command = rendered_command
-        self.action_runner = action_runner or NoActionRunnerFactory
+        self.action_runner = action_runner or NoActionRunnerFactory()
         self.machine = machine or state.StateMachine(
             self.STATE_SCHEDULED,
             delegate=self,
@@ -269,13 +269,11 @@ class ActionRun(object):
             job_run_node,
         )
 
-        action_runner_data = state_data.get(
-            'action_runner',
-        )
+        action_runner_data = state_data.get('action_runner')
         if action_runner_data:
             action_runner = SubprocessActionRunnerFactory(**action_runner_data)
         else:
-            action_runner = NoActionRunnerFactory
+            action_runner = NoActionRunnerFactory()
 
         rendered_command = state_data.get('rendered_command')
         run = cls(
@@ -407,28 +405,48 @@ class ActionRun(object):
         # Freeze command after it's run
         command = rendered_command if rendered_command else self.bare_command
         return {
-            'job_run_id': self.job_run_id,
-            'action_name': self.action_name,
-            'state': self.state.name,
-            'start_time': self.start_time,
-            'end_time': self.end_time,
-            'command': command,
-            'rendered_command': self.rendered_command,
-            'node_name': self.node.get_name() if self.node else None,
-            'exit_status': self.exit_status,
-            'executor': self.executor,
-            'cluster': self.cluster,
-            'pool': self.pool,
-            'cpus': self.cpus,
-            'mem': self.mem,
-            'service': self.service,
-            'deploy_group': self.deploy_group,
-            'retries_remaining': self.retries_remaining,
-            'exit_statuses': self.exit_statuses,
-            'action_runner': None if self.action_runner == NoActionRunnerFactory else {
-                'status_path': self.action_runner.status_path,
-                'exec_path': self.action_runner.exec_path,
-            },
+            'job_run_id':
+                self.job_run_id,
+            'action_name':
+                self.action_name,
+            'state':
+                self.state.name,
+            'start_time':
+                self.start_time,
+            'end_time':
+                self.end_time,
+            'command':
+                command,
+            'rendered_command':
+                self.rendered_command,
+            'node_name':
+                self.node.get_name() if self.node else None,
+            'exit_status':
+                self.exit_status,
+            'executor':
+                self.executor,
+            'cluster':
+                self.cluster,
+            'pool':
+                self.pool,
+            'cpus':
+                self.cpus,
+            'mem':
+                self.mem,
+            'service':
+                self.service,
+            'deploy_group':
+                self.deploy_group,
+            'retries_remaining':
+                self.retries_remaining,
+            'exit_statuses':
+                self.exit_statuses,
+            'action_runner':
+                None
+                if type(self.action_runner) == NoActionRunnerFactory else {
+                    'status_path': self.action_runner.status_path,
+                    'exec_path': self.action_runner.exec_path,
+                },
         }
 
     def render_command(self):

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -402,51 +402,35 @@ class ActionRun(object):
     def state_data(self):
         """This data is used to serialize the state of this action run."""
         rendered_command = self.rendered_command
+
+        action_runner = None if type(
+            self.action_runner
+        ) == NoActionRunnerFactory else {
+            'status_path': self.action_runner.status_path,
+            'exec_path': self.action_runner.exec_path,
+        }
         # Freeze command after it's run
         command = rendered_command if rendered_command else self.bare_command
         return {
-            'job_run_id':
-                self.job_run_id,
-            'action_name':
-                self.action_name,
-            'state':
-                self.state.name,
-            'start_time':
-                self.start_time,
-            'end_time':
-                self.end_time,
-            'command':
-                command,
-            'rendered_command':
-                self.rendered_command,
-            'node_name':
-                self.node.get_name() if self.node else None,
-            'exit_status':
-                self.exit_status,
-            'executor':
-                self.executor,
-            'cluster':
-                self.cluster,
-            'pool':
-                self.pool,
-            'cpus':
-                self.cpus,
-            'mem':
-                self.mem,
-            'service':
-                self.service,
-            'deploy_group':
-                self.deploy_group,
-            'retries_remaining':
-                self.retries_remaining,
-            'exit_statuses':
-                self.exit_statuses,
-            'action_runner':
-                None
-                if type(self.action_runner) == NoActionRunnerFactory else {
-                    'status_path': self.action_runner.status_path,
-                    'exec_path': self.action_runner.exec_path,
-                },
+            'job_run_id': self.job_run_id,
+            'action_name': self.action_name,
+            'state': self.state.name,
+            'start_time': self.start_time,
+            'end_time': self.end_time,
+            'command': command,
+            'rendered_command': self.rendered_command,
+            'node_name': self.node.get_name() if self.node else None,
+            'exit_status': self.exit_status,
+            'executor': self.executor,
+            'cluster': self.cluster,
+            'pool': self.pool,
+            'cpus': self.cpus,
+            'mem': self.mem,
+            'service': self.service,
+            'deploy_group': self.deploy_group,
+            'retries_remaining': self.retries_remaining,
+            'exit_statuses': self.exit_statuses,
+            'action_runner': action_runner
         }
 
     def render_command(self):

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -194,6 +194,7 @@ class ActionRun(object):
         deploy_group=None,
         retries_remaining=None,
         exit_statuses=None,
+        machine=None,
     ):
         self.job_run_id = maybe_decode(job_run_id)
         self.action_name = maybe_decode(name)
@@ -204,7 +205,7 @@ class ActionRun(object):
         self.bare_command = maybe_decode(bare_command)
         self.rendered_command = rendered_command
         self.action_runner = action_runner or NoActionRunnerFactory
-        self.machine = state.StateMachine(
+        self.machine = machine or state.StateMachine(
             self.STATE_SCHEDULED,
             delegate=self,
             force_state=run_state,

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -227,11 +227,12 @@ class Job(Observable, Observer):
             )
 
             for action_run in runs_to_recover:
-                deferred = recovery.recover_action_run(action_run)
+                deferred = recovery.recover_action_run(
+                    action_run, action_run.action_runnner
+                )
                 if not deferred:
                     log.debug(
-                        "unable to recover action run %s" %
-                        action_run.id,
+                        "unable to recover action run %s" % action_run.id,
                     )
             self.watch(run)
 

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -221,8 +221,6 @@ class Job(Observable, Observer):
             self.context,
             self.node_pool,
         )
-        for run in job_runs:
-            self.watch(run)
         return job_runs
 
     def build_new_runs(self, run_time, manual=False):
@@ -280,6 +278,8 @@ class JobScheduler(Observer):
     def restore_state(self, job_state_data, config_action_runner):
         """Restore the job state and schedule any JobRuns."""
         job_runs = self.job.get_job_runs_from_state(job_state_data)
+        for run in job_runs:
+            self.job.watch(run)
         self.job.runs.runs.extend(job_runs)
         self.job.event.ok('restored')
 

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -222,10 +222,11 @@ class Job(Observable, Observer):
             self.node_pool,
         )
         for run in job_runs:
-            action_runs_needing_recovery = recovery.filter_action_runs_needing_recovery(
-                action_runs=run._action_runs,
+            runs_to_recover = recovery.filter_recovery_candidates(
+                run._action_runs,
             )
-            for action_run in action_runs_needing_recovery:
+
+            for action_run in runs_to_recover:
                 deferred = recovery.recover_action_run(action_run)
                 if not deferred:
                     log.debug(

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -375,7 +375,6 @@ class JobRunCollection(object):
     def cancel_pending(self):
         """Find any queued or scheduled runs and cancel them."""
         for pending in self.get_pending():
-            print('here!')
             pending.cancel()
 
     def remove_pending(self):

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -353,31 +353,6 @@ class JobRunCollection(object):
         """Factory method for creating a JobRunCollection from a config."""
         return cls(job_config.run_limit)
 
-    def restore_state(
-        self,
-        state_data,
-        action_graph,
-        output_path,
-        context,
-        node_pool,
-    ):
-        """Apply state to all jobs from the state dict."""
-        if self.runs:
-            msg = "State can not be restored to a collection with runs."
-            raise ValueError(msg)
-
-        restored_runs = [
-            JobRun.from_state(
-                run_state,
-                action_graph,
-                output_path.clone(),
-                context,
-                node_pool.next(),
-            ) for run_state in state_data
-        ]
-        self.runs.extend(restored_runs)
-        return restored_runs
-
     def build_new_run(self, job, run_time, node, manual=False):
         """Create a new run for the job, add it to the runs list,
         and return it.
@@ -400,6 +375,7 @@ class JobRunCollection(object):
     def cancel_pending(self):
         """Find any queued or scheduled runs and cancel them."""
         for pending in self.get_pending():
+            print('here!')
             pending.cancel()
 
     def remove_pending(self):
@@ -539,3 +515,21 @@ class JobRunCollection(object):
             type(self).__name__,
             ', '.join("%s(%s)" % (r.run_num, r.state) for r in self.runs),
         )
+
+
+def job_runs_from_state(
+    runs,
+    action_graph,
+    output_path,
+    context,
+    node_pool,
+):
+    return [
+        JobRun.from_state(
+            run,
+            action_graph,
+            output_path.clone(),
+            context,
+            node_pool.next(),
+        ) for run in runs
+    ]

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -317,7 +317,6 @@ class JobRun(Observable, Observer):
         if self.action_runs.is_queued:
             return ActionRun.STATE_QUEUED
 
-        log.info("%s in an unknown state: %s" % (self, self.action_runs))
         return ActionRun.STATE_UNKNOWN
 
     @property

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -8,6 +8,7 @@ from tron.core.actionrun import ActionRun
 from tron.core.actionrun import SSHActionRun
 
 RECOVERY_BINARY = "/work/bin/recover_batch.py"
+STATUS_PATH = "/tmp/tron"
 
 log = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ def recover_action_run(action_run):
     log.info("creating recovery run")
     if action_run.action_runner == NoActionRunnerFactory:
         log.info(
-            "unable to recover action_run %s: action_run has no action_runner"
+            "unable to recover action_run %s: action_run has no action_runner" % action_run.id,
         )
         return None
 
@@ -37,7 +38,7 @@ def recover_action_run(action_run):
         node=action_run.node,
         bare_command=build_recovery_command(
             recovery_binary=RECOVERY_BINARY,
-            path=action_run.action_runner.path,
+            path="%s/%s/status" % (STATUS_PATH, action_run.id),
         ),
         output_path=action_run.output_path,
     )

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -7,8 +7,6 @@ from tron.actioncommand import NoActionRunnerFactory
 from tron.core.actionrun import ActionRun
 from tron.core.actionrun import SSHActionRun
 
-RECOVERY_BINARY = "/work/bin/recover_batch.py"
-
 log = logging.getLogger(__name__)
 
 
@@ -36,7 +34,9 @@ def recover_action_run(action_run):
         name="recovery-%s" % action_run.id,
         node=action_run.node,
         bare_command=build_recovery_command(
-            recovery_binary=RECOVERY_BINARY,
+            recovery_binary="%s/recover_batch.py" % (
+                action_run.action_runner.exec_path
+            ),
             path="%s/%s/status" % (
                 action_run.action_runner.status_path,
                 action_run.id,

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -83,10 +83,15 @@ def recover_action_run(action_run, action_runner):
     return deferred
 
 
-def launch_recovery_actionruns_for_job_runs(job_runs):
+def launch_recovery_actionruns_for_job_runs(job_runs, master_action_runner):
     for run in job_runs:
         runs_to_recover = filter_recovery_candidates(run._action_runs)
         for action_run in runs_to_recover:
-            deferred = recover_action_run(action_run, action_run.action_runner)
+            if type(action_run.action_runner) == NoActionRunnerFactory and \
+               type(master_action_runner) != NoActionRunnerFactory:
+                action_runner = master_action_runner
+            else:
+                action_runner = action_run.action_runner
+            deferred = recover_action_run(action_run, action_runner)
             if not deferred:
-                log.debug("unable to recover action run %s" % action_run.id, )
+                log.debug("unable to recover action run %s" % action_run.id)

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import logging
+
+from tron.actioncommand import NoActionRunnerFactory
+from tron.core.actionrun import ActionRun
+from tron.core.actionrun import SSHActionRun
+
+RECOVERY_BINARY = "/work/bin/recover_batch.py"
+
+log = logging.getLogger(__name__)
+
+
+def filter_action_runs_needing_recovery(action_runs):
+    return [
+        action_run for action_run in action_runs
+        if action_run.state == ActionRun.STATE_UNKNOWN
+    ]
+
+
+def build_recovery_command(recovery_binary, path):
+    return "%s %s" % (recovery_binary, path)
+
+
+def recover_action_run(action_run):
+    log.info("creating recovery run")
+    if action_run.action_runner == NoActionRunnerFactory:
+        log.info(
+            "unable to recover action_run %s: action_run has no action_runner"
+        )
+        return None
+
+    recovery_run = SSHActionRun(
+        job_run_id=action_run.job_run_id,
+        name="recovery-%s" % action_run.id,
+        node=action_run.node,
+        bare_command=build_recovery_command(
+            recovery_binary=RECOVERY_BINARY,
+            path=action_run.action_runner.path,
+        ),
+        output_path=action_run.output_path,
+    )
+    recovery_action_command = recovery_run.build_action_command()
+    recovery_action_command.write_stdout(
+        "recovering action run %s" % action_run.id,
+    )
+
+    # this line is where the magic happens.
+    action_run.watch(recovery_action_command)
+
+    log.info(
+        "submitting recovery job with command %s to node %s" % (
+            recovery_action_command.command,
+            recovery_run.node,
+        )
+    )
+    deferred = recovery_run.node.submit_command(recovery_action_command, )
+    deferred.addCallback(
+        lambda x: log.info("completed recovery run %s" % recovery_run.id, )
+    )
+    return deferred

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -8,7 +8,6 @@ from tron.core.actionrun import ActionRun
 from tron.core.actionrun import SSHActionRun
 
 RECOVERY_BINARY = "/work/bin/recover_batch.py"
-STATUS_PATH = "/tmp/tron"
 
 log = logging.getLogger(__name__)
 
@@ -38,7 +37,10 @@ def recover_action_run(action_run):
         node=action_run.node,
         bare_command=build_recovery_command(
             recovery_binary=RECOVERY_BINARY,
-            path="%s/%s/status" % (STATUS_PATH, action_run.id),
+            path="%s/%s/status" % (
+                action_run.action_runner.status_path,
+                action_run.id,
+            ),
         ),
         output_path=action_run.output_path,
     )

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -76,9 +76,9 @@ def recover_action_run(action_run, action_runner):
             recovery_run.node,
         )
     )
-    deferred = recovery_run.node.submit_command(recovery_action_command, )
+    deferred = recovery_run.node.submit_command(recovery_action_command)
     deferred.addCallback(
-        lambda x: log.info("completed recovery run %s" % recovery_run.id, )
+        lambda x: log.info("completed recovery run %s" % recovery_run.id)
     )
     return deferred
 

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -30,7 +30,7 @@ def filter_recoverable_action_runs(action_runs):
 
 def filter_recovery_candidates(runs):
     return filter_recoverable_action_runs(
-        action_runs=filter_recoverable_action_runs(action_runs=runs),
+        action_runs=filter_action_runs_needing_recovery(action_runs=runs),
     )
 
 
@@ -85,7 +85,7 @@ def recover_action_run(action_run, action_runner):
 
 def launch_recovery_actionruns_for_job_runs(job_runs):
     for run in job_runs:
-        runs_to_recover = filter_recovery_candidates(run._action_runs, )
+        runs_to_recover = filter_recovery_candidates(run._action_runs)
         for action_run in runs_to_recover:
             deferred = recover_action_run(action_run, action_run.action_runner)
             if not deferred:

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -81,3 +81,12 @@ def recover_action_run(action_run, action_runner):
         lambda x: log.info("completed recovery run %s" % recovery_run.id, )
     )
     return deferred
+
+
+def launch_recovery_actionruns_for_job_runs(job_runs):
+    for run in job_runs:
+        runs_to_recover = filter_recovery_candidates(run._action_runs, )
+        for action_run in runs_to_recover:
+            deferred = recover_action_run(action_run, action_run.action_runner)
+            if not deferred:
+                log.debug("unable to recover action run %s" % action_run.id, )

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -38,11 +38,12 @@ def build_recovery_command(recovery_binary, path):
     return "%s %s" % (recovery_binary, path)
 
 
-def recover_action_run(action_run):
-    log.info("creating recovery run")
-    if action_run.action_runner == NoActionRunnerFactory:
+def recover_action_run(action_run, action_runner):
+    log.info("creating recovery run for actionrun %s" % action_run.id)
+    if type(action_runner) == NoActionRunnerFactory:
         log.info(
-            "unable to recover action_run %s: action_run has no action_runner" % action_run.id,
+            "unable to recover action_run %s: action_run has no action_runner"
+            % action_run.id,
         )
         return None
 
@@ -51,11 +52,9 @@ def recover_action_run(action_run):
         name="recovery-%s" % action_run.id,
         node=action_run.node,
         bare_command=build_recovery_command(
-            recovery_binary="%s/recover_batch.py" % (
-                action_run.action_runner.exec_path
-            ),
+            recovery_binary="%s/recover_batch.py" % (action_runner.exec_path),
             path="%s/%s/status" % (
-                action_run.action_runner.status_path,
+                action_runner.status_path,
                 action_run.id,
             ),
         ),
@@ -67,6 +66,8 @@ def recover_action_run(action_run):
     )
 
     # this line is where the magic happens.
+    # the action run watches another actioncommand,
+    # and updates its internal state acoording to its result.
     action_run.watch(recovery_action_command)
 
     log.info(

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -17,6 +17,23 @@ def filter_action_runs_needing_recovery(action_runs):
     ]
 
 
+def filter_recoverable_action_runs(action_runs):
+    """
+    Given a list of action_runs, create a filtered list that only includes those that can be recovered
+    For now, the only test is whether the run is an SSHActionRun
+    """
+    return [
+        action_run for action_run in action_runs
+        if isinstance(action_run, SSHActionRun)
+    ]
+
+
+def filter_recovery_candidates(runs):
+    return filter_recoverable_action_runs(
+        action_runs=filter_recoverable_action_runs(action_runs=runs),
+    )
+
+
 def build_recovery_command(recovery_binary, path):
     return "%s %s" % (recovery_binary, path)
 

--- a/tron/logging.conf
+++ b/tron/logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=root, twisted, tron
+keys=root, twisted, tron, tron.serialize
 
 [handlers]
 keys=timedRotatingFileHandler, syslogHandler
@@ -19,6 +19,12 @@ propagate=0
 
 [logger_tron]
 level=WARNING
+handlers=timedRotatingFileHandler
+qualname=tron
+propagate=0
+
+[logger_tron.serialize]
+level=CRITICAL
 handlers=timedRotatingFileHandler
 qualname=tron
 propagate=0

--- a/tron/mcp.py
+++ b/tron/mcp.py
@@ -69,7 +69,11 @@ class MasterControlProgram(object):
         In this case jobs shouldn't be scheduled until the state is applied.
         """
         self._load_config()
-        self.restore_state(self.config.load().get_master().action_runner)
+        self.restore_state(
+            actioncommand.create_action_runner_factory_from_config(
+                self.config.load().get_master().action_runner
+            )
+        )
         # Any job with existing state would have been scheduled already. Jobs
         # without any state will be scheduled here.
         self.jobs.run_queue_schedule()

--- a/tron/mcp.py
+++ b/tron/mcp.py
@@ -69,7 +69,7 @@ class MasterControlProgram(object):
         In this case jobs shouldn't be scheduled until the state is applied.
         """
         self._load_config()
-        self.restore_state()
+        self.restore_state(self.config.load().get_master().action_runner)
         # Any job with existing state would have been scheduled already. Jobs
         # without any state will be scheduled here.
         self.jobs.run_queue_schedule()
@@ -144,14 +144,14 @@ class MasterControlProgram(object):
     def get_config_manager(self):
         return self.config
 
-    def restore_state(self):
+    def restore_state(self, action_runner):
         """Use the state manager to retrieve to persisted state and apply it
         to the configured Jobs.
         """
         self.event_recorder.notice('restoring')
         job_states = self.state_watcher.restore(self.jobs.get_names())
 
-        self.jobs.restore_state(job_states)
+        self.jobs.restore_state(job_states, action_runner)
         self.state_watcher.save_metadata()
 
     def __str__(self):

--- a/tron/utils/collections.py
+++ b/tron/utils/collections.py
@@ -40,11 +40,6 @@ class MappingCollection(dict):
         log.info("Removing %s %s", self.item_name, name)
         self.pop(name).disable()
 
-    def restore_state(self, state_data):
-        for name, state in six.iteritems(state_data):
-            self[name].restore_state(state)
-        log.info("Loaded state for %d %s", len(state_data), self.item_name)
-
     def contains_item(self, item, handle_update_func):
         if item == self.get(item.get_name()):
             return True


### PR DESCRIPTION
TODO:
- [x] fix the exit from the recovery script to not raise an exception (twisted related)
- [x] figure out how to recover actionruns without an action_runner in the state (we currently dont bother).
- [x] put the constants in the recovery script into tronfig, rather than hardcoding in the module. (I've actually just assumed that the status path and exec_path is the same as the action_runner).
- [x] figure out what to do with PaasTAActionRuns (ignore them)
- [x] add a check that the action_runner is still alive. if not, we'll be waiting forever for the status file to be updated. This is likely to happen if the batch machine is unexpectedly shut down.
- [ ] mark the batch being recovered as in progress once the recovery starts

Edit: I'm going to let this feature set go out as a first pass and bump recovering unknown jobs *without* a restart for another PR - this'll catch 99% of our issues, and I'd like to get it out fast and iterate.

I'm going to build a deb and install on tronplayground to start experimenting.