### PR TITLE
Maybe decode all the things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ debian/tron.postinst.debhelper
 debian/tron.postrm.debhelper
 debian/tron.prerm.debhelper
 debian/debhelper-build-stamp
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ debian/tron.postrm.debhelper
 debian/tron.prerm.debhelper
 debian/debhelper-build-stamp
 .vscode
+example-cluster/MASTER.*
+example-cluster/tron-repl.pid

--- a/bin/tronrepl
+++ b/bin/tronrepl
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+""" Start the Tron server daemon."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import argparse
+import logging
+import os
+import traceback
+
+import IPython
+import pkg_resources
+
+import tron
+from tron import mcp
+from tron import trondaemon
+from tron.commands import cmd_utils
+from tron.config import manager
+
+log = logging.getLogger(__name__)
+
+DEFAULT_CONF = 'default_config.yaml'
+DEFAULT_CONF_PATH = 'config/'
+DEFAULT_WORKING_DIR = '/var/lib/tron/'
+DEFAULT_PIDFILE = 'tron-repl.pid'
+DEFAULT_PIDPATH = '/var/run/' + DEFAULT_PIDFILE
+
+
+def parse_cli():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--version', action='version', version="%s %s" % (parser.prog, tron.__version__),
+    )
+
+    parser.add_argument(
+        "-w", "--working-dir", default=DEFAULT_WORKING_DIR,
+        help="Working directory for the Tron daemon, default %(default)s",
+    )
+
+    parser.add_argument(
+        "-c", "--config-path", default=DEFAULT_CONF_PATH,
+        help="File path to the Tron configuration file",
+    )
+
+    parser.add_argument(
+        "--nodaemon", action="store_true", default=False,
+        help="Disable daemonizing, default %(default)s",
+    )
+
+    parser.add_argument(
+        "--pid-file",
+        help="File path to PID file, defaults to %s if working directory "
+        "is default. Otherwise defaults to <working dir>/%s" %
+        (DEFAULT_PIDPATH, DEFAULT_PIDFILE),
+    )
+
+    logging_group = parser.add_argument_group('logging', '')
+    logging_group.add_argument(
+        "--log-conf", "-l",
+        help="File path to a custom logging.conf",
+    )
+
+    logging_group.add_argument(
+        "-v", "--verbose", action="count", default=0,
+        help="Verbose logging. Repeat for more verbosity.",
+    )
+
+    logging_group.add_argument(
+        "--debug", action="store_true",
+        help="Debug mode, extra error reporting, no daemonizing",
+    )
+
+    api_group = parser.add_argument_group('Web Service API', '')
+    api_group.add_argument(
+        "--port", "-P", dest="listen_port", type=int,
+        help="TCP port number to listen on, default %(default)s",
+        default=cmd_utils.DEFAULT_PORT,
+    )
+
+    api_group.add_argument(
+        "--host", "-H", dest="listen_host",
+        help="Hostname to listen on, default %(default)s",
+        default=cmd_utils.DEFAULT_HOST,
+    )
+
+    requirement = pkg_resources.Requirement.parse("tron")
+    api_group.add_argument(
+        "--web-path",
+        default=pkg_resources.resource_filename(
+            requirement, 'tronweb',
+        ),
+        help="Path to static web resources, default %(default)s.",
+    )
+
+    args = parser.parse_args()
+    args.working_dir = os.path.abspath(args.working_dir)
+
+    if args.log_conf:
+        args.log_conf = os.path.join(args.working_dir, args.log_conf)
+        if not os.path.exists(args.log_conf):
+            parser.error(
+                "Logging config file not found: %s" %
+                args.log_conf,
+            )
+
+    if not args.pid_file:
+        if args.working_dir == DEFAULT_WORKING_DIR:
+            args.pid_file = DEFAULT_PIDPATH
+        else:
+            args.pid_file = DEFAULT_PIDFILE
+
+    args.pid_file = os.path.join(args.working_dir, args.pid_file)
+    args.config_path = os.path.join(
+        args.working_dir, args.config_path,
+    )
+
+    if args.debug:
+        args.nodaemon = True
+
+    return args
+
+
+def create_default_config(config_path):
+    """Create a default empty configuration for first time installs"""
+    default = pkg_resources.resource_string(tron.__name__, DEFAULT_CONF)
+    manager.create_new_config(config_path, default)
+
+
+def setup_environment(args):
+    """Setup the working directory and config environment."""
+    if not os.path.exists(args.working_dir):
+        os.makedirs(args.working_dir)
+
+    if (not os.path.isdir(args.working_dir) or
+            not os.access(args.working_dir, os.R_OK | os.W_OK | os.X_OK)):
+        msg = "Error, can't access working directory %s" % args.working_dir
+        raise SystemExit(msg)
+
+    # Attempt to create a default config if config is missing
+    if not os.path.exists(args.config_path):
+        try:
+            create_default_config(args.config_path)
+        except OSError as e:
+            msg = "Error creating default configuration at %s: %s"
+            log.debug(traceback.format_exc())
+            raise SystemExit(msg % (args.config_path, e))
+
+    if not os.access(args.config_path, os.R_OK | os.W_OK):
+        msg = "Error opening configuration %s: Missing Permissions"
+        raise SystemExit(msg % args.config_path)
+
+
+def main():
+    args = parse_cli()
+
+    setup_environment(args)
+    trond = trondaemon.TronDaemon(args)  # noqa: F841
+    trond.mcp = mcp.MasterControlProgram(
+        trond.options.working_dir, trond.options.config_path,
+    )
+    trond.mcp._load_config()
+    trond.mcp.restore_state()
+    IPython.embed()
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/tronrepl
+++ b/bin/tronrepl
@@ -12,7 +12,7 @@ import IPython
 import pkg_resources
 
 import tron
-from tron import mcp
+import tron.mcp
 from tron import trondaemon
 from tron.commands import cmd_utils
 from tron.config import manager
@@ -156,11 +156,26 @@ def main():
 
     setup_environment(args)
     trond = trondaemon.TronDaemon(args)  # noqa: F841
-    trond.mcp = mcp.MasterControlProgram(
+    trond.mcp = tron.mcp.MasterControlProgram(
         trond.options.working_dir, trond.options.config_path,
     )
     trond.mcp._load_config()
     trond.mcp.restore_state()
+
+    mcp = trond.mcp  # noqa: F841
+    store = mcp.state_watcher.state_manager._impl  # noqa: F841
+    shelve = store.shelve  # noqa: F841
+
+    print("")
+    print("+---------------------+")
+    print("| Tron REPL           |")
+    print("|   Available locals: |")
+    print("|   - trond           |")
+    print("|   - mcp             |")
+    print("|   - store           |")
+    print("|   - shelve          |")
+    print("+---------------------+")
+    print("")
     IPython.embed()
 
 

--- a/dev/req_dev.txt
+++ b/dev/req_dev.txt
@@ -13,3 +13,5 @@ Twisted>=17.0.0
 mock>=0.8
 pre-commit
 bsddb3
+ipython
+ipdb

--- a/example-cluster/config/MASTER.yaml
+++ b/example-cluster/config/MASTER.yaml
@@ -1,3 +1,8 @@
+state_persistence:
+    name: "/nail/tron/tron_state"
+    store_type: "shelve"
+    buffer_size: 10
+
 ssh_options:
    agent: False
    identities:
@@ -17,10 +22,11 @@ time_zone: US/Eastern
 jobs:
   - name: "test"
     node: localhost
-    schedule: "daily 17:00:00"
+    schedule: "cron * * * * *"
     time_zone: "US/Pacific"
     actions:
       - name: "first"
-        command: "sleep 5m"
+        command: "date; ruby -e 'exit(rand(0..1))'"
+        retries: 3
     cleanup_action:
       command: "echo %(last_success:shortdate)s %(cleanup_job_status)s"

--- a/example-cluster/start.sh
+++ b/example-cluster/start.sh
@@ -1,6 +1,20 @@
-#/bin/sh
-pip install -e .
-export USER=root
-/etc/init.d/ssh start &
+#!/usr/bin/env bash
+
+if ! service ssh status > /dev/null; then
+  echo Setting up SSH
+  apt-get -qq -y install ssh
+  mkdir -p ~/.ssh
+  cp example-cluster/insecure_key ~/.ssh/id_rsa
+  cp example-cluster/insecure_key.pub ~/.ssh/authorized_keys
+  chmod -R 0600 ~/.ssh
+  service ssh start
+fi
+
+if ! pip list --format=columns | grep 'tron.*/work' > /dev/null; then
+  echo Installing packages
+  pip install -q -e .
+fi
+
+echo Starting Tron
 rm -f /nail/tron/tron.pid
 exec faketime -f '+0.0y x10' trond -l logging.conf --nodaemon --working-dir=/nail/tron -v

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ setup(
         'yelp-clog',
         'enum34>=1.1.6',
         'bsddb3',
+        'ipython',
+        'ipdb',
     ],
     packages=find_packages(exclude=['tests.*', 'tests']) + ['tronweb'],
     scripts=glob.glob('bin/*'),

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -21,6 +21,7 @@ from twisted.web import http, resource, static, server
 from tron import event
 from tron.api import adapter, controller
 from tron.api import requestargs
+from tron.utils import maybe_decode
 
 
 log = logging.getLogger(__name__)
@@ -114,6 +115,8 @@ class JobRunResource(resource.Resource):
     def getChild(self, action_name, _):
         if not action_name:
             return self
+
+        action_name = maybe_decode(action_name)
         if action_name == '_events':
             return EventResource(self.job_run.id)
         if action_name in self.job_run.action_runs:
@@ -161,6 +164,8 @@ class JobResource(resource.Resource):
     def getChild(self, run_id, _):
         if not run_id:
             return self
+
+        run_id = maybe_decode(run_id)
         if run_id == '_events':
             return EventResource(self.job_scheduler.get_name())
 
@@ -225,6 +230,8 @@ class JobCollectionResource(resource.Resource):
     def getChild(self, name, request):
         if not name:
             return self
+
+        name = maybe_decode(name)
         return resource_from_collection(self.job_collection, name, JobResource)
 
     def get_data(self, include_job_run=False, include_action_runs=False):

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -5,6 +5,7 @@ import logging
 
 from tron import node
 from tron.config.schema import CLEANUP_ACTION_NAME
+from tron.utils import maybe_decode
 
 log = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ class Action(object):
         service=None,
         deploy_group=None,
     ):
-        self.name = name
+        self.name = maybe_decode(name)
         self.command = command
         self.node_pool = node_pool
         self.retries = retries

--- a/tron/core/actiongraph.py
+++ b/tron/core/actiongraph.py
@@ -6,6 +6,7 @@ import logging
 import six
 
 from tron.core import action
+from tron.utils import maybe_decode
 
 log = logging.getLogger(__name__)
 
@@ -21,12 +22,12 @@ class ActionGraph(object):
     def from_config(cls, actions_config, cleanup_action_config=None):
         """Create this graph from a job config."""
         actions = {
-            name: action.Action.from_config(conf)
+            maybe_decode(name): action.Action.from_config(conf)
             for name, conf in six.iteritems(actions_config)
         }
         if cleanup_action_config:
             cleanup_action = action.Action.from_config(cleanup_action_config)
-            actions[cleanup_action.name] = cleanup_action
+            actions[maybe_decode(cleanup_action.name)] = cleanup_action
 
         return cls(cls._build_dag(actions, actions_config), actions)
 
@@ -50,7 +51,7 @@ class ActionGraph(object):
     def _get_dependencies(cls, actions_config, action_name):
         if action_name == action.CLEANUP_ACTION_NAME:
             return []
-        return actions_config[action_name].requires
+        return actions_config[maybe_decode(action_name)].requires
 
     def actions_for_names(self, names):
         return (self.action_map[name] for name in names)

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -17,6 +17,7 @@ from tron.config.schema import ExecutorTypes
 from tron.core import action
 from tron.serialize import filehandler
 from tron.utils import iteration
+from tron.utils import maybe_decode
 from tron.utils import proxy
 from tron.utils import state
 from tron.utils import timeutils
@@ -35,7 +36,7 @@ class ActionRunFactory(object):
         """Create an ActionRunGraph from an ActionGraph and JobRun."""
         action_map = six.iteritems(job_run.action_graph.get_action_map())
         action_run_map = {
-            name: cls.build_run_for_action(job_run, action_inst, action_runner)
+            maybe_decode(name): cls.build_run_for_action(job_run, action_inst, action_runner)
             for name, action_inst in action_map
         }
         return ActionRunCollection(job_run.action_graph, action_run_map)
@@ -55,7 +56,8 @@ class ActionRunFactory(object):
             ))
 
         action_run_map = {
-            action_run.action_name: action_run for action_run in action_runs
+            maybe_decode(action_run.action_name): action_run
+            for action_run in action_runs
         }
         return ActionRunCollection(job_run.action_graph, action_run_map)
 
@@ -182,8 +184,8 @@ class ActionRun(object):
         retries_remaining=None,
         exit_statuses=None,
     ):
-        self.job_run_id = job_run_id
-        self.action_name = name
+        self.job_run_id = maybe_decode(job_run_id)
+        self.action_name = maybe_decode(name)
         self.node = node
         self.start_time = start_time
         self.end_time = end_time

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -19,6 +19,7 @@ from tron.scheduler import scheduler_from_config
 from tron.serialize import filehandler
 from tron.utils import collections
 from tron.utils import iteration
+from tron.utils import maybe_decode
 from tron.utils import proxy
 from tron.utils import timeutils
 from tron.utils.observer import Observable
@@ -86,7 +87,7 @@ class Job(Observable, Observer):
         deploy_group=None,
     ):
         super(Job, self).__init__()
-        self.name = name
+        self.name = maybe_decode(name)
         self.monitoring = monitoring
         self.action_graph = action_graph
         self.scheduler = scheduler

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -15,6 +15,7 @@ from tron import node
 from tron.core.actionrun import ActionRun
 from tron.core.actionrun import ActionRunFactory
 from tron.serialize import filehandler
+from tron.utils import maybe_decode
 from tron.utils import proxy
 from tron.utils import timeutils
 from tron.utils.observer import Observable
@@ -47,7 +48,7 @@ class JobRun(Observable, Observer):
         deploy_group=None,
     ):
         super(JobRun, self).__init__()
-        self.job_name = job_name
+        self.job_name = maybe_decode(job_name)
         self.run_num = run_num
         self.run_time = run_time
         self.node = node

--- a/tron/serialize/runstate/shelvestore.py
+++ b/tron/serialize/runstate/shelvestore.py
@@ -12,6 +12,8 @@ import bsddb3
 from six.moves import filter
 from six.moves import zip
 
+from tron.utils import maybe_decode
+
 
 log = logging.getLogger(__name__)
 
@@ -49,8 +51,8 @@ class ShelveKey(object):
     __slots__ = ['type', 'iden']
 
     def __init__(self, type, iden):
-        self.type = type
-        self.iden = iden
+        self.type = maybe_decode(type)
+        self.iden = maybe_decode(iden)
 
     @property
     def key(self):

--- a/tron/utils/__init__.py
+++ b/tron/utils/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+
+def maybe_decode(maybe_string):
+    if type(maybe_string) is bytes:
+        return maybe_string.decode()
+    return maybe_string
+
+
+def maybe_encode(maybe_bytes):
+    if type(maybe_bytes) is not bytes:
+        return maybe_bytes.encode()
+    return maybe_bytes


### PR DESCRIPTION
The problem is that due to differences in bytes/unicode handling between py2 and py3, there are inconsistent key encodings in various collections in tron state.

This PR injects bunch of `maybe_decode`s in (hopefully) right places, so in theory after loading/storing the state everything will converge to unicode names/keys everywhere.

This will also be merged into py3 branch for consistency and will be cleaned up after we migrate.

Additionally:

-  i've copied `trond` with some changes into `tronrepl` to make it easy to inspect current state of tron, this is not recommended to use in production until I add readonly mode for state store class. to try it out, run it with the same arguments as trond, you will be dropped into ipython (pip install it beforehand) and you have some local variables prepared for observation.
- copied start.sh from py3 branch that is less noisy and does less things when called multiple times