### PR TITLE
speed up tronview command with zero args

### DIFF
--- a/bin/tronview
+++ b/bin/tronview
@@ -71,7 +71,12 @@ def view_all(args, client):
     if args.show_events:
         return display_events(client.events())
 
-    return display.DisplayJobs().format(client.jobs())
+    return display.DisplayJobs().format(client.jobs(
+        include_job_runs=False,
+        include_action_runs=False,
+        include_action_graph=False,
+        include_node_pool=False,
+    ))
 
 
 def view_job(args, job_id, client):

--- a/tests/api/resource_test.py
+++ b/tests/api/resource_test.py
@@ -184,7 +184,7 @@ class JobCollectionResourceTestCase(WWWTestCase):
     def test_render_GET(self):
         self.resource.get_data = Turtle()
         result = self.resource.render_GET(REQUEST)
-        assert_call(self.resource.get_data, 0, False, False)
+        assert_call(self.resource.get_data, 0, False, False, False, False)
         assert 'jobs' in result
 
     def test_getChild(self):

--- a/tests/commands/client_test.py
+++ b/tests/commands/client_test.py
@@ -154,7 +154,7 @@ class ClientTestCase(TestCase):
     def test_jobs(self):
         self.client.jobs()
         self.client.request.assert_called_with(
-            '/api/jobs?include_action_runs=0&include_job_runs=0',
+            '/api/jobs?include_action_graph=1&include_action_runs=0&include_job_runs=0&include_node_pool=1',
         )
 
 

--- a/tron/api/adapter.py
+++ b/tron/api/adapter.py
@@ -253,12 +253,14 @@ class JobAdapter(ReprAdapter):
         include_job_runs=False,
         include_action_runs=False,
         include_action_graph=True,
+        include_node_pool=True,
         num_runs=None,
     ):
         super(JobAdapter, self).__init__(job)
         self.include_job_runs = include_job_runs
         self.include_action_runs = include_action_runs
         self.include_action_graph = include_action_graph
+        self.include_node_pool = include_node_pool
         self.num_runs = num_runs
 
     def get_name(self):
@@ -273,6 +275,7 @@ class JobAdapter(ReprAdapter):
     def get_action_names(self):
         return self._obj.action_graph.names
 
+    @toggle_flag('include_node_pool')
     def get_node_pool(self):
         return NodePoolAdapter(self._obj.node_pool).get_repr()
 

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -227,12 +227,14 @@ class JobCollectionResource(resource.Resource):
             return self
         return resource_from_collection(self.job_collection, name, JobResource)
 
-    def get_data(self, include_job_run=False, include_action_runs=False):
+    def get_data(self, include_job_run=False, include_action_runs=False, include_action_graph=True, include_node_pool=True):
         return adapter.adapt_many(
             adapter.JobAdapter,
             self.job_collection.get_jobs(),
             include_job_run,
             include_action_runs,
+            include_action_graph,
+            include_node_pool,
             num_runs=5,
         )
 
@@ -247,8 +249,12 @@ class JobCollectionResource(resource.Resource):
         include_action_runs = requestargs.get_bool(
             request, 'include_action_runs',
         )
+        include_action_graph = requestargs.get_bool(
+            request, 'include_action_graph',
+        )
+        include_node_pool = requestargs.get_bool(request, 'include_node_pool')
         output = dict(jobs=self.get_data(
-            include_job_runs, include_action_runs,
+            include_job_runs, include_action_runs, include_action_graph, include_node_pool,
         ))
         return respond(request, output)
 

--- a/tron/commands/client.py
+++ b/tron/commands/client.py
@@ -129,10 +129,12 @@ class Client(object):
     def get_url(self, identifier):
         return get_object_type_from_identifier(self.index(), identifier).url
 
-    def jobs(self, include_job_runs=False, include_action_runs=False):
+    def jobs(self, include_job_runs=False, include_action_runs=False, include_action_graph=True, include_node_pool=True):
         params = {
             'include_job_runs': int(include_job_runs),
             'include_action_runs': int(include_action_runs),
+            'include_action_graph': int(include_action_graph),
+            'include_node_pool': int(include_node_pool),
         }
         return self.http_get('/api/jobs', params).get('jobs')
 


### PR DESCRIPTION
tronview and tronweb work fine with this change. Unfortunately, I don't have the numbers to show how much it gonna speed up, but it shouldn't be worse at least. And this requires trond restarts.