### PR TITLE
Always send signals to the full process group in the tron action runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ debian/tron.postinst.debhelper
 debian/tron.postrm.debhelper
 debian/tron.prerm.debhelper
 debian/debhelper-build-stamp
+
+# example_cluster junk
+*.stdout
+*.stderr

--- a/bin/action_status.py
+++ b/bin/action_status.py
@@ -33,7 +33,7 @@ def send_signal(signal_num, status_file):
     pid = get_field('pid', status_file)
     if pid:
         try:
-            os.kill(pid, signal_num)
+            os.killpg(os.getpgid(pid), signal_num)
         except OSError as e:
             msg = "Failed to signal %s with %s: %s"
             raise SystemExit(msg % (pid, signal_num, e))

--- a/tests/bin/action_status_test.py
+++ b/tests/bin/action_status_test.py
@@ -27,12 +27,12 @@ class ActionStatusTestCase(TestCase):
         yield
         self.status_file.close()
 
-    @mock.patch('action_status.os.kill', autospec=True)
-    def test_send_signal(self, mock_kill):
+    @mock.patch('action_status.os.killpg', autospec=True)
+    @mock.patch('action_status.os.getpgid', autospec=True, return_value=42)
+    def test_send_signal(self, mock_getpgid, mock_kill):
         action_status.send_signal(signal.SIGKILL, self.status_file)
-        mock_kill.assert_called_with(
-            self.status_content['pid'], signal.SIGKILL,
-        )
+        mock_getpgid.assert_called_with(self.status_content['pid'])
+        mock_kill.assert_called_with(42, signal.SIGKILL)
 
     def test_get_field_retrieves_last_entry(self):
         self.status_file.seek(0, 2)


### PR DESCRIPTION
With the action runner we always run things with `shell=True`, which means we get a /bin/sh -c on everything.

The downside to this is that when you run `tronctl kill`, the signal doesn't "propagate" to the child process, so it gets reparented to 1.

This changes makes it so we signal the whole process group (like dumb-init).

Before this change, the proocess tree looked like this:
```
root@8ca2af892aaa:/work# ps -ef --forest
UID         PID   PPID  C STIME TTY          TIME CMD
root          1      0  0 00:04 ?        00:00:00 /bin/bash
root         16      1  0 00:05 ?        00:00:00 faketime -f +0.0y x10 trond -l logging.conf --nodaemon --working-dir=/nail/tron -v
root       1159     16  0 00:06 ?        00:00:00  \_ [ssh] <defunct>
root       1164     16  0 00:06 ?        00:00:01  \_ /usr/bin/python /usr/local/bin/trond -l logging.conf --nodaemon --working-dir=/nail/tron -v
root       1182      1  0 00:06 ?        00:00:00 /usr/sbin/sshd
root       1300   1182  0 00:21 ?        00:00:00  \_ sshd: tron [priv]
tron       1311   1300  0 00:21 ?        00:00:00      \_ sshd: tron@notty
tron       1312   1311  0 00:21 ?        00:00:00          \_ python /work/bin/action_runner.py /tmp/tron/MASTER.test.2.first sleep 5m MASTER.test.2.first
tron       1313   1312  0 00:21 ?        00:00:00              \_ /bin/sh -c sleep 5m
tron       1314   1313  0 00:21 ?        00:00:00                  \_ sleep 5m
root       1333      1  0 00:21 ?        00:00:00 ps -ef --forest
root@8ca2af892aaa:/work#  tronctl stop MASTER.test.2.first
root@8ca2af892aaa:/work# ps -ef --forest
UID         PID   PPID  C STIME TTY          TIME CMD
root          1      0  0 00:04 ?        00:00:00 /bin/bash
root         16      1  0 00:05 ?        00:00:00 faketime -f +0.0y x10 trond -l logging.conf --nodaemon --working-dir=/nail/tron -v
root       1159     16  0 00:06 ?        00:00:00  \_ [ssh] <defunct>
root       1164     16  0 00:06 ?        00:00:01  \_ /usr/bin/python /usr/local/bin/trond -l logging.conf --nodaemon --working-dir=/nail/tron -v
root       1182      1  0 00:06 ?        00:00:00 /usr/sbin/sshd
root       1214   1182  0 00:14 ?        00:00:00  \_ sshd: tron [priv]
tron       1225   1214  0 00:14 ?        00:00:00      \_ sshd: tron@notty
tron       1228      1  0 00:14 ?        00:00:00 sleep 5m
root       1285      1  0 00:15 ?        00:00:00 ps -ef --forest
```

And now with this change, `sleep 5m` actually does go away.

Kinda makes me wonder how this ever worked?

cc @chriskuehl 