### PR TITLE
Fix Xenial build

### DIFF
--- a/yelp_package/xenial/Dockerfile
+++ b/yelp_package/xenial/Dockerfile
@@ -26,6 +26,10 @@ RUN apt-get -q update && \
         wget \
     && apt-get -q clean
 
+RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py
+RUN python3.6 /tmp/get-pip.py
+RUN pip3.6 install --ignore-installed six -U tox wheel setuptools PyYAML
+
 RUN cd /tmp && \
     wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
     gdebi -n dh-virtualenv*.deb && \


### PR DESCRIPTION
Fix for
```
04:15:16 Step 8/8 : WORKDIR /work
04:15:16  ---> Using cache
04:15:16  ---> 5b6c272bd17f
04:15:16 Successfully built 5b6c272bd17f
04:15:16 docker run -t -v /ephemeral/jenkins/workspace/itest_xenial:/work:rw tron-builder-xenial python3.6 -m tox -vv --workdir .tox-docker -e py36
04:15:16 /usr/bin/python3.6: No module named tox
04:15:16 make: *** [test_in_docker_xenial] Error 1
```
Just copy-pasted `tox` installation commands for py3 from the trusty's `Dockerfile`.