### PR TITLE
Added docker-compose dependency to fix example-cluster on Trusty

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,8 @@ commands=
 
 [testenv:example-cluster]
 whitelist_externals=docker-compose
+deps=
+    docker-compose
 commands=
     docker-compose -f example-cluster/docker-compose.yml build playground
     docker-compose -f example-cluster/docker-compose.yml run -p 8089:8089 playground


### PR DESCRIPTION
Before:
```
ERROR: Version in "./example-cluster/docker-compose.yml" is unsupported. Either specify a version of "2" (or "2.0") and place your s
ervice definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to
 use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
ERROR: InvocationError: '/nail/sys/bin/docker-compose -f example-cluster/docker-compose.yml build playground'

```