### PR TITLE
set check_every in monitoring script

### DIFF
--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -24,6 +24,7 @@ class CheckJobsTestCase(TestCase):
         mock_check_job_result,
     ):
         type(mock_args.return_value).job = PropertyMock(return_value=None)
+        type(mock_args.return_value).run_interval = 300
         mock_client.return_value.jobs.return_value = [
             {
                 'name': 'job1',


### PR DESCRIPTION
set check_every in monitoring script, so the developers can set alert_after in the config file.