### PR TITLE
bug fixes: namespace deletion, reading long status files

### DIFF
--- a/bin/action_runner.py
+++ b/bin/action_runner.py
@@ -43,6 +43,7 @@ class StatusFile(object):
                     proc=proc,
                 ),
                 fh,
+                explicit_start=True,
             )
             try:
                 yield
@@ -54,6 +55,7 @@ class StatusFile(object):
                         proc=proc,
                     ),
                     fh,
+                    explicit_start=True,
                 )
 
 

--- a/bin/action_status.py
+++ b/bin/action_status.py
@@ -19,8 +19,8 @@ STATUS_FILE = 'status'
 
 
 def get_field(field, status_file):
-    lines = status_file.readlines()
-    content = yaml.load(lines[-1])
+    docs = yaml.load_all(status_file.read())
+    content = list(docs)[-1]
     return content.get(field)
 
 

--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -129,7 +129,8 @@ Optional Fields
 
 **retries** (beta)
     An integer representing how many times Tron is allowed to automatically
-    retry an action if it fails.
+    retry the command. Tron will immediately re-run the command if it fails,
+    and the action will not enter the failed state until retries are exhausted.
     Defaults to None (0 retries allowed).
 
 **expected_runtime** (default **24h**)

--- a/tests/api/resource_test.py
+++ b/tests/api/resource_test.py
@@ -35,7 +35,7 @@ REQUEST.childLink = lambda val: "/jobs/%s" % val
 
 
 def build_request(**kwargs):
-    args = {k.encode(): [v] for k, v in six.iteritems(kwargs)}
+    args = {k.encode(): [v.encode()] for k, v in six.iteritems(kwargs)}
     return mock.create_autospec(twisted.web.server.Request, args=args)
 
 

--- a/tests/bin/action_status_test.py
+++ b/tests/bin/action_status_test.py
@@ -39,8 +39,11 @@ class ActionStatusTestCase(TestCase):
             'pid': 1234,
             'return_code': 0,
             'run_id': 'MASTER.foo.bar.1234',
+            'command': 'echo ' + 'really_long' * 100,
         }
-        self.status_file.write(yaml.safe_dump(additional_status_content))
+        self.status_file.write(
+            yaml.safe_dump(additional_status_content, explicit_start=True),
+        )
         self.status_file.flush()
         self.status_file.seek(0)
         assert action_status.get_field('return_code', self.status_file) == 0

--- a/tron/api/requestargs.py
+++ b/tron/api/requestargs.py
@@ -31,7 +31,7 @@ def get_string(request, key):
         return None
 
     val = request.args[key][0]
-    if val and type(val) is bytes:
+    if val is not None and type(val) is bytes:
         val = val.decode()
 
     return val

--- a/tron/yaml.py
+++ b/tron/yaml.py
@@ -12,3 +12,8 @@ def dump(*args, **kwargs):
 def load(*args, **kwargs):
     kwargs['Loader'] = yaml.CSafeLoader
     return yaml.load(*args, **kwargs)
+
+
+def load_all(*args, **kwargs):
+    kwargs['Loader'] = yaml.CSafeLoader
+    return yaml.load_all(*args, **kwargs)


### PR DESCRIPTION
Commits:
* Fix namespace deletion bytes bug, by decoding the empty string that delete requests use. Manually tested this fix on playground, too.
* Slightly more docs on retries
* Explicitly separate YAML documents in action runner scripts. yaml.load_all can handle line breaks as long as the documents are separated by the document separator (---).