### PR TITLE
Fixed the example Docker container name in README.md

### DIFF
--- a/example-cluster/README.md
+++ b/example-cluster/README.md
@@ -22,9 +22,6 @@ you will attach to that running container. There you will be able to run `tronct
 `tronview` and others against the Trond master in the example cluster.
 
 ```
-$ docker ps
-
-[find container ID of examplecluster_master]
-
-$ sudo docker exec -it <ID> /bin/bash
+$ EXAMPLE_CONTAINER_ID=$(docker ps -q -f status=running -f name=example-cluster_playground)
+$ sudo docker exec -it $EXAMPLE_CONTAINER_ID /bin/bash
 ```


### PR DESCRIPTION
```shell
$ docker ps | grep example-cluster_playground
f92fbde86f7a        example-cluster_playground                                                                                              "/bin/bash"              19 minutes ago      Up 19 minutes       0.0.0.0:8089->8089/tcp                             example-cluster_playground_run_1
```

Probably it's even better to provide a command which extracts the container id, i.e.:
```shell
$ EXAMPLE_CONTAINER_ID=$(docker ps -q -f status=running -f name=example-cluster_playground)
$ sudo docker exec -it $EXAMPLE_CONTAINER_ID /bin/bash
```