### PR TITLE
Revert "Fix reloading config ignores changes in `enabled`"

### DIFF
--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -75,7 +75,6 @@ class Job(Observable, Observer):
         'service',
         'deploy_group',
         'expected_runtime',
-        'enabled',
     ]
 
     # TODO: use config object


### PR DESCRIPTION
Reverts Yelp/Tron#446 as it basically reverts Yelp/Tron#154