### PR TITLE
run tasks on Mesos

### DIFF
--- a/dev/logging.conf
+++ b/dev/logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=root, twisted, tron, tron.serialize.runstate.statemanager, tron.api.www.access
+keys=root, twisted, tron, tron.serialize.runstate.statemanager, tron.api.www.access, task_processing
 
 [handlers]
 keys=stdoutHandler, accessHandler
@@ -33,6 +33,12 @@ propagate=0
 level=DEBUG
 handlers=stdoutHandler
 qualname=tron.serialize.runstate.statemanager
+propagate=0
+
+[logger_task_processing]
+level=INFO
+handlers=stdoutHandler
+qualname=task_processing
 propagate=0
 
 [handler_stdoutHandler]

--- a/example-cluster/logging.conf
+++ b/example-cluster/logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=root, twisted, tron, tron.serialize.runstate.statemanager, tron.api.www.access
+keys=root, twisted, tron, tron.serialize.runstate.statemanager, tron.api.www.access, task_processing
 
 [handlers]
 keys=stdoutHandler
@@ -34,6 +34,12 @@ propagate=0
 level=DEBUG
 handlers=stdoutHandler
 qualname=tron.serialize.runstate.statemanager
+propagate=0
+
+[logger_task_processing]
+level=INFO
+handlers=stdoutHandler
+qualname=task_processing
 propagate=0
 
 [handler_stdoutHandler]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ pytz>=2011n
 PyYAML>=3.0
 Sphinx-PyPI-upload>=0.2.1
 Sphinx>=1.1.2
+task_processing[mesos_executor]>=0.0.8
 testify>=0.1.12
 Twisted>=17.0.0

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'bsddb3',
         'ipython',
         'ipdb',
+        'task_processing[mesos_executor]>=0.0.8',
     ],
     packages=find_packages(exclude=['tests.*', 'tests']) + ['tronweb'],
     scripts=glob.glob('bin/*'),

--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -53,10 +53,6 @@ nodes:
 node_pools:
     - name: NodePool
       nodes: [node0, node1]
-
-clusters:
-    - cluster-one
-    - cluster-two
 """
 
 
@@ -83,10 +79,6 @@ nodes:
 node_pools:
     -   name: nodePool
         nodes: [node0, node1]
-
-clusters:
-    - cluster-one
-    - cluster-two
     """
 
     config = BASE_CONFIG + """
@@ -164,14 +156,16 @@ jobs:
     -
         name: "test_job_mesos"
         node: nodePool
-        service: my_service
-        deploy_group: prod.non_canary
         schedule: "daily"
         actions:
             -
-                name: "action4_0"
+                name: "action_mesos"
                 executor: mesos
-                command: "test_command4.0"
+                command: "test_command_mesos"
+                cpus: .1
+                mem: 100
+                mesos_address: the-master.mesos
+                docker_image: container:latest
 
 """
 
@@ -227,7 +221,6 @@ jobs:
                         ),
                 }
             ),
-            clusters=('cluster-one', 'cluster-two'),
             jobs=FrozenDict(
                 {
                     'MASTER.test_job0':
@@ -236,8 +229,6 @@ jobs:
                             namespace='MASTER',
                             node='node0',
                             monitoring={},
-                            service=None,
-                            deploy_group=None,
                             schedule=ConfigIntervalScheduler(
                                 timedelta=datetime.timedelta(0, 20),
                                 jitter=None,
@@ -277,8 +268,6 @@ jobs:
                             node='node0',
                             enabled=True,
                             monitoring={},
-                            service=None,
-                            deploy_group=None,
                             schedule=schedule_parse.ConfigDailyScheduler(
                                 days={1, 3, 5},
                                 hour=0,
@@ -325,8 +314,6 @@ jobs:
                             node='node1',
                             enabled=True,
                             monitoring={},
-                            service=None,
-                            deploy_group=None,
                             schedule=schedule_parse.ConfigDailyScheduler(
                                 days=set(),
                                 hour=16,
@@ -365,8 +352,6 @@ jobs:
                             schedule=ConfigConstantScheduler(),
                             enabled=True,
                             monitoring={},
-                            service=None,
-                            deploy_group=None,
                             actions=FrozenDict(
                                 {
                                     'action3_1':
@@ -416,8 +401,6 @@ jobs:
                             namespace='MASTER',
                             node='nodePool',
                             monitoring={},
-                            service=None,
-                            deploy_group=None,
                             schedule=schedule_parse.ConfigDailyScheduler(
                                 days=set(),
                                 hour=0,
@@ -455,8 +438,6 @@ jobs:
                             namespace='MASTER',
                             node='nodePool',
                             monitoring={},
-                            service='my_service',
-                            deploy_group='prod.non_canary',
                             schedule=schedule_parse.ConfigDailyScheduler(
                                 days=set(),
                                 hour=0,
@@ -467,14 +448,18 @@ jobs:
                             ),
                             actions=FrozenDict(
                                 {
-                                    'action4_0':
+                                    'action_mesos':
                                         schema.ConfigAction(
-                                            name='action4_0',
-                                            command='test_command4.0',
+                                            name='action_mesos',
+                                            command='test_command_mesos',
                                             executor='mesos',
                                             requires=(),
                                             expected_runtime=datetime.
                                             timedelta(1),
+                                            cpus=0.1,
+                                            mem=100,
+                                            mesos_address='the-master.mesos',
+                                            docker_image='container:latest',
                                         ),
                                 }
                             ),
@@ -602,14 +587,16 @@ jobs:
     -
         name: "test_job_mesos"
         node: NodePool
-        service: my_service
-        deploy_group: prod.non_canary
         schedule: "daily"
         actions:
             -
-                name: "action4_0"
+                name: "action_mesos"
                 executor: mesos
-                command: "test_command4.0"
+                command: "test_command_mesos"
+                cpus: .1
+                mem: 100
+                mesos_address: the-master.mesos
+                docker_image: container:latest
 
 """
 
@@ -623,8 +610,6 @@ jobs:
                             namespace='test_namespace',
                             node='node0',
                             monitoring={},
-                            service=None,
-                            deploy_group=None,
                             schedule=ConfigIntervalScheduler(
                                 timedelta=datetime.timedelta(0, 20),
                                 jitter=None,
@@ -650,12 +635,6 @@ jobs:
                                 command='test_command0.1',
                                 node=None,
                                 executor='ssh',
-                                cluster=None,
-                                pool=None,
-                                cpus=None,
-                                mem=None,
-                                service=None,
-                                deploy_group=None,
                                 expected_runtime=datetime.timedelta(1),
                             ),
                             enabled=True,
@@ -671,8 +650,6 @@ jobs:
                             node='node0',
                             enabled=True,
                             monitoring={},
-                            service=None,
-                            deploy_group=None,
                             schedule=schedule_parse.ConfigDailyScheduler(
                                 days={1, 3, 5},
                                 hour=0,
@@ -720,8 +697,6 @@ jobs:
                             node='node1',
                             enabled=True,
                             monitoring={},
-                            service=None,
-                            deploy_group=None,
                             schedule=schedule_parse.ConfigDailyScheduler(
                                 days=set(),
                                 hour=16,
@@ -760,8 +735,6 @@ jobs:
                             schedule=ConfigConstantScheduler(),
                             enabled=True,
                             monitoring={},
-                            service=None,
-                            deploy_group=None,
                             actions=FrozenDict(
                                 {
                                     'action3_1':
@@ -811,8 +784,6 @@ jobs:
                             namespace='test_namespace',
                             node='NodePool',
                             monitoring={},
-                            service=None,
-                            deploy_group=None,
                             schedule=schedule_parse.ConfigDailyScheduler(
                                 days=set(),
                                 hour=0,
@@ -850,8 +821,6 @@ jobs:
                             namespace='test_namespace',
                             node='NodePool',
                             monitoring={},
-                            service='my_service',
-                            deploy_group='prod.non_canary',
                             schedule=schedule_parse.ConfigDailyScheduler(
                                 days=set(),
                                 hour=0,
@@ -862,14 +831,18 @@ jobs:
                             ),
                             actions=FrozenDict(
                                 {
-                                    'action4_0':
+                                    'action_mesos':
                                         schema.ConfigAction(
-                                            name='action4_0',
-                                            command='test_command4.0',
+                                            name='action_mesos',
+                                            command='test_command_mesos',
                                             executor='mesos',
                                             requires=(),
                                             expected_runtime=datetime.
                                             timedelta(1),
+                                            cpus=0.1,
+                                            mem=100,
+                                            mesos_address='the-master.mesos',
+                                            docker_image='container:latest',
                                         ),
                                 }
                             ),
@@ -1092,131 +1065,6 @@ jobs:
         )
         assert_equal(expected_msg, str(exception))
 
-    def test_job_with_invalid_cluster(self):
-        test_config = BASE_CONFIG + """
-jobs:
-    -
-        name: "test_job0"
-        node: node0
-        schedule: "interval 20s"
-        service: foo
-        deploy_group: prod
-        actions:
-            -
-                name: "action0_0"
-                executor: mesos
-                cluster: unknown-cluster
-                command: "test_command0.0"
-"""
-        expected_msg = "Unknown cluster name unknown-cluster"
-        exception = assert_raises(
-            ConfigError,
-            valid_config_from_yaml,
-            test_config,
-        )
-        assert_in(expected_msg, str(exception))
-
-    def test_job_with_missing_service_for_mesos_action(self):
-        test_config = BASE_CONFIG + """
-jobs:
-    -
-        name: "test_job0"
-        node: node0
-        schedule: "interval 20s"
-        actions:
-            -
-                name: "action0_0"
-                executor: mesos
-                cluster: cluster-one
-                command: "test_command0.0"
-"""
-        expected_msg = "need a service and deploy_group"
-        exception = assert_raises(
-            ConfigError,
-            valid_config_from_yaml,
-            test_config,
-        )
-        assert_in(expected_msg, str(exception))
-
-    def test_job_with_missing_service_for_mesos_cleanup_action(self):
-        test_config = BASE_CONFIG + """
-jobs:
-    -
-        name: "test_job0"
-        node: node0
-        schedule: "interval 20s"
-        actions:
-            -
-                name: "action0_0"
-                command: "test_command0.0"
-                executor: ssh
-        cleanup_action:
-            command: "test_command0.1"
-            executor: mesos
-"""
-        expected_msg = "need a service and deploy_group"
-        exception = assert_raises(
-            ConfigError,
-            valid_config_from_yaml,
-            test_config,
-        )
-        assert_in(expected_msg, str(exception))
-
-    def test_job_with_service_in_mesos_action_only_is_valid(self):
-        test_config = BASE_CONFIG + """
-jobs:
-    -
-        name: "test_job0"
-        node: node0
-        schedule: "interval 20s"
-        actions:
-            -
-                name: "action0_0"
-                executor: mesos
-                cluster: cluster-one
-                service: baz
-                deploy_group: prod
-                command: "test_command0.0"
-"""
-        expected = schema.ConfigJob(
-            name='MASTER.test_job0',
-            namespace='MASTER',
-            node='node0',
-            monitoring={},
-            service=None,
-            deploy_group=None,
-            schedule=ConfigIntervalScheduler(
-                timedelta=datetime.timedelta(0, 20),
-                jitter=None,
-            ),
-            actions=FrozenDict(
-                {
-                    'action0_0':
-                        schema.ConfigAction(
-                            name='action0_0',
-                            command='test_command0.0',
-                            executor='mesos',
-                            cluster='cluster-one',
-                            service='baz',
-                            deploy_group='prod',
-                            requires=(),
-                            expected_runtime=datetime.timedelta(1),
-                        ),
-                }
-            ),
-            queueing=True,
-            run_limit=50,
-            all_nodes=False,
-            cleanup_action=None,
-            enabled=True,
-            max_runtime=None,
-            allow_overlap=False,
-            time_zone=None,
-            expected_runtime=datetime.timedelta(1),
-        )
-        parsed_config = valid_config_from_yaml(test_config)
-        assert_equal(parsed_config.jobs['MASTER.test_job0'], expected)
-
     def test_validate_job_no_actions(self):
         job_config = dict(
             name="job_name",
@@ -1227,7 +1075,6 @@ jobs:
         config_context = config_utils.ConfigContext(
             'config',
             ['localhost'],
-            ['cluster'],
             None,
             None,
         )
@@ -1372,6 +1219,28 @@ class ValidateJobsTestCase(TestCase):
                             name: "action0_0"
                             command: "test_command0.0"
                             expected_runtime: "20m"
+                        -   name: "action_mesos"
+                            command: "test_command_mesos"
+                            executor: mesos
+                            cpus: 4
+                            mem: 300
+                            constraints:
+                                - attribute: pool
+                                  operator: LIKE
+                                  value: default
+                            docker_image: my_container:latest
+                            docker_parameters:
+                                - key: label
+                                  value: labelA
+                                - key: label
+                                  value: labelB
+                            env:
+                                USER: batch
+                            extra_volumes:
+                                - container_path: /tmp
+                                  host_path: /home/tmp
+                                  mode: RO
+                            mesos_address: http://my-mesos-master.com
                     cleanup_action:
                         command: "test_command0.1"
                     """
@@ -1383,8 +1252,6 @@ class ValidateJobsTestCase(TestCase):
                     namespace='MASTER',
                     node='node0',
                     monitoring={},
-                    service=None,
-                    deploy_group=None,
                     schedule=ConfigIntervalScheduler(
                         timedelta=datetime.timedelta(0, 20),
                         jitter=None,
@@ -1401,6 +1268,45 @@ class ValidateJobsTestCase(TestCase):
                                         0, 1200
                                     ),
                                 ),
+                            'action_mesos':
+                                schema.ConfigAction(
+                                    name='action_mesos',
+                                    command='test_command_mesos',
+                                    executor='mesos',
+                                    requires=(),
+                                    cpus=4.0,
+                                    mem=300.0,
+                                    constraints=(
+                                        schema.ConfigConstraint(
+                                            attribute='pool',
+                                            operator='LIKE',
+                                            value='default',
+                                        ),
+                                    ),
+                                    docker_image='my_container:latest',
+                                    docker_parameters=(
+                                        schema.ConfigParameter(
+                                            key='label',
+                                            value='labelA',
+                                        ),
+                                        schema.ConfigParameter(
+                                            key='label',
+                                            value='labelB',
+                                        ),
+                                    ),
+                                    env={'USER': 'batch'},
+                                    extra_volumes=(
+                                        schema.ConfigVolume(
+                                            container_path='/tmp',
+                                            host_path='/home/tmp',
+                                            mode='RO',
+                                        ),
+                                    ),
+                                    mesos_address='http://my-mesos-master.com',
+                                    expected_runtime=datetime.timedelta(
+                                        hours=24
+                                    ),
+                                ),
                         }
                     ),
                     queueing=True,
@@ -1411,12 +1317,6 @@ class ValidateJobsTestCase(TestCase):
                         name='cleanup',
                         node=None,
                         executor='ssh',
-                        cluster=None,
-                        pool=None,
-                        cpus=None,
-                        mem=None,
-                        service=None,
-                        deploy_group=None,
                         expected_runtime=datetime.timedelta(1),
                     ),
                     enabled=True,
@@ -1431,12 +1331,44 @@ class ValidateJobsTestCase(TestCase):
         context = config_utils.ConfigContext(
             'config',
             ['node0'],
-            ['unused-cluster'],
             None,
             MASTER_NAMESPACE,
         )
         config_parse.validate_jobs(config, context)
         assert_equal(expected_jobs, config['jobs'])
+
+
+class ValidMesosActionTestCase(TestCase):
+    def test_missing_docker_image(self):
+        config = dict(
+            name='test_missing',
+            command='echo hello',
+            executor=schema.ExecutorTypes.mesos,
+            cpus=0.2,
+            mem=150,
+            mesos_address='http://hello.org',
+        )
+        assert_raises(
+            ConfigError,
+            config_parse.valid_action,
+            config,
+            NullConfigContext,
+        )
+
+    def test_cleanup_missing_docker_image(self):
+        config = dict(
+            command='echo hello',
+            executor=schema.ExecutorTypes.mesos,
+            cpus=0.2,
+            mem=150,
+            mesos_address='http://hello.org',
+        )
+        assert_raises(
+            ConfigError,
+            config_parse.valid_action,
+            config,
+            NullConfigContext,
+        )
 
 
 class ValidCleanupActionNameTestCase(TestCase):
@@ -1514,7 +1446,6 @@ class BuildFormatStringValidatorTestCase(TestCase):
     def test_validator_passes_with_context(self):
         template = "The %(one)s thing I %(seven)s is %(mars)s"
         context = config_utils.ConfigContext(
-            None,
             None,
             None,
             {'mars': 'ok'},

--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -162,7 +162,7 @@ jobs:
                 name: "action4_0"
                 command: "test_command4.0"
     -
-        name: "test_job_paasta"
+        name: "test_job_mesos"
         node: nodePool
         service: my_service
         deploy_group: prod.non_canary
@@ -170,7 +170,7 @@ jobs:
         actions:
             -
                 name: "action4_0"
-                executor: paasta
+                executor: mesos
                 command: "test_command4.0"
 
 """
@@ -449,9 +449,9 @@ jobs:
                             time_zone=None,
                             expected_runtime=datetime.timedelta(1),
                         ),
-                    'MASTER.test_job_paasta':
+                    'MASTER.test_job_mesos':
                         schema.ConfigJob(
-                            name='MASTER.test_job_paasta',
+                            name='MASTER.test_job_mesos',
                             namespace='MASTER',
                             node='nodePool',
                             monitoring={},
@@ -471,7 +471,7 @@ jobs:
                                         schema.ConfigAction(
                                             name='action4_0',
                                             command='test_command4.0',
-                                            executor='paasta',
+                                            executor='mesos',
                                             requires=(),
                                             expected_runtime=datetime.
                                             timedelta(1),
@@ -523,8 +523,8 @@ jobs:
             expected.jobs['MASTER.test_job4'],
         )
         assert_equal(
-            test_config.jobs['MASTER.test_job_paasta'],
-            expected.jobs['MASTER.test_job_paasta'],
+            test_config.jobs['MASTER.test_job_mesos'],
+            expected.jobs['MASTER.test_job_mesos'],
         )
         assert_equal(test_config.jobs, expected.jobs)
         assert_equal(test_config, expected)
@@ -600,7 +600,7 @@ jobs:
                 name: "action4_0"
                 command: "test_command4.0"
     -
-        name: "test_job_paasta"
+        name: "test_job_mesos"
         node: NodePool
         service: my_service
         deploy_group: prod.non_canary
@@ -608,7 +608,7 @@ jobs:
         actions:
             -
                 name: "action4_0"
-                executor: paasta
+                executor: mesos
                 command: "test_command4.0"
 
 """
@@ -844,9 +844,9 @@ jobs:
                             time_zone=None,
                             expected_runtime=datetime.timedelta(1),
                         ),
-                    'test_job_paasta':
+                    'test_job_mesos':
                         schema.ConfigJob(
-                            name='test_job_paasta',
+                            name='test_job_mesos',
                             namespace='test_namespace',
                             node='NodePool',
                             monitoring={},
@@ -866,7 +866,7 @@ jobs:
                                         schema.ConfigAction(
                                             name='action4_0',
                                             command='test_command4.0',
-                                            executor='paasta',
+                                            executor='mesos',
                                             requires=(),
                                             expected_runtime=datetime.
                                             timedelta(1),
@@ -897,8 +897,8 @@ jobs:
         assert_equal(test_config.jobs['test_job3'], expected.jobs['test_job3'])
         assert_equal(test_config.jobs['test_job4'], expected.jobs['test_job4'])
         assert_equal(
-            test_config.jobs['test_job_paasta'],
-            expected.jobs['test_job_paasta'],
+            test_config.jobs['test_job_mesos'],
+            expected.jobs['test_job_mesos'],
         )
         assert_equal(test_config.jobs, expected.jobs)
         assert_equal(test_config, expected)
@@ -1104,7 +1104,7 @@ jobs:
         actions:
             -
                 name: "action0_0"
-                executor: paasta
+                executor: mesos
                 cluster: unknown-cluster
                 command: "test_command0.0"
 """
@@ -1116,7 +1116,7 @@ jobs:
         )
         assert_in(expected_msg, str(exception))
 
-    def test_job_with_missing_service_for_paasta_action(self):
+    def test_job_with_missing_service_for_mesos_action(self):
         test_config = BASE_CONFIG + """
 jobs:
     -
@@ -1126,7 +1126,7 @@ jobs:
         actions:
             -
                 name: "action0_0"
-                executor: paasta
+                executor: mesos
                 cluster: cluster-one
                 command: "test_command0.0"
 """
@@ -1138,7 +1138,7 @@ jobs:
         )
         assert_in(expected_msg, str(exception))
 
-    def test_job_with_missing_service_for_paasta_cleanup_action(self):
+    def test_job_with_missing_service_for_mesos_cleanup_action(self):
         test_config = BASE_CONFIG + """
 jobs:
     -
@@ -1152,7 +1152,7 @@ jobs:
                 executor: ssh
         cleanup_action:
             command: "test_command0.1"
-            executor: paasta
+            executor: mesos
 """
         expected_msg = "need a service and deploy_group"
         exception = assert_raises(
@@ -1162,7 +1162,7 @@ jobs:
         )
         assert_in(expected_msg, str(exception))
 
-    def test_job_with_service_in_paasta_action_only_is_valid(self):
+    def test_job_with_service_in_mesos_action_only_is_valid(self):
         test_config = BASE_CONFIG + """
 jobs:
     -
@@ -1172,7 +1172,7 @@ jobs:
         actions:
             -
                 name: "action0_0"
-                executor: paasta
+                executor: mesos
                 cluster: cluster-one
                 service: baz
                 deploy_group: prod
@@ -1195,7 +1195,7 @@ jobs:
                         schema.ConfigAction(
                             name='action0_0',
                             command='test_command0.0',
-                            executor='paasta',
+                            executor='mesos',
                             cluster='cluster-one',
                             service='baz',
                             deploy_group='prod',
@@ -1594,7 +1594,7 @@ class ConfigContainerTestCase(TestCase):
             'test_job3',
             'test_job2',
             'test_job4',
-            'test_job_paasta',
+            'test_job_mesos',
         ]
         assert_equal(set(job_names), set(expected))
 
@@ -1605,7 +1605,7 @@ class ConfigContainerTestCase(TestCase):
             'test_job3',
             'test_job2',
             'test_job4',
-            'test_job_paasta',
+            'test_job_mesos',
         ]
         assert_equal(set(expected), set(self.container.get_jobs().keys()))
 

--- a/tests/config/config_utils_test.py
+++ b/tests/config/config_utils_test.py
@@ -165,12 +165,10 @@ class ValidTimeDeltaTestCase(TestCase):
 class ConfigContextTestCase(TestCase):
     def test_build_config_context(self):
         path, nodes, namespace = 'path', {1, 2, 3}, 'namespace'
-        clusters = {'c1', 'c2'}
         command_context = mock.MagicMock()
         parent_context = config_utils.ConfigContext(
             path,
             nodes,
-            clusters,
             command_context,
             namespace,
         )
@@ -178,7 +176,6 @@ class ConfigContextTestCase(TestCase):
         child = parent_context.build_child_context('child')
         assert_equal(child.path, '%s.child' % path)
         assert_equal(child.nodes, nodes)
-        assert_equal(child.clusters, clusters)
         assert_equal(child.namespace, namespace)
         assert_equal(child.command_context, command_context)
         assert not child.partial

--- a/tests/core/action_test.py
+++ b/tests/core/action_test.py
@@ -8,6 +8,10 @@ from testify import setup
 from testify import TestCase
 
 from tron import node
+from tron.config.schema import ConfigAction
+from tron.config.schema import ConfigConstraint
+from tron.config.schema import ConfigParameter
+from tron.config.schema import ConfigVolume
 from tron.core import action
 
 
@@ -17,24 +21,36 @@ class TestAction(TestCase):
         self.node_pool = mock.create_autospec(node.NodePool)
         self.action = action.Action("my_action", "doit", self.node_pool)
 
-    def test_from_config(self):
-        config = mock.Mock(
+    def test_from_config_full(self):
+        config = ConfigAction(
             name="ted",
             command="do something",
             node="first",
             executor="ssh",
             cpus=1,
             mem=100,
-            constraints=[['pool', 'LIKE', 'default']],
+            constraints=[
+                ConfigConstraint(
+                    attribute='pool',
+                    operator='LIKE',
+                    value='default',
+                ),
+            ],
             docker_image='fake-docker.com:400/image',
-            docker_parameters=[{
-                'key': 'test',
-                'value': 123
-            }],
+            docker_parameters=[
+                ConfigParameter(
+                    key='test',
+                    value=123,
+                ),
+            ],
             env={'TESTING': 'true'},
-            extra_volumes=[{
-                'path': '/tmp'
-            }],
+            extra_volumes=[
+                ConfigVolume(
+                    host_path='/tmp',
+                    container_path='/nail/tmp',
+                    mode='RO',
+                ),
+            ],
             mesos_address='fake-mesos-master.com',
         )
         new_action = action.Action.from_config(config)
@@ -45,12 +61,45 @@ class TestAction(TestCase):
         assert_equal(new_action.executor, config.executor)
         assert_equal(new_action.cpus, config.cpus)
         assert_equal(new_action.mem, config.mem)
-        assert_equal(new_action.constraints, config.constraints)
+        assert_equal(new_action.constraints, [['pool', 'LIKE', 'default']])
         assert_equal(new_action.docker_image, config.docker_image)
-        assert_equal(new_action.docker_parameters, config.docker_parameters)
+        assert_equal(
+            new_action.docker_parameters,
+            [{
+                'key': 'test',
+                'value': 123
+            }],
+        )
         assert_equal(new_action.env, config.env)
-        assert_equal(new_action.extra_volumes, config.extra_volumes)
+        assert_equal(
+            new_action.extra_volumes,
+            [
+                {
+                    'container_path': '/nail/tmp',
+                    'host_path': '/tmp',
+                    'mode': 'RO'
+                }
+            ],
+        )
         assert_equal(new_action.mesos_address, config.mesos_address)
+
+    def test_from_config_none_values(self):
+        config = ConfigAction(
+            name="ted",
+            command="do something",
+            node="first",
+            executor="ssh",
+        )
+        new_action = action.Action.from_config(config)
+        assert_equal(new_action.name, config.name)
+        assert_equal(new_action.command, config.command)
+        assert_equal(new_action.required_actions, [])
+        assert_equal(new_action.executor, config.executor)
+        assert_equal(new_action.constraints, [])
+        assert_equal(new_action.docker_image, None)
+        assert_equal(new_action.docker_parameters, [])
+        assert_equal(new_action.env, {})
+        assert_equal(new_action.extra_volumes, [])
 
     def test__eq__(self):
         new_action = action.Action(

--- a/tests/core/action_test.py
+++ b/tests/core/action_test.py
@@ -23,25 +23,34 @@ class TestAction(TestCase):
             command="do something",
             node="first",
             executor="ssh",
-            cluster="prod",
-            pool="default",
             cpus=1,
             mem=100,
-            service="bar",
-            deploy_group="test",
+            constraints=[['pool', 'LIKE', 'default']],
+            docker_image='fake-docker.com:400/image',
+            docker_parameters=[{
+                'key': 'test',
+                'value': 123
+            }],
+            env={'TESTING': 'true'},
+            extra_volumes=[{
+                'path': '/tmp'
+            }],
+            mesos_address='fake-mesos-master.com',
         )
         new_action = action.Action.from_config(config)
         assert_equal(new_action.name, config.name)
         assert_equal(new_action.command, config.command)
-        assert_equal(new_action.executor, config.executor)
-        assert_equal(new_action.cluster, config.cluster)
-        assert_equal(new_action.pool, config.pool)
-        assert_equal(new_action.cpus, config.cpus)
-        assert_equal(new_action.mem, config.mem)
-        assert_equal(new_action.service, config.service)
-        assert_equal(new_action.deploy_group, config.deploy_group)
         assert_equal(new_action.node_pool, None)
         assert_equal(new_action.required_actions, [])
+        assert_equal(new_action.executor, config.executor)
+        assert_equal(new_action.cpus, config.cpus)
+        assert_equal(new_action.mem, config.mem)
+        assert_equal(new_action.constraints, config.constraints)
+        assert_equal(new_action.docker_image, config.docker_image)
+        assert_equal(new_action.docker_parameters, config.docker_parameters)
+        assert_equal(new_action.env, config.env)
+        assert_equal(new_action.extra_volumes, config.extra_volumes)
+        assert_equal(new_action.mesos_address, config.mesos_address)
 
     def test__eq__(self):
         new_action = action.Action(

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -29,7 +29,7 @@ from tron.core.actionrun import ActionCommand
 from tron.core.actionrun import ActionRun
 from tron.core.actionrun import ActionRunCollection
 from tron.core.actionrun import ActionRunFactory
-from tron.core.actionrun import PaaSTAActionRun
+from tron.core.actionrun import MesosActionRun
 from tron.core.actionrun import SSHActionRun
 from tron.serialize import filehandler
 
@@ -155,11 +155,11 @@ class ActionRunFactoryTestCase(TestCase):
         )
         assert_equal(action_run.__class__, SSHActionRun)
 
-    def test_build_run_for_paasta_action_default_service(self):
+    def test_build_run_for_mesos_action_default_service(self):
         action = Turtle(
             name='theaction',
             command="doit",
-            executor=ExecutorTypes.paasta,
+            executor=ExecutorTypes.mesos,
             cluster='prod',
             pool='default',
             cpus=10,
@@ -172,7 +172,7 @@ class ActionRunFactoryTestCase(TestCase):
             action,
             self.action_runner,
         )
-        assert_equal(action_run.__class__, PaaSTAActionRun)
+        assert_equal(action_run.__class__, MesosActionRun)
         assert_equal(action_run.cluster, action.cluster)
         assert_equal(action_run.pool, action.pool)
         assert_equal(action_run.cpus, action.cpus)
@@ -180,11 +180,11 @@ class ActionRunFactoryTestCase(TestCase):
         assert_equal(action_run.service, self.job_run.service)
         assert_equal(action_run.deploy_group, self.job_run.deploy_group)
 
-    def test_build_run_for_paasta_action_overrides_service(self):
+    def test_build_run_for_mesos_action_overrides_service(self):
         action = Turtle(
             name='theaction',
             command="doit",
-            executor=ExecutorTypes.paasta,
+            executor=ExecutorTypes.mesos,
             service='bar',
             deploy_group='dev',
         )
@@ -193,7 +193,7 @@ class ActionRunFactoryTestCase(TestCase):
             action,
             self.action_runner,
         )
-        assert_equal(action_run.__class__, PaaSTAActionRun)
+        assert_equal(action_run.__class__, MesosActionRun)
         assert_equal(action_run.service, action.service)
         assert_equal(action_run.deploy_group, action.deploy_group)
 
@@ -208,9 +208,9 @@ class ActionRunFactoryTestCase(TestCase):
         assert not action_run.is_cleanup
         assert_equal(action_run.__class__, SSHActionRun)
 
-    def test_action_run_from_state_paasta(self):
+    def test_action_run_from_state_mesos(self):
         state_data = self.action_state_data
-        state_data['executor'] = ExecutorTypes.paasta
+        state_data['executor'] = ExecutorTypes.mesos
         state_data['cluster'] = 'cluster-one'
         state_data['pool'] = 'private'
         state_data['cpus'] = 2
@@ -230,7 +230,7 @@ class ActionRunFactoryTestCase(TestCase):
         assert_equal(action_run.service, state_data['service'])
         assert_equal(action_run.deploy_group, state_data['deploy_group'])
         assert not action_run.is_cleanup
-        assert_equal(action_run.__class__, PaaSTAActionRun)
+        assert_equal(action_run.__class__, MesosActionRun)
 
 
 class ActionRunTestCase(TestCase):

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -61,7 +61,7 @@ class JobTestCase(TestCase):
 
     @mock.patch('tron.core.job.event', autospec=True)
     def test_from_config(self, _mock_event):
-        action = mock.Mock(
+        action = mock.MagicMock(
             name='first',
             command='doit',
             node=None,

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -80,8 +80,6 @@ class JobTestCase(TestCase):
             run_limit=20,
             actions={action.name: action},
             cleanup_action=None,
-            service='foo',
-            deploy_group='test',
         )
         scheduler = 'scheduler_token'
         parent_context = 'parent_context_token'
@@ -101,8 +99,6 @@ class JobTestCase(TestCase):
         )
         assert_equal(new_job.enabled, True)
         assert_equal(new_job.get_monitoring()["team"], "foo")
-        assert_equal(new_job.get_service(), 'foo')
-        assert_equal(new_job.get_deploy_group(), 'test')
         assert new_job.action_graph
 
     def test_update_from_job(self):

--- a/tests/core/jobrun_test.py
+++ b/tests/core/jobrun_test.py
@@ -34,8 +34,6 @@ def build_mock_job():
         output_path=mock.Mock(),
         context=mock.Mock(),
         action_runner=runner,
-        service='foo',
-        deploy_group='test',
     )
 
 
@@ -59,8 +57,6 @@ class JobRunTestCase(TestCase):
                 action_runs_with_cleanup=[],
                 get_startable_action_runs=lambda: [],
             ),
-            service='baz',
-            deploy_group='other',
         )
         autospec_method(self.job_run.watch)
         autospec_method(self.job_run.notify)
@@ -91,8 +87,6 @@ class JobRunTestCase(TestCase):
         assert_equal(run.run_num, run_num)
         assert_equal(run.node, mock_node)
         assert not run.manual
-        assert_equal(run.service, self.job.service)
-        assert_equal(run.deploy_group, self.job.deploy_group)
 
     def test_for_job_manual(self):
         run_num = 6
@@ -112,8 +106,6 @@ class JobRunTestCase(TestCase):
         assert_equal(state_data['run_num'], 7)
         assert not state_data['manual']
         assert_equal(state_data['run_time'], self.run_time)
-        assert_equal(state_data['service'], 'baz')
-        assert_equal(state_data['deploy_group'], 'other')
 
     def test_set_action_runs(self):
         self.job_run._action_runs = None
@@ -377,8 +369,6 @@ class JobRunFromStateTestCase(TestCase):
             'runs': self.action_run_state_data,
             'cleanup_run': None,
             'manual': True,
-            'service': 'foo',
-            'deploy_group': 'test',
         }
         self.context = mock.Mock()
 
@@ -397,8 +387,6 @@ class JobRunFromStateTestCase(TestCase):
         assert_equal(run.output_path, self.output_path)
         assert run.context.next
         assert run.action_graph
-        assert_equal(run.service, self.state_data['service'])
-        assert_equal(run.deploy_group, self.state_data['deploy_group'])
 
     def test_from_state_node_no_longer_exists(self):
         run = jobrun.JobRun.from_state(

--- a/tests/core/recovery_test.py
+++ b/tests/core/recovery_test.py
@@ -10,7 +10,7 @@ from testify import TestCase
 from tron.actioncommand import NoActionRunnerFactory
 from tron.actioncommand import SubprocessActionRunnerFactory
 from tron.core.actionrun import ActionRun
-from tron.core.actionrun import PaaSTAActionRun
+from tron.core.actionrun import MesosActionRun
 from tron.core.actionrun import SSHActionRun
 from tron.core.recovery import build_recovery_command
 from tron.core.recovery import filter_action_runs_needing_recovery
@@ -41,7 +41,7 @@ class TestRecovery(TestCase):
                 node=Mock(),
                 machine=mock_ok_machine,
             ),
-            PaaSTAActionRun(
+            MesosActionRun(
                 job_run_id="test.succeeded",
                 name="test.succeeded",
                 node=Mock(),

--- a/tests/mesos_test.py
+++ b/tests/mesos_test.py
@@ -1,0 +1,307 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import mock
+from testify import assert_equal
+from testify import setup_teardown
+from testify import TestCase
+
+from tron.mesos import DOCKERCFG_LOCATION
+from tron.mesos import MESOS_ROLE
+from tron.mesos import MESOS_SECRET
+from tron.mesos import MesosCluster
+from tron.mesos import MesosTask
+from tron.mesos import OFFER_TIMEOUT
+
+
+def mock_task_event(
+    task_id, platform_type, raw=None, terminal=False, success=False, **kwargs
+):
+    return mock.MagicMock(
+        kind='task',
+        task_id=task_id,
+        platform_type=platform_type,
+        raw=raw or {},
+        terminal=terminal,
+        success=success,
+        **kwargs
+    )
+
+
+class MesosTaskTestCase(TestCase):
+    @setup_teardown
+    def setup(self):
+        self.action_run_id = 'my_service.job.1.action'
+        self.task_id = '123abcuuid'
+        self.task = MesosTask(
+            id=self.action_run_id,
+            task_config=mock.Mock(
+                cmd='echo hello world',
+                task_id=self.task_id,
+            ),
+        )
+        # Suppress logging
+        with mock.patch.object(self.task, 'log'):
+            yield
+
+    def test_handle_staging(self):
+        event = mock_task_event(
+            task_id=self.task_id,
+            platform_type='staging',
+        )
+        self.task.handle_event(event)
+        assert self.task.state == MesosTask.PENDING
+
+    def test_handle_running(self):
+        event = mock_task_event(
+            task_id=self.task_id,
+            platform_type='running',
+        )
+        self.task.handle_event(event)
+        assert self.task.state == MesosTask.RUNNING
+
+    def test_handle_running_for_other_task(self):
+        event = mock_task_event(
+            task_id='other321',
+            platform_type='running',
+        )
+        self.task.handle_event(event)
+        assert self.task.state == MesosTask.PENDING
+
+    def test_handle_finished(self):
+        self.task.started()
+        event = mock_task_event(
+            task_id=self.task_id,
+            platform_type='finished',
+            terminal=True,
+            success=True,
+        )
+        self.task.handle_event(event)
+        assert self.task.is_complete
+
+    def test_handle_failed(self):
+        self.task.started()
+        event = mock_task_event(
+            task_id=self.task_id,
+            platform_type='failed',
+            terminal=True,
+            success=False,
+        )
+        self.task.handle_event(event)
+        assert self.task.is_failed
+        assert self.task.is_done
+
+    def test_handle_killed(self):
+        self.task.started()
+        event = mock_task_event(
+            task_id=self.task_id,
+            platform_type='killed',
+            terminal=True,
+            success=False,
+        )
+        self.task.handle_event(event)
+        assert self.task.is_failed
+        assert self.task.is_done
+
+    def test_handle_lost(self):
+        self.task.started()
+        event = mock_task_event(
+            task_id=self.task_id,
+            platform_type='lost',
+            terminal=True,
+            success=False,
+        )
+        self.task.handle_event(event)
+        assert self.task.is_failed
+        assert self.task.is_done
+
+    def test_handle_error(self):
+        self.task.started()
+        event = mock_task_event(
+            task_id=self.task_id,
+            platform_type='error',
+            terminal=True,
+            success=False,
+        )
+        self.task.handle_event(event)
+        assert self.task.is_failed
+        assert self.task.is_done
+
+    def test_handle_unknown_terminal_event(self):
+        self.task.started()
+        event = mock_task_event(
+            task_id=self.task_id,
+            platform_type=None,
+            terminal=True,
+            success=False,
+        )
+        self.task.handle_event(event)
+        assert self.task.is_failed
+        assert self.task.is_done
+
+    def test_handle_success_sequence(self):
+        self.task.handle_event(
+            mock_task_event(
+                task_id=self.task_id,
+                platform_type='staging',
+            )
+        )
+        self.task.handle_event(
+            mock_task_event(
+                task_id=self.task_id,
+                platform_type='running',
+            )
+        )
+        self.task.handle_event(
+            mock_task_event(
+                task_id=self.task_id,
+                platform_type='finished',
+                terminal=True,
+                success=True,
+            )
+        )
+        assert self.task.is_complete
+
+    def test_log_event_error(self):
+        with mock.patch.object(self.task, 'log_event_info') as mock_log_event:
+            mock_log_event.side_effect = Exception
+            self.task.handle_event(
+                mock_task_event(
+                    task_id=self.task_id,
+                    platform_type='running',
+                )
+            )
+            assert mock_log_event.called
+        assert self.task.state == MesosTask.RUNNING
+
+
+class MesosClusterTestCase(TestCase):
+    @setup_teardown
+    def setup_mocks(self):
+        with mock.patch(
+            'tron.mesos.PyDeferredQueue',
+            autospec=True,
+        ) as queue_cls, mock.patch(
+            'tron.mesos.get_mesos_processor',
+            autospec=True,
+        ) as get_processor, mock.patch(
+            'tron.mesos.Subscription',
+            autospec=True,
+        ) as runner_cls, mock.patch(
+            'tron.mesos.get_mesos_leader',
+            autospec=True,
+        ) as mock_get_leader:
+            self.mock_queue = queue_cls.return_value
+            self.mock_processor = get_processor.return_value
+            self.mock_runner_cls = runner_cls
+            self.mock_runner_cls.return_value.stopping = False
+            self.mock_get_leader = mock_get_leader
+            yield
+
+    def test_init(self):
+        cluster = MesosCluster('mesos-cluster-a.me')
+        assert_equal(cluster.queue, self.mock_queue)
+        assert_equal(cluster.processor, self.mock_processor)
+
+        self.mock_get_leader.assert_called_once_with('mesos-cluster-a.me')
+        self.mock_processor.executor_from_config.assert_called_once_with(
+            provider='mesos',
+            provider_config={
+                'secret': MESOS_SECRET,
+                'mesos_address': self.mock_get_leader.return_value,
+                'role': MESOS_ROLE,
+                'framework_name': 'tron',
+            },
+        )
+        self.mock_runner_cls.assert_called_once_with(
+            self.mock_processor.executor_from_config.return_value,
+            self.mock_queue,
+        )
+        assert_equal(cluster.runner, self.mock_runner_cls.return_value)
+
+        get_event_deferred = cluster.deferred
+        assert_equal(get_event_deferred, self.mock_queue.get.return_value)
+        get_event_deferred.addCallback.assert_has_calls(
+            [
+                mock.call(cluster._process_event),
+                mock.call(cluster.handle_next_event),
+            ]
+        )
+
+    def test_submit(self):
+        cluster = MesosCluster('mesos-cluster-a.me')
+        mock_task = mock.MagicMock(spec_set=MesosTask)
+        mock_task.get_mesos_id.return_value = 'this_task'
+        cluster.submit(mock_task)
+
+        assert 'this_task' in cluster.tasks
+        assert_equal(cluster.tasks['this_task'], mock_task)
+        cluster.runner.run.assert_called_once_with(
+            mock_task.get_config.return_value,
+        )
+
+    @mock.patch('tron.mesos.MesosTask', autospec=True)
+    def test_create_task(self, mock_task):
+        cluster = MesosCluster('mesos-cluster-a.me')
+        mock_serializer = mock.MagicMock()
+        task = cluster.create_task(
+            action_run_id='action_c',
+            command='echo hi',
+            cpus=1,
+            mem=10,
+            constraints=[],
+            docker_image='container:latest',
+            docker_parameters=[],
+            env={'TESTING': 'true'},
+            extra_volumes=[],
+            serializer=mock_serializer,
+        )
+        cluster.runner.TASK_CONFIG_INTERFACE.assert_called_once_with(
+            name='action_c',
+            cmd='echo hi',
+            cpus=1,
+            mem=10,
+            constraints=[],
+            image='container:latest',
+            docker_parameters=[],
+            environment={'TESTING': 'true'},
+            volumes=[],
+            uris=[DOCKERCFG_LOCATION],
+            offer_timeout=OFFER_TIMEOUT,
+        )
+        assert_equal(task, mock_task.return_value)
+        mock_task.assert_called_once_with(
+            'action_c',
+            cluster.runner.TASK_CONFIG_INTERFACE.return_value,
+            mock_serializer,
+        )
+
+    def test_process_event_task(self):
+        event = mock_task_event('this_task', 'some_platform_type')
+        cluster = MesosCluster('mesos-cluster-a.me')
+        mock_task = mock.MagicMock(spec_set=MesosTask)
+        mock_task.get_mesos_id.return_value = 'this_task'
+        cluster.tasks['this_task'] = mock_task
+
+        cluster._process_event(event)
+        mock_task.handle_event.assert_called_once_with(event)
+
+    def test_process_event_task_id_invalid(self):
+        event = mock_task_event('other_task', 'some_platform_type')
+        cluster = MesosCluster('mesos-cluster-a.me')
+        mock_task = mock.MagicMock(spec_set=MesosTask)
+        mock_task.get_mesos_id.return_value = 'this_task'
+        cluster.tasks['this_task'] = mock_task
+
+        cluster._process_event(event)
+        assert_equal(mock_task.handle_event.call_count, 0)
+
+    def test_process_event_control_stop(self):
+        event = mock.MagicMock(
+            kind='control',
+            message='stop',
+        )
+        cluster = MesosCluster('mesos-cluster-a.me')
+        cluster._process_event(event)
+        assert_equal(cluster.runner.stop.call_count, 1)
+        assert_equal(cluster.deferred.cancel.call_count, 1)

--- a/tests/mesos_test.py
+++ b/tests/mesos_test.py
@@ -182,9 +182,9 @@ class MesosClusterTestCase(TestCase):
             'tron.mesos.PyDeferredQueue',
             autospec=True,
         ) as queue_cls, mock.patch(
-            'tron.mesos.get_mesos_processor',
+            'tron.mesos.TaskProcessor',
             autospec=True,
-        ) as get_processor, mock.patch(
+        ) as processor_cls, mock.patch(
             'tron.mesos.Subscription',
             autospec=True,
         ) as runner_cls, mock.patch(
@@ -192,7 +192,7 @@ class MesosClusterTestCase(TestCase):
             autospec=True,
         ) as mock_get_leader:
             self.mock_queue = queue_cls.return_value
-            self.mock_processor = get_processor.return_value
+            self.mock_processor = processor_cls.return_value
             self.mock_runner_cls = runner_cls
             self.mock_runner_cls.return_value.stopping = False
             self.mock_get_leader = mock_get_leader

--- a/tests/mesos_test.py
+++ b/tests/mesos_test.py
@@ -198,8 +198,11 @@ class MesosClusterTestCase(TestCase):
             self.mock_get_leader = mock_get_leader
             yield
 
-    def test_init(self):
+    @mock.patch('tron.mesos.socket', autospec=True)
+    def test_init(self, mock_socket):
+        mock_socket.gethostname.return_value = 'hostname'
         cluster = MesosCluster('mesos-cluster-a.me')
+
         assert_equal(cluster.queue, self.mock_queue)
         assert_equal(cluster.processor, self.mock_processor)
 
@@ -210,7 +213,7 @@ class MesosClusterTestCase(TestCase):
                 'secret': MESOS_SECRET,
                 'mesos_address': self.mock_get_leader.return_value,
                 'role': MESOS_ROLE,
-                'framework_name': 'tron',
+                'framework_name': 'tron-hostname',
             },
         )
         self.mock_runner_cls.assert_called_once_with(

--- a/tests/utils/dicts_test.py
+++ b/tests/utils/dicts_test.py
@@ -23,3 +23,38 @@ class InvertDictListTestCase(TestCase):
             3: ['e', 'f'],
         }
         assert_equal(dicts.invert_dict_list(original), expected)
+
+
+class GetDeepTestCase(TestCase):
+
+    data = {'foo': 23, 'bar': {'car': 'hello'}}
+
+    def test_get_deep_one_key(self):
+        assert_equal(
+            dicts.get_deep(self.data, 'foo'),
+            23,
+        )
+
+    def test_get_deep_two_keys(self):
+        assert_equal(
+            dicts.get_deep(self.data, 'bar.car'),
+            'hello',
+        )
+
+    def test_get_deep_missing(self):
+        assert_equal(
+            dicts.get_deep(self.data, 'bar.baz'),
+            None,
+        )
+
+    def test_get_deep_missing_first_key(self):
+        assert_equal(
+            dicts.get_deep(self.data, 'other.car'),
+            None,
+        )
+
+    def test_get_deep_default(self):
+        assert_equal(
+            dicts.get_deep(self.data, 'other', 'custom_default'),
+            'custom_default',
+        )

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -14,6 +14,7 @@ import os
 import pytz
 import six
 from six import string_types
+from task_processing.plugins.mesos.constraints import OPERATORS
 
 from tron import command_context
 from tron.config import config_utils
@@ -151,15 +152,9 @@ def valid_node_name(value, config_context):
 class ValidateConstraint(Validator):
     config_class = ConfigConstraint
     validators = {
-        'attribute':
-            valid_string,
-        'operator':
-            config_utils.build_enum_validator(
-                # TODO: import from taskproc
-                ['EQUALS', 'NOTEQUALS', 'LIKE', 'UNLIKE']
-            ),
-        'value':
-            valid_string,
+        'attribute': valid_string,
+        'operator': config_utils.build_enum_validator(OPERATORS.keys()),
+        'value': valid_string,
     }
 
 

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -434,31 +434,31 @@ class ValidateJob(Validator):
 
     def post_validation(self, job, config_context):
         """Validate actions for the job."""
-        incomplete_paasta_actions = []
+        incomplete_mesos_actions = []
 
-        def is_incomplete_paasta_action(action):
+        def is_incomplete_mesos_action(action):
             return (
-                action.executor == schema.ExecutorTypes.paasta
+                action.executor == schema.ExecutorTypes.mesos
                 and (action.service is None or action.deploy_group is None)
             )
 
         for _, action in six.iteritems(job['actions']):
             self._validate_dependencies(job, job['actions'], action)
-            if is_incomplete_paasta_action(action):
-                incomplete_paasta_actions.append(action)
+            if is_incomplete_mesos_action(action):
+                incomplete_mesos_actions.append(action)
 
         cleanup_action = job.get('cleanup_action')
-        if cleanup_action and is_incomplete_paasta_action(cleanup_action):
-            incomplete_paasta_actions.append(action)
+        if cleanup_action and is_incomplete_mesos_action(cleanup_action):
+            incomplete_mesos_actions.append(action)
 
-        if incomplete_paasta_actions and not (
+        if incomplete_mesos_actions and not (
             job.get('service') and job.get('deploy_group')
         ):
             raise ConfigError(
-                'Either job {name} or PaaSTA actions {actions} need a service '
+                'Either job {name} or Mesos actions {actions} need a service '
                 'and deploy_group.'.format(
                     name=job['name'],
-                    actions=incomplete_paasta_actions,
+                    actions=incomplete_mesos_actions,
                 ),
             )
 

--- a/tron/config/config_utils.py
+++ b/tron/config/config_utils.py
@@ -197,17 +197,16 @@ class ConfigContext(object):
     """
     partial = False
 
-    def __init__(self, path, nodes, clusters, command_context, namespace):
+    def __init__(self, path, nodes, command_context, namespace):
         self.path = path
         self.nodes = set(nodes or [])
-        self.clusters = set(clusters or [])
         self.command_context = command_context or {}
         self.namespace = namespace
 
     def build_child_context(self, path):
         """Construct a new ConfigContext based on this one."""
         path = '%s.%s' % (self.path, path)
-        args = path, self.nodes, self.clusters, self.command_context, self.namespace
+        args = path, self.nodes, self.command_context, self.namespace
         return ConfigContext(*args)
 
 
@@ -231,7 +230,6 @@ class PartialConfigContext(object):
 class NullConfigContext(object):
     path = ''
     nodes = set()
-    clusters = set()
     command_context = {}
     namespace = MASTER_NAMESPACE
     partial = False

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -49,7 +49,6 @@ TronConfig = config_object_factory(
         'nodes',  # FrozenDict of ConfigNode
         'node_pools',  # FrozenDict of ConfigNodePool
         'jobs',  # FrozenDict of ConfigJob
-        'clusters',  # tuple of str
     ],
 )
 
@@ -126,8 +125,6 @@ ConfigJob = config_object_factory(
         'allow_overlap',  # bool
         'max_runtime',  # datetime.Timedelta
         'time_zone',  # pytz time zone
-        'service',  # str
-        'deploy_group',  # str
         'expected_runtime',  # datetime.Timedelta
     ],
 )
@@ -141,14 +138,16 @@ ConfigAction = config_object_factory(
     optional=[
         'requires',  # tuple of str
         'node',  # str
+        'retries',  # int
         'executor',  # str
-        'cluster',  # str
-        'pool',  # str
         'cpus',  # float
         'mem',  # float
-        'service',  # str
-        'deploy_group',  # str
-        'retries',  # int
+        'constraints',  # List of ConfigConstraint
+        'docker_image',  # str
+        'docker_parameters',  # List of ConfigParameter
+        'env',  # dict
+        'extra_volumes',  # List of ConfigVolume
+        'mesos_address',  # str
         'expected_runtime',  # datetime.Timedelta
     ],
 )
@@ -161,16 +160,47 @@ ConfigCleanupAction = config_object_factory(
     optional=[
         'name',  # str
         'node',  # str
-        'executor',  # str
-        'cluster',  # str
-        'pool',  # str
-        'cpus',  # float
-        'mem',  # float
-        'service',  # str
-        'deploy_group',  # str
         'retries',  # int
         'expected_runtime',  # datetime.Timedelta
+        'executor',  # str
+        'cpus',  # float
+        'mem',  # float
+        'constraints',  # List of ConfigConstraint
+        'docker_image',  # str
+        'docker_parameters',  # List of ConfigParameter
+        'env',  # dict
+        'extra_volumes',  # List of ConfigVolume
+        'mesos_address',  # str
     ],
+)
+
+ConfigConstraint = config_object_factory(
+    name='ConfigConstraint',
+    required=[
+        'attribute',
+        'operator',
+        'value',
+    ],
+    optional=[],
+)
+
+ConfigVolume = config_object_factory(
+    name='ConfigVolume',
+    required=[
+        'container_path',
+        'host_path',
+        'mode',
+    ],
+    optional=[],
+)
+
+ConfigParameter = config_object_factory(
+    name='ConfigParameter',
+    required=[
+        'key',
+        'value',
+    ],
+    optional=[],
 )
 
 StatePersistenceTypes = Enum.create('shelve', 'sql', 'yaml')
@@ -178,3 +208,5 @@ StatePersistenceTypes = Enum.create('shelve', 'sql', 'yaml')
 ExecutorTypes = Enum.create('ssh', 'mesos')
 
 ActionRunnerTypes = Enum.create('none', 'subprocess')
+
+VolumeModes = Enum.create('RO', 'RW')

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -175,6 +175,6 @@ ConfigCleanupAction = config_object_factory(
 
 StatePersistenceTypes = Enum.create('shelve', 'sql', 'yaml')
 
-ExecutorTypes = Enum.create('ssh', 'paasta')
+ExecutorTypes = Enum.create('ssh', 'mesos')
 
 ActionRunnerTypes = Enum.create('none', 'subprocess')

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -65,6 +65,20 @@ class Action(object):
     def from_config(cls, config):
         """Factory method for creating a new Action."""
         node_repo = node.NodePoolRepository.get_instance()
+
+        # Only convert config values if they are not None.
+        constraints = config.constraints
+        if constraints:
+            constraints = [
+                [c.attribute, c.operator, c.value] for c in constraints
+            ]
+        docker_parameters = config.docker_parameters
+        if docker_parameters:
+            docker_parameters = [c._asdict() for c in docker_parameters]
+        extra_volumes = config.extra_volumes
+        if extra_volumes:
+            extra_volumes = [c._asdict() for c in extra_volumes]
+
         return cls(
             name=config.name,
             command=config.command,
@@ -74,11 +88,11 @@ class Action(object):
             executor=config.executor,
             cpus=config.cpus,
             mem=config.mem,
-            constraints=config.constraints,
+            constraints=constraints,
             docker_image=config.docker_image,
-            docker_parameters=config.docker_parameters,
+            docker_parameters=docker_parameters,
             env=config.env,
-            extra_volumes=config.extra_volumes,
+            extra_volumes=extra_volumes,
             mesos_address=config.mesos_address,
         )
 

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -15,9 +15,10 @@ class Action(object):
     """A configurable data object for an Action."""
 
     equality_attributes = [
-        'name', 'command', 'node_pool', 'is_cleanup', 'executor', 'cluster',
-        'pool', 'cpus', 'mem', 'service', 'deploy_group', 'retries',
-        'expected_runtime'
+        'name', 'command', 'node_pool', 'is_cleanup', 'retries',
+        'expected_runtime', 'executor', 'cpus', 'mem', 'constraints',
+        'docker_image', 'docker_parameters', 'env', 'extra_volumes',
+        'mesos_address'
     ]
 
     def __init__(
@@ -28,14 +29,16 @@ class Action(object):
         required_actions=None,
         dependent_actions=None,
         retries=None,
+        expected_runtime=None,
         executor=None,
-        cluster=None,
-        pool=None,
         cpus=None,
         mem=None,
-        service=None,
-        deploy_group=None,
-        expected_runtime=None,
+        constraints=None,
+        docker_image=None,
+        docker_parameters=None,
+        env=None,
+        extra_volumes=None,
+        mesos_address=None,
     ):
         self.name = maybe_decode(name)
         self.command = command
@@ -43,14 +46,16 @@ class Action(object):
         self.retries = retries
         self.required_actions = required_actions or []
         self.dependent_actions = dependent_actions or []
+        self.expected_runtime = expected_runtime
         self.executor = executor
-        self.cluster = cluster
-        self.pool = pool
         self.cpus = cpus
         self.mem = mem
-        self.service = service
-        self.deploy_group = deploy_group
-        self.expected_runtime = expected_runtime
+        self.constraints = constraints or []
+        self.docker_image = docker_image
+        self.docker_parameters = docker_parameters or []
+        self.env = env or {}
+        self.extra_volumes = extra_volumes or []
+        self.mesos_address = mesos_address
 
     @property
     def is_cleanup(self):
@@ -65,14 +70,16 @@ class Action(object):
             command=config.command,
             node_pool=node_repo.get_by_name(config.node),
             retries=config.retries,
+            expected_runtime=config.expected_runtime,
             executor=config.executor,
-            cluster=config.cluster,
-            pool=config.pool,
             cpus=config.cpus,
             mem=config.mem,
-            service=config.service,
-            deploy_group=config.deploy_group,
-            expected_runtime=config.expected_runtime,
+            constraints=config.constraints,
+            docker_image=config.docker_image,
+            docker_parameters=config.docker_parameters,
+            env=config.env,
+            extra_volumes=config.extra_volumes,
+            mesos_address=config.mesos_address,
         )
 
     def __eq__(self, other):

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -96,8 +96,8 @@ class ActionRunFactory(object):
             'deploy_group': action.deploy_group or job_run.deploy_group,
             'retries_remaining': action.retries,
         }
-        if action.executor == ExecutorTypes.paasta:
-            return PaaSTAActionRun(**args)
+        if action.executor == ExecutorTypes.mesos:
+            return MesosActionRun(**args)
         return SSHActionRun(**args)
 
     @classmethod
@@ -111,8 +111,8 @@ class ActionRunFactory(object):
             'cleanup': cleanup,
         }
 
-        if state_data.get('executor') == ExecutorTypes.paasta:
-            return PaaSTAActionRun.from_state(**args)
+        if state_data.get('executor') == ExecutorTypes.mesos:
+            return MesosActionRun.from_state(**args)
         return SSHActionRun.from_state(**args)
 
 
@@ -569,8 +569,8 @@ class SSHActionRun(ActionRun, Observer):
     handler = handle_action_command_state_change
 
 
-class PaaSTAActionRun(ActionRun):
-    """An ActionRun that executes the command on a PaaSTA Mesos cluster.
+class MesosActionRun(ActionRun):
+    """An ActionRun that executes the command on a Mesos cluster.
     """
 
     def submit_command(self):

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -599,6 +599,7 @@ class MesosActionRun(ActionRun, Observer):
             extra_volumes=self.extra_volumes,
             serializer=serializer,
         )
+        # TODO: save task.task_id (mesos id) to state
         mesos_cluster.submit(task)  # TODO: catch errors
         self.watch(task)
         return task

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -73,8 +73,6 @@ class Job(Observable, Observer):
         'allow_overlap',
         'monitoring',
         'time_zone',
-        'service',
-        'deploy_group',
         'expected_runtime',
     ]
 
@@ -96,8 +94,6 @@ class Job(Observable, Observer):
         action_runner=None,
         max_runtime=None,
         time_zone=None,
-        service=None,
-        deploy_group=None,
         expected_runtime=None
     ):
         super(Job, self).__init__()
@@ -114,8 +110,6 @@ class Job(Observable, Observer):
         self.action_runner = action_runner
         self.max_runtime = max_runtime
         self.time_zone = time_zone
-        self.service = service
-        self.deploy_group = deploy_group
         self.expected_runtime = expected_runtime
         self.output_path = output_path or filehandler.OutputPath()
         self.output_path.append(name)
@@ -156,8 +150,6 @@ class Job(Observable, Observer):
             allow_overlap=job_config.allow_overlap,
             action_runner=action_runner,
             max_runtime=job_config.max_runtime,
-            service=job_config.service,
-            deploy_group=job_config.deploy_group,
             expected_runtime=job_config.expected_runtime,
         )
 
@@ -192,12 +184,6 @@ class Job(Observable, Observer):
 
     def get_time_zone(self):
         return self.time_zone
-
-    def get_service(self):
-        return self.service
-
-    def get_deploy_group(self):
-        return self.deploy_group
 
     def get_runs(self):
         return self.runs

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -51,8 +51,6 @@ class JobRun(Observable, Observer):
         action_runs=None,
         action_graph=None,
         manual=None,
-        service=None,
-        deploy_group=None,
     ):
         super(JobRun, self).__init__()
         self.job_name = maybe_decode(job_name)
@@ -65,8 +63,6 @@ class JobRun(Observable, Observer):
         self._action_runs = None
         self.action_graph = action_graph
         self.manual = manual
-        self.service = service
-        self.deploy_group = deploy_group
         self.event = event.get_recorder(self.full_id)
         self.event.ok('created')
 
@@ -91,8 +87,6 @@ class JobRun(Observable, Observer):
             job.context,
             action_graph=job.action_graph,
             manual=manual,
-            service=job.service,
-            deploy_group=job.deploy_group,
         )
 
         action_runs = ActionRunFactory.build_action_run_collection(
@@ -125,8 +119,6 @@ class JobRun(Observable, Observer):
             manual=state_data.get('manual', False),
             output_path=output_path,
             base_context=context,
-            service=state_data.get('service'),
-            deploy_group=state_data.get('deploy_group'),
         )
         action_runs = ActionRunFactory.action_run_collection_from_state(
             job_run,
@@ -147,8 +139,6 @@ class JobRun(Observable, Observer):
             'runs': self.action_runs.state_data,
             'cleanup_run': self.action_runs.cleanup_action_state_data,
             'manual': self.manual,
-            'service': self.service,
-            'deploy_group': self.deploy_group,
         }
 
     def _get_action_runs(self):

--- a/tron/logging.conf
+++ b/tron/logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=root, twisted, tron, tron.serialize
+keys=root, twisted, tron, tron.serialize, task_processing
 
 [handlers]
 keys=timedRotatingFileHandler, syslogHandler
@@ -27,6 +27,12 @@ propagate=0
 level=CRITICAL
 handlers=timedRotatingFileHandler
 qualname=tron
+propagate=0
+
+[logger_task_processing]
+level=WARNING
+handlers=timedRotatingFileHandler
+qualname=task_processing
 propagate=0
 
 [handler_timedRotatingFileHandler]

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -20,16 +20,7 @@ MESOS_ROLE = '*'
 OFFER_TIMEOUT = 300
 
 log = logging.getLogger(__name__)
-_processor = None
 frameworks = {}  # TODO: improve
-
-
-def get_mesos_processor():
-    global _processor
-    if not _processor:
-        _processor = TaskProcessor()
-        _processor.load_plugin(provider_module='task_processing.plugins.mesos')
-    return _processor
 
 
 def get_mesos_leader(master_address):
@@ -148,12 +139,15 @@ class MesosTask(ActionCommand):
 class MesosCluster:
     def __init__(self, mesos_address):
         self.mesos_address = mesos_address
-        self.processor = get_mesos_processor()
+        self.processor = TaskProcessor()
         self.queue = PyDeferredQueue()
         self.deferred = None
         self.runner = None
         self.tasks = {}
 
+        self.processor.load_plugin(
+            provider_module='task_processing.plugins.mesos'
+        )
         self.connect()
 
     # TODO: Should this be done asynchronously?

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -135,10 +135,13 @@ class MesosTask(ActionCommand):
 
         if event.terminal:
             self.log.info('Event was terminal, closing task')
+
+            exit_code = int(not getattr(event, 'success', False))
             # Returns False if we've already exited normally above
-            unexpected_error = self.exited(None)
+            unexpected_error = self.exited(exit_code)
             if unexpected_error:
                 self.log.error('Unknown failure, exiting')
+
             self.done()
 
 

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -5,10 +5,10 @@ from urllib.parse import urlparse
 import requests
 from task_processing.runners.subscription import Subscription
 from task_processing.task_processor import TaskProcessor
-from twisted.internet.defer import DeferredQueue
 from twisted.internet.defer import logError
 
 from tron.actioncommand import ActionCommand
+from tron.utils.queue import PyDeferredQueue
 
 TASK_LOG_FORMAT = '%(asctime)s %(name)s %(levelname)s %(message)s'
 # TODO: put in configs
@@ -120,7 +120,7 @@ class MesosCluster:
     def __init__(self, mesos_address):
         self.mesos_address = mesos_address
         self.processor = get_mesos_processor()
-        self.queue = DeferredQueue()
+        self.queue = PyDeferredQueue()
         self.deferred = None
         self.runner = self.get_runner(mesos_address, self.queue)
         self.tasks = {}

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -9,6 +9,7 @@ from twisted.internet.defer import DeferredQueue
 
 from tron.actioncommand import ActionCommand
 
+TASK_LOG_FORMAT = '%(asctime)s %(name)s %(levelname)s %(message)s'
 # TODO: put in configs
 MESOS_MASTER_PORT = 5050
 DOCKERCFG_LOCATION = "file:///root/.dockercfg"
@@ -52,6 +53,14 @@ class MesosTask(ActionCommand):
         super(MesosTask, self).__init__(id, task_config.cmd, serializer)
         self.task_config = task_config
         self.mesos_task_id = None
+        self.log = self.setup_logger()
+
+    def setup_logger(self):
+        log = logging.getLogger(__name__ + '.' + self.id)
+        handler = logging.StreamHandler(self.stderr)
+        handler.setFormatter(logging.Formatter(TASK_LOG_FORMAT))
+        log.addHandler(handler)
+        return log
 
 
 class MesosCluster:

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -17,6 +17,7 @@ MESOS_MASTER_PORT = 5050
 DOCKERCFG_LOCATION = "file:///root/.dockercfg"
 MESOS_SECRET = ''
 MESOS_ROLE = '*'
+OFFER_TIMEOUT = 300
 
 log = logging.getLogger(__name__)
 _processor = None
@@ -213,6 +214,7 @@ class MesosCluster:
             environment=env,
             volumes=extra_volumes,  # TODO: add default volumes
             uris=[DOCKERCFG_LOCATION],
+            offer_timeout=OFFER_TIMEOUT,
         )
         return MesosTask(action_run_id, task_config, serializer)
 

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -207,9 +207,8 @@ class MesosCluster:
             cmd=command,
             cpus=cpus,
             mem=mem,
-            constraints=constraints,  # TODO: format back to dict
+            constraints=constraints,
             image=docker_image,
-            # TODO: format. and should ulimit, cap_add be passed in directly?
             docker_parameters=docker_parameters,
             environment=env,
             volumes=extra_volumes,  # TODO: add default volumes

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import socket
 from urllib.parse import urlparse
 
 import requests
@@ -216,14 +217,14 @@ class MesosCluster:
         return MesosTask(action_run_id, task_config, serializer)
 
     def get_runner(self, mesos_address, queue):
+        framework_name = 'tron-{}'.format(socket.gethostname())
         executor = self.processor.executor_from_config(
             provider='mesos',
             provider_config={
                 'secret': MESOS_SECRET,
                 'mesos_address': get_mesos_leader(mesos_address),
                 'role': MESOS_ROLE,
-                # TODO: could also be in config, to include Tron cluster name
-                'framework_name': 'tron',
+                'framework_name': framework_name,
             }
         )
         return Subscription(executor, queue)

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -1,0 +1,157 @@
+import json
+import logging
+from urllib.parse import urlparse
+
+import requests
+from task_processing.runners.subscription import Subscription
+from task_processing.task_processor import TaskProcessor
+from twisted.internet.defer import DeferredQueue
+
+from tron.actioncommand import ActionCommand
+
+# TODO: put in configs
+MESOS_MASTER_PORT = 5050
+DOCKERCFG_LOCATION = "file:///root/.dockercfg"
+MESOS_SECRET = ''
+MESOS_ROLE = '*'
+
+log = logging.getLogger(__name__)
+_processor = None
+frameworks = {}  # TODO: improve
+
+
+def get_mesos_processor():
+    global _processor
+    if not _processor:
+        _processor = TaskProcessor()
+        _processor.load_plugin(provider_module='task_processing.plugins.mesos')
+    return _processor
+
+
+def get_mesos_leader(master_address):
+    url = "http://%s:%s/redirect" % (master_address, MESOS_MASTER_PORT)
+    response = requests.get(url)
+    return '{}:{}'.format(urlparse(response.url).hostname, MESOS_MASTER_PORT)
+
+
+def get_mesos_cluster(master_address):
+    global frameworks
+    if master_address not in frameworks:
+        frameworks[master_address] = MesosCluster(master_address)
+    return frameworks[master_address]
+
+
+def shutdown_frameworks():
+    global frameworks
+    for name, framework in frameworks.items():
+        framework.stop()
+
+
+class MesosTask(ActionCommand):
+    def __init__(self, id, task_config, serializer=None):
+        super(MesosTask, self).__init__(id, task_config.cmd, serializer)
+        self.task_config = task_config
+        self.mesos_task_id = None
+
+
+class MesosCluster:
+
+    # TODO: does it create a connection on init? should it be async?
+    def __init__(self, mesos_address):
+        self.processor = get_mesos_processor()
+        self.queue = DeferredQueue()
+        self.deferred = self.queue.get()
+        self.deferred.addCallback(self.handle_event)
+        # TODO: addErrback?
+        self.runner = self.get_runner(mesos_address, self.queue)
+        self.tasks = {}
+
+    def submit(self, task):
+        self.tasks[task.id] = task
+        self.runner.run(task.task_config)
+
+    def create_task(
+        self,
+        action_run_id,
+        command,
+        cpus,
+        mem,
+        constraints,
+        docker_image,
+        docker_parameters,
+        env,
+        extra_volumes,
+        serializer,
+    ):
+        task_config = self.runner.TASK_CONFIG_INTERFACE(
+            name=action_run_id,
+            cmd=command,
+            cpus=cpus,
+            mem=mem,
+            constraints=constraints,  # TODO: format back to dict
+            image=docker_image,
+            # TODO: format. and should ulimit, cap_add be passed in directly?
+            docker_parameters=docker_parameters,
+            environment=env,
+            volumes=extra_volumes,  # TODO: add default volumes
+            uris=[DOCKERCFG_LOCATION],
+        )
+        return MesosTask(action_run_id, task_config, serializer)
+
+    def get_runner(self, mesos_address, queue):
+        executor = self.processor.executor_from_config(
+            provider='mesos',
+            provider_config={
+                'secret': MESOS_SECRET,
+                'mesos_address': get_mesos_leader(mesos_address),
+                'role': MESOS_ROLE,
+                # TODO: could also be in config, to include Tron cluster name
+                'framework_name': 'tron',
+            }
+        )
+        return Subscription(executor, queue)
+
+    def handle_event(self, event):
+        log.info(
+            'Task {id}, {type}'.format(
+                id=event.task_id, type=event.platform_type
+            )
+        )
+        action_run_id = event.task_config.name
+        if action_run_id not in self.tasks:
+            log.warning(
+                'Got event for unknown action run: {}'.format(action_run_id)
+            )
+        else:
+            task = self.tasks[action_run_id]
+            task.write_stdout(json.dumps(event.raw))
+            if event.platform_type == 'staging':
+                task.mesos_task_id = event.task_id
+                # TODO: save task_id in action run state
+            elif event.platform_type == 'running':
+                task.started()
+            elif event.platform_type == 'finished':
+                task.exited(0)
+            elif event.platform_type == 'failed':
+                task.exited(1)
+                log.error('Task failed')  # todo
+            elif event.platform_type == 'killed':
+                task.exited(1)
+                log.info('Task killed')
+            elif event.platform_type == 'lost':
+                task.exited(1)
+                log.info('Task lost, should retry')
+            elif event.platform_type == 'error':
+                task.exited(1)
+                log.info('Task error, {}'.format(event.raw))
+
+            if event.terminal:
+                task.done()
+                del self.tasks[action_run_id]
+
+        self.deferred = self.queue.get()
+        self.deferred.addCallback(self.handle_event)
+
+    def stop(self):
+        self.runner.stop()
+        self.deferred.cancel()

--- a/tron/trondaemon.py
+++ b/tron/trondaemon.py
@@ -20,6 +20,7 @@ from twisted.internet.main import installReactor
 from twisted.python import log as twisted_log
 
 import tron
+from tron.mesos import shutdown_frameworks
 from tron.utils import flockfile
 
 if platform.system() == 'Linux':
@@ -220,6 +221,7 @@ class TronDaemon(object):
         log.info("Shutdown requested: sig %s" % sig_num)
         if self.mcp:
             self.mcp.shutdown()
+        shutdown_frameworks()
         self.reactor.stop()
         self.context.terminate(sig_num, stack_frame)
 

--- a/tron/utils/dicts.py
+++ b/tron/utils/dicts.py
@@ -20,6 +20,21 @@ def invert_dict_list(dictionary):
     return dict(itertools.chain.from_iterable(seq))
 
 
+def get_deep(dictionary, path, default=None):
+    """Safely get a nested value from a dict, with a default.
+
+    Path is a dot-separated string of keys to follow for the value.
+    """
+    keys = path.split('.')
+    result = dictionary
+    try:
+        for key in keys:
+            result = result[key]
+    except (KeyError, TypeError, ValueError):
+        result = default
+    return result
+
+
 class FrozenDict(Mapping):
     """Simple implementation of an immutable dictionary so we can freeze the
     command context, set of jobs, actions, etc.

--- a/tron/utils/queue.py
+++ b/tron/utils/queue.py
@@ -1,0 +1,27 @@
+import queue
+
+from twisted.internet import defer
+
+
+class PyDeferredQueue(defer.DeferredQueue):
+    """
+    Implements the stdlib queue.Queue get/put interface with a DeferredQueue.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(PyDeferredQueue, self).__init__(*args, **kwargs)
+
+    def put(self, item, block=None, timeout=None):
+        # Call from reactor thread so callbacks from get() will be executed
+        # on the reactor thread, even if this is called from another thread.
+        from twisted.internet import reactor
+        try:
+            reactor.callFromThread(super(PyDeferredQueue, self).put, item)
+        except defer.QueueOverflow:
+            raise queue.Full
+
+    def get(self, block=None, timeout=None):
+        try:
+            return super(PyDeferredQueue, self).get()
+        except defer.QueueUnderflow:
+            raise queue.Empty


### PR DESCRIPTION
Updates the API to be more general (no more paasta, just mesos and docker arguments) and uses taskproc to submit tasks to the mesos cluster.

Works for the action configurations I've tried so far. To do:
- [x] unit tests
- [ ] ~~error handling/retries when creating the framework~~ I want to make a follow-up change for this, since the diff is big already.
- [x] more manual testing