### PR TITLE
Action runner factory should always be an instance

### DIFF
--- a/tests/actioncommand_test.py
+++ b/tests/actioncommand_test.py
@@ -117,14 +117,14 @@ class CreateActionCommandFactoryFromConfigTestCase(TestCase):
         factory = actioncommand.create_action_runner_factory_from_config(
             config,
         )
-        assert_equal(factory, actioncommand.NoActionRunnerFactory)
+        assert_equal(type(factory), actioncommand.NoActionRunnerFactory)
 
     def test_create_default_action_command(self):
         config = schema.ConfigActionRunner('none', None, None)
         factory = actioncommand.create_action_runner_factory_from_config(
             config,
         )
-        assert_equal(factory, actioncommand.NoActionRunnerFactory)
+        assert_equal(type(factory), actioncommand.NoActionRunnerFactory)
 
     def test_create_action_command_with_simple_runner(self):
         status_path, exec_path = '/tmp/what', '/remote/bin'

--- a/tron/actioncommand.py
+++ b/tron/actioncommand.py
@@ -230,13 +230,13 @@ def create_action_runner_factory_from_config(config):
     constructor for ActionCommand.
     """
     if not config:
-        return NoActionRunnerFactory
+        return NoActionRunnerFactory()
 
     if config.runner_type not in schema.ActionRunnerTypes:
         raise ValueError("Unknown runner type: %s", config.runner_type)
 
     if config.runner_type == schema.ActionRunnerTypes.none:
-        return NoActionRunnerFactory
+        return NoActionRunnerFactory()
 
     if config.runner_type == schema.ActionRunnerTypes.subprocess:
         return SubprocessActionRunnerFactory.from_config(config)


### PR DESCRIPTION
Fixes the AttributeError with state_data.

- type was class instead of NoActionRunnerFactory, causing an exception when trying to access status_path: https://github.com/Yelp/Tron/blob/master/tron/core/actionrun.py#L406
- python calls `__getattr__` if a property raises an exception. In actionrun, that raises an AttributeError
- The exception in getting `action_runs.state_data` raises an exception in the jobrun state_data property (https://github.com/Yelp/Tron/blob/master/tron/core/jobrun.py#L147), calling jobrun's `__getattr__`
- that calls action_run_proxy, which doesn't have state_data either, leading to the traceback we saw