### PR TITLE
set the machine state to 'running' before recovery

### DIFF
--- a/tests/core/recovery_test.py
+++ b/tests/core/recovery_test.py
@@ -79,10 +79,12 @@ class TestRecovery(TestCase):
             job_run_id="test.succeeded",
             name="test.succeeded",
             node=mock_node,
-            action_runner=action_runner
+            action_runner=action_runner,
         )
+        action_run.machine.state = action_run.STATE_UNKNOWN
         res = recover_action_run(action_run, action_runner)
         mock_node.submit_command.assert_called_once()
+        assert action_run.machine.state == action_run.STATE_RUNNING
 
     def test_filter_recoverable_action_runs(self):
         assert filter_recoverable_action_runs(self.action_runs) == \

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -150,6 +150,10 @@ class ActionRun(object):
     STATE_FAILED['skip'] = STATE_SKIPPED
     STATE_CANCELLED['skip'] = STATE_SKIPPED
 
+    STATE_UNKNOWN['running'] = STATE_RUNNING
+    STATE_UNKNOWN['failed'] = STATE_FAILED
+    STATE_UNKNOWN['success'] = STATE_SUCCEEDED
+
     # We can force many states to be success or failure
     for event_state in (STATE_UNKNOWN, STATE_QUEUED, STATE_SCHEDULED):
         event_state['success'] = STATE_SUCCEEDED

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -151,8 +151,6 @@ class ActionRun(object):
     STATE_CANCELLED['skip'] = STATE_SKIPPED
 
     STATE_UNKNOWN['running'] = STATE_RUNNING
-    STATE_UNKNOWN['failed'] = STATE_FAILED
-    STATE_UNKNOWN['success'] = STATE_SUCCEEDED
 
     # We can force many states to be success or failure
     for event_state in (STATE_UNKNOWN, STATE_QUEUED, STATE_SCHEDULED):

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -70,6 +70,14 @@ def recover_action_run(action_run, action_runner):
     # and updates its internal state acoording to its result.
     action_run.watch(recovery_action_command)
 
+    if not action_run.machine.check('running'):
+        log.error(
+            'unable to transition action run %s from %s to start' %
+            (action_run.id, action_run.machine.state)
+        )
+    else:
+        action_run.machine.transition('running')
+
     log.info(
         "submitting recovery job with command %s to node %s" % (
             recovery_action_command.command,


### PR DESCRIPTION
without this, the state machine remains in the unknown state until the
recovery job terminates.