### PR TITLE
ClusterRepository for accessing Mesos clusters

### DIFF
--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -912,8 +912,8 @@ class MesosActionRunTestCase(TestCase):
         )
 
     @mock.patch('tron.core.actionrun.filehandler', autospec=True)
-    @mock.patch('tron.core.actionrun.get_mesos_cluster', autospec=True)
-    def test_submit_command(self, mock_get_cluster, mock_filehandler):
+    @mock.patch('tron.core.actionrun.MesosClusterRepository', autospec=True)
+    def test_submit_command(self, mock_cluster_repo, mock_filehandler):
         serializer = mock_filehandler.OutputStreamSerializer.return_value
         with mock.patch.object(
             self.action_run,
@@ -922,6 +922,7 @@ class MesosActionRunTestCase(TestCase):
         ) as mock_watch:
             self.action_run.submit_command()
 
+            mock_get_cluster = mock_cluster_repo.get_cluster
             mock_get_cluster.assert_called_once_with(self.mesos_address)
             mock_get_cluster.return_value.create_task.assert_called_once_with(
                 action_run_id=self.action_run.id,

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -16,7 +16,7 @@ from tron.actioncommand import NoActionRunnerFactory
 from tron.actioncommand import SubprocessActionRunnerFactory
 from tron.config.schema import ExecutorTypes
 from tron.core import action
-from tron.mesos import get_mesos_cluster
+from tron.mesos import MesosClusterRepository
 from tron.serialize import filehandler
 from tron.utils import iteration
 from tron.utils import maybe_decode
@@ -588,7 +588,7 @@ class MesosActionRun(ActionRun, Observer):
 
     def submit_command(self):
         serializer = filehandler.OutputStreamSerializer(self.output_path)
-        mesos_cluster = get_mesos_cluster(self.mesos_address)
+        mesos_cluster = MesosClusterRepository.get_cluster(self.mesos_address)
         task = mesos_cluster.create_task(
             action_run_id=self.id,
             command=self.command,

--- a/tron/trondaemon.py
+++ b/tron/trondaemon.py
@@ -20,7 +20,7 @@ from twisted.internet.main import installReactor
 from twisted.python import log as twisted_log
 
 import tron
-from tron.mesos import shutdown_frameworks
+from tron.mesos import MesosClusterRepository
 from tron.utils import flockfile
 
 if platform.system() == 'Linux':
@@ -221,7 +221,7 @@ class TronDaemon(object):
         log.info("Shutdown requested: sig %s" % sig_num)
         if self.mcp:
             self.mcp.shutdown()
-        shutdown_frameworks()
+        MesosClusterRepository.shutdown()
         self.reactor.stop()
         self.context.terminate(sig_num, stack_frame)
 


### PR DESCRIPTION
Basically the same as using a global, but now it's namespaced under the class? So it's slightly nicer to change configuration and stuff like that.

Decided to do it this way instead of copying NodePoolRepository (https://github.com/Yelp/Tron/blob/62ebd9b8c45d4bce49c5943b1f319ee6c8f3aa85/tron/node.py#L60) since it doesn't actually work as a singleton... you can get different instances with NodePoolRepository() as many times as you want, it just enforces that get_instance() returns the same one. Didn't seem worth the extra code, but let me know if you like that better.

The enabling is proof-of-concept for how configuration would be done, need to follow up on using that configuration value properly in MesosCluster and adding the field to MASTER.