### PR TITLE
Bounded asynchronous API request handling

### DIFF
--- a/tests/api/resource_test.py
+++ b/tests/api/resource_test.py
@@ -4,6 +4,8 @@ Test cases for the web services interface to tron
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from functools import wraps
+
 import mock
 import six
 import twisted.web.http
@@ -26,7 +28,14 @@ from tron import event
 from tron import mcp
 from tron import node
 from tron.api import controller
-from tron.api import resource as www
+with mock.patch(
+    'tron.api.async_resource.AsyncResource.bounded', lambda fn: fn
+):
+    with mock.patch(
+        'tron.api.async_resource.AsyncResource.exclusive', lambda fn: fn
+    ):
+        from tron.api import resource as www
+
 from tron.core import job
 from tron.core import jobrun
 

--- a/tests/api/resource_test.py
+++ b/tests/api/resource_test.py
@@ -4,8 +4,6 @@ Test cases for the web services interface to tron
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from functools import wraps
-
 import mock
 import six
 import twisted.web.http

--- a/tron/api/async_resource.py
+++ b/tron/api/async_resource.py
@@ -1,5 +1,7 @@
 import threading
 
+from twisted.internet import threads
+
 
 class AsyncResource():
     capacity = 10

--- a/tron/api/async_resource.py
+++ b/tron/api/async_resource.py
@@ -1,6 +1,7 @@
 import threading
 
 from twisted.internet import threads
+from twisted.web import server
 
 
 class AsyncResource():

--- a/tron/api/async_resource.py
+++ b/tron/api/async_resource.py
@@ -1,0 +1,45 @@
+import threading
+
+
+class AsyncResource():
+    capacity = 10
+    semaphore = threading.Semaphore(value=capacity)
+    lock = threading.Lock()
+
+    @staticmethod
+    def finish(result, request):
+        request.write(result)
+        request.finish()
+
+    @staticmethod
+    def process(fn, resource, request):
+        with AsyncResource.semaphore:
+            return fn(resource, request)
+
+    @staticmethod
+    def bounded(fn):
+        def wrapper(resource, request):
+            d = threads.deferToThread(
+                AsyncResource.process, fn, resource, request
+            )
+            d.addCallback(AsyncResource.finish, request)
+            d.addErrback(lambda f: f)
+            return server.NOT_DONE_YET
+
+        return wrapper
+
+    @staticmethod
+    def exclusive(fn):
+        def wrapper(*args, **kwargs):
+            # ensures only one exclusive request starts consuming the semaphore
+            with AsyncResource.lock:
+                # this will wait until all bounded requests finished processing
+                for _ in range(AsyncResource.capacity):
+                    AsyncResource.semaphore.acquire()
+                try:
+                    return fn(*args, **kwargs)
+                finally:
+                    for _ in range(AsyncResource.capacity):
+                        AsyncResource.semaphore.release()
+
+        return wrapper

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -6,10 +6,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import collections
-import contextlib
 import datetime
 import logging
-import threading
 
 import six
 
@@ -20,7 +18,6 @@ except ImportError:
     import json
 
 from twisted.web import http, resource, static, server
-from twisted.internet import reactor, threads
 
 from tron import event
 from tron.api import adapter, controller

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -436,7 +436,6 @@ class RootResource(resource.Resource):
         self.putChild(b'web', static.File(web_path))
         self.putChild(b'', self)
 
-    @AsyncResource.bounded
     def render_GET(self, request):
         request.redirect(request.prePathURL() + b'web')
         request.finish()

--- a/tron/trondaemon.py
+++ b/tron/trondaemon.py
@@ -26,6 +26,7 @@ from tron.utils import flockfile
 log = logging.getLogger(__name__)
 reactor.suggestThreadPoolSize(8)
 
+
 class PIDFile(object):
     """Create and check for a PID file for the daemon."""
 

--- a/tron/trondaemon.py
+++ b/tron/trondaemon.py
@@ -24,7 +24,6 @@ from tron.mesos import shutdown_frameworks
 from tron.utils import flockfile
 
 log = logging.getLogger(__name__)
-reactor.suggestThreadPoolSize(8)
 
 
 class PIDFile(object):


### PR DESCRIPTION
- [x] run all get requests asynchronously
- [x] figure out locking for POSTs

all GET request handlers use semaphore with capacity=10 to limit number of concurrent requests, POST requests acquire exclusive lock and drain capacity from semaphore before proceeding.

in this PR also:

- Remove reactor initialization
we've upgraded twisted a while ago, it already has the right logic to pick reactor implementation by default.