### PR TITLE
stream action_runner output from subprocess

### DIFF
--- a/bin/action_runner.py
+++ b/bin/action_runner.py
@@ -11,6 +11,7 @@ import logging
 import os
 import subprocess
 import sys
+import threading
 import time
 
 import yaml
@@ -109,15 +110,31 @@ def run_command(command):
     return subprocess.Popen(
         command,
         shell=True,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
+
+
+def stdout_reader(proc):
+    for line in iter(proc.stdout.readline, b''):
+        sys.stdout.write(line.decode('utf-8'))
+        sys.stdout.flush()
+
+
+def stderr_reader(proc):
+    for line in iter(proc.stderr.readline, b''):
+        sys.stderr.write(line.decode('utf-8'))
+        sys.stdout.flush()
 
 
 if __name__ == "__main__":
     logging.basicConfig()
     args = parse_args()
     proc = run_command(args.command)
+    stdout_printer_t = threading.Thread(target=stdout_reader, args=(proc, ))
+    stderr_printer_t = threading.Thread(target=stderr_reader, args=(proc, ))
+    stdout_printer_t.start()
+    stderr_printer_t.start()
     run_proc(
         output_path=args.output_dir,
         run_id=args.run_id,


### PR DESCRIPTION
as it stands, if the caller of this script (normally ssh) is killed,
then the subprocess will exit with status code 141 (pipefail) when it
attempts to write any output to stderr or stdout of the child process to
sys.stdout.

this change instead tells the subprocess to send the child's stderr and
stdout to a pipe, and seperate threads iterate through those values and
print to the callers stderr and stdout. this'll mean that although the
action_runner will still have errors when it tries to write to stdout
and sterr, this won't affect the exit code of the subprocess, and as a
result the correct exit code is written to the status file