### PR TITLE
reset actionrun endtime on recovery

### DIFF
--- a/tests/core/recovery_test.py
+++ b/tests/core/recovery_test.py
@@ -18,6 +18,7 @@ from tron.core.recovery import filter_recoverable_action_runs
 from tron.core.recovery import filter_recovery_candidates
 from tron.core.recovery import launch_recovery_actionruns_for_job_runs
 from tron.core.recovery import recover_action_run
+from tron.utils import timeutils
 
 
 class TestRecovery(TestCase):
@@ -80,11 +81,13 @@ class TestRecovery(TestCase):
             name="test.succeeded",
             node=mock_node,
             action_runner=action_runner,
+            end_time=timeutils.current_time()
         )
         action_run.machine.state = action_run.STATE_UNKNOWN
         recover_action_run(action_run, action_runner)
         mock_node.submit_command.assert_called_once()
         assert action_run.machine.state == action_run.STATE_RUNNING
+        assert action_run.end_time is None
 
     def test_filter_recoverable_action_runs(self):
         assert filter_recoverable_action_runs(self.action_runs) == \

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -76,6 +76,7 @@ def recover_action_run(action_run, action_runner):
             (action_run.id, action_run.machine.state)
         )
     else:
+        action_run.end_time = None
         action_run.machine.transition('running')
 
     log.info(


### PR DESCRIPTION
each time an actionrun enters a terminal state (as it does with unknown)
an end time is set for the job.

this is particularly confusing when a job is set back into a running
state by the recovery job, since the job will be marked as 'running' but
also have an end time. this change resets the end time to None, such
that the job appears 'in progress' again.