### PR TITLE
implement kill terminate for mesos actions

### DIFF
--- a/tests/api/controller_test.py
+++ b/tests/api/controller_test.py
@@ -76,9 +76,16 @@ class ActionRunControllerTestCase(TestCase):
         result = self.controller.handle_termination('stop')
         assert_in("Failed to stop", result)
 
-    def test_handle_termination_success(self):
+    def test_handle_termination_success_without_extra_msg(self):
+        self.action_run.kill.return_value = None
         result = self.controller.handle_termination('kill')
         assert_in("Attempting to kill", result)
+
+    def test_handle_termination_success_with_extra_msg(self):
+        self.action_run.kill.return_value = "Warning Message"
+        result = self.controller.handle_termination('kill')
+        assert_in("Attempting to kill", result)
+        assert_in("Warning Message", result)
 
 
 class JobRunControllerTestCase(TestCase):

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -954,9 +954,20 @@ class MesosActionRunTestCase(TestCase):
     def test_kill_task(self, mock_cluster_repo):
         mock_get_cluster = mock_cluster_repo.get_cluster
         self.action_run.task_id = 'fake_task_id'
-        self.action_run.kill()
+        error_message = self.action_run.kill()
         mock_get_cluster.return_value.kill.assert_called_once_with(
             self.action_run.task_id
+        )
+        assert_equal(
+            error_message,
+            "Warning: It might take up to docker_stop_timeout (current setting is 2 mins) for killing."
+        )
+
+    @mock.patch('tron.core.actionrun.MesosClusterRepository', autospec=True)
+    def test_kill_task_not_running(self, mock_cluster_repo):
+        error_message = self.action_run.kill()
+        assert_equal(
+            error_message, "Error: Can't find task id for the action."
         )
 
     @mock.patch('tron.core.actionrun.MesosClusterRepository', autospec=True)
@@ -966,6 +977,13 @@ class MesosActionRunTestCase(TestCase):
         self.action_run.stop()
         mock_get_cluster.return_value.kill.assert_called_once_with(
             self.action_run.task_id
+        )
+
+    @mock.patch('tron.core.actionrun.MesosClusterRepository', autospec=True)
+    def test_stop_task_not_running(self, mock_cluster_repo):
+        error_message = self.action_run.stop()
+        assert_equal(
+            error_message, "Error: Can't find task id for the action."
         )
 
 

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -950,6 +950,24 @@ class MesosActionRunTestCase(TestCase):
         mock_get_cluster.assert_called_once_with(self.mesos_address)
         assert self.action_run.is_failed
 
+    @mock.patch('tron.core.actionrun.MesosClusterRepository', autospec=True)
+    def test_kill_task(self, mock_cluster_repo):
+        mock_get_cluster = mock_cluster_repo.get_cluster
+        self.action_run.task_id = 'fake_task_id'
+        self.action_run.kill()
+        mock_get_cluster.return_value.kill.assert_called_once_with(
+            self.action_run.task_id
+        )
+
+    @mock.patch('tron.core.actionrun.MesosClusterRepository', autospec=True)
+    def test_stop_task(self, mock_cluster_repo):
+        mock_get_cluster = mock_cluster_repo.get_cluster
+        self.action_run.task_id = 'fake_task_id'
+        self.action_run.stop()
+        mock_get_cluster.return_value.kill.assert_called_once_with(
+            self.action_run.task_id
+        )
+
 
 if __name__ == "__main__":
     run()

--- a/tests/mesos_test.py
+++ b/tests/mesos_test.py
@@ -438,3 +438,8 @@ class MesosClusterTestCase(TestCase):
         # Shouldn't raise an error
         cluster = MesosCluster('mesos-cluster-a.me', enabled=False)
         cluster.stop()
+
+    def test_kill(self):
+        cluster = MesosCluster('mesos-cluster-a.me')
+        cluster.kill('fake_task_id')
+        cluster.runner.kill.assert_called_once_with('fake_task_id')

--- a/tron/api/controller.py
+++ b/tron/api/controller.py
@@ -77,8 +77,11 @@ class ActionRunController(object):
 
     def handle_termination(self, command):
         try:
-            getattr(self.action_run, command)()
+            # Extra message is only used for killing mesos action as warning so far.
+            extra_msg = getattr(self.action_run, command)()
             msg = "Attempting to %s %s"
+            if extra_msg is not None:
+                msg = msg + "\n" + extra_msg
             return msg % (command, self.action_run)
         except NotImplementedError as e:
             msg = "Failed to %s: %s"

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -605,6 +605,7 @@ class MesosActionRun(ActionRun, Observer):
             self.fail(None)
             return
 
+        self.task_id = task.get_mesos_id()
         # TODO: save task.task_id (mesos id) to state
 
         # Watch before submitting, in case submit causes a transition
@@ -616,13 +617,18 @@ class MesosActionRun(ActionRun, Observer):
         if self.retries_remaining is not None:
             self.retries_remaining = -1
 
-        pass
+        self._kill_mesos_task()
 
     def kill(self, final=True):
         if self.retries_remaining is not None and final:
             self.retries_remaining = -1
 
-        pass
+        self._kill_mesos_task()
+        return "Warning: It might take up to docker_stop_timeout (current setting is 2 mins) for killing."
+
+    def _kill_mesos_task(self):
+        mesos_cluster = MesosClusterRepository.get_cluster(self.mesos_address)
+        mesos_cluster.kill(self.task_id)
 
     def handle_action_command_state_change(self, action_command, event):
         """Observe ActionCommand state changes."""

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -345,3 +345,6 @@ class MesosCluster:
             )
             task.exited(None)
             del self.tasks[key]
+
+    def kill(self, task_id):
+        self.runner.kill(task_id)


### PR DESCRIPTION
There's no difference between stopping a task or killing a task for task processing, so I use the same call except that "tronctl kill" would print the extra line saying "Warning: Mesos action might not be killed forcibly."