### PR TITLE
Add default volumes and some other Mesos task settings to master config

### DIFF
--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -583,10 +583,20 @@ class ValidateMesos(Validator):
     option = True
     defaults = {
         'enabled': False,
+        'default_volumes': (),
+        'dockercfg_location': None,
+        'offer_timeout': 300,
     }
 
     validators = {
-        'enabled': valid_bool,
+        'enabled':
+            valid_bool,
+        'default_volumes':
+            build_list_of_type_validator(valid_volume, allow_empty=True),
+        'dockercfg_location':
+            valid_string,
+        'offer_timeout':
+            valid_int,
     }
 
 

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -111,6 +111,9 @@ ConfigMesos = config_object_factory(
     name='ConfigMesos',
     optional=[
         'enabled',
+        'default_volumes',
+        'dockercfg_location',
+        'offer_timeout',
     ],
 )
 


### PR DESCRIPTION
MESOS_MASTER_PORT, MESOS_SECRET, MESOS_ROLE would require changing the framework on reconfiguration, so leaving those for later.