### PR TITLE
handle failures streaming  to stdout/stderr

### DIFF
--- a/bin/action_runner.py
+++ b/bin/action_runner.py
@@ -86,7 +86,7 @@ def run_proc(output_path, command, run_id, proc):
         proc=proc,
     ):
         returncode = proc.wait()
-        log.warn(f'pid {proc.pid} exited with returncode {returncode}')
+        log.warning(f'pid {proc.pid} exited with returncode {returncode}')
         sys.exit(returncode)
 
 
@@ -117,15 +117,27 @@ def run_command(command):
 
 
 def stdout_reader(proc):
+    is_connected = True
     for line in iter(proc.stdout.readline, b''):
-        sys.stdout.write(line.decode('utf-8'))
-        sys.stdout.flush()
+        if is_connected:
+            try:
+                sys.stdout.write(line.decode('utf-8'))
+                sys.stdout.flush()
+            except Exception as e:
+                log.warning(f'failed writing to stdout: {e}')
+                is_connected = False
 
 
 def stderr_reader(proc):
+    is_connected = True
     for line in iter(proc.stderr.readline, b''):
-        sys.stderr.write(line.decode('utf-8'))
-        sys.stdout.flush()
+        if is_connected:
+            try:
+                sys.stderr.write(line.decode('utf-8'))
+                sys.stderr.flush()
+            except Exception as e:
+                log.warning(f'failed writing to stderr: {e}')
+                is_connected = False
 
 
 if __name__ == "__main__":

--- a/bin/action_runner.py
+++ b/bin/action_runner.py
@@ -126,7 +126,7 @@ def stream(source, dst):
                 logging.warning(f'{dst.name}: {line}')
             except Exception as e:
                 logging.warning(f'failed writing to {dst}: {e}')
-                logging.warning(line)
+                logging.warning(f'{dst.name}: {line}')
                 is_connected = False
         else:
             logging.warning(f'{dst.name}: {line}')

--- a/bin/action_runner.py
+++ b/bin/action_runner.py
@@ -16,8 +16,6 @@ import time
 
 import yaml
 
-log = logging.getLogger("tron.action_runner")
-
 STATUS_FILE = 'status'
 
 
@@ -79,6 +77,7 @@ def get_status_file(output_path):
 
 
 def run_proc(output_path, command, run_id, proc):
+    logging.warning(f'{run_id} running as pid {proc.pid}')
     status_file = get_status_file(output_path)
     with status_file.wrap(
         command=command,
@@ -86,7 +85,7 @@ def run_proc(output_path, command, run_id, proc):
         proc=proc,
     ):
         returncode = proc.wait()
-        log.warning(f'pid {proc.pid} exited with returncode {returncode}')
+        logging.warning(f'pid {proc.pid} exited with returncode {returncode}')
         sys.exit(returncode)
 
 
@@ -116,42 +115,43 @@ def run_command(command):
     )
 
 
-def stdout_reader(proc):
+def stream(source, dst):
     is_connected = True
-    for line in iter(proc.stdout.readline, b''):
+    logging.warning(f'streaming {source} to {dst}')
+    for line in iter(source.readline, b''):
         if is_connected:
             try:
-                sys.stdout.write(line.decode('utf-8'))
-                sys.stdout.flush()
+                dst.write(line.decode('utf-8'))
+                dst.flush()
+                logging.warning(line)
             except Exception as e:
-                log.warning(f'failed writing to stdout: {e}')
+                logging.warning(f'failed writing to {dst}: {e}')
+                logging.warning(line)
                 is_connected = False
+        else:
+            logging.warning(line)
+            is_connected = False
 
 
-def stderr_reader(proc):
-    is_connected = True
-    for line in iter(proc.stderr.readline, b''):
-        if is_connected:
-            try:
-                sys.stderr.write(line.decode('utf-8'))
-                sys.stderr.flush()
-            except Exception as e:
-                log.warning(f'failed writing to stderr: {e}')
-                is_connected = False
+def configure_logging(run_id):
+    logging.basicConfig(filename=f'/tmp/{run_id}.log')
 
 
 if __name__ == "__main__":
-    logging.basicConfig()
     args = parse_args()
+    configure_logging(args.run_id)
     proc = run_command(args.command)
-    stdout_printer_t = threading.Thread(
-        target=stdout_reader, args=(proc, ), daemon=True
-    )
-    stderr_printer_t = threading.Thread(
-        target=stderr_reader, args=(proc, ), daemon=True
-    )
-    stdout_printer_t.start()
-    stderr_printer_t.start()
+    streaming_threads = [
+        threading.Thread(
+            target=stream, args=(
+                pair[0],
+                pair[1],
+            ), daemon=True
+        ) for pair in [(proc.stdout, sys.stdout), (proc.stderr, sys.stderr)]
+    ]
+    for t in streaming_threads:
+        t.start()
+
     run_proc(
         output_path=args.output_dir,
         run_id=args.run_id,


### PR DESCRIPTION
if stdout or stderr disappear from under us and the thread reading them
crashes, then the stderr and stdout of the subprocess being run can
backup, and possibly prevent it exiting (see TRON-339 for an example of
docker doing this). catch any exceptions we get writing so that we
continue to read from the stderr and stdout of the subprocess.

example output in ``/tmp/{run_id}.log`` launching a pid that is interrupted:

```
WARNING:root:streaming 4 to <stdout>
WARNING:root:<stdout>: b'hi\n'
WARNING:root:streaming 6 to <stderr>
WARNING:root:foo-bar-123 running as pid 31721
WARNING:root:<stderr>: b'error\n'
WARNING:root:<stdout>: b'hi\n'
WARNING:root:<stderr>: b'error\n'
WARNING:root:<stdout>: b'hi\n'
WARNING:root:<stderr>: b'error\n'
WARNING:root:<stdout>: b'hi\n'
WARNING:root:<stderr>: b'error\n'
WARNING:root:failed writing to <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>: [Errno 32] Broken pipe
WARNING:root:b'hi\n'
WARNING:root:failed writing to <_io.TextIOWrapper name='<stderr>' mode='w' encoding='UTF-8'>: [Errno 32] Broken pipe
WARNING:root:b'error\n'
WARNING:root:<stdout>: b'hi\n'
WARNING:root:<stderr>: b'error\n'
```

Note: this change means that we'll now log the stderr and stdout to the local disk, as well as streaming it back to tron. I thought it'd make for easier debugging, but will probably mean we need to bump the size of our disks?