### PR TITLE
Fix the docs

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,10 @@
+docutils>=0.8.1
+Jinja2>=2.6
+psutil
+Pygments>=1.4
+pytimeparse
+pytz>=2011n
+PyYAML>=3.0
+requests
+Sphinx-PyPI-upload>=0.2.1
+Sphinx>=1.1.2


### PR DESCRIPTION
The docs have been broken since the 3.6 upgrade.

This splits out a unique docs requirements file so readthedocs.org can not try to build C-extension stuff.