### PR TITLE
Catch errors from commands and return a nicer error message

### DIFF
--- a/bin/tronctl
+++ b/bin/tronctl
@@ -88,6 +88,7 @@ def edit(args, uri):
     response = client.request(uri, data=data)
 
     if response.error:
+        log.error(response.content)
         return
 
     print(response.content['result'])

--- a/tests/api/resource_test.py
+++ b/tests/api/resource_test.py
@@ -99,6 +99,21 @@ class HandleCommandTestCase(TestCase):
             {'result': mock_controller.handle_command.return_value},
         )
 
+    def test_handle_command_error(self):
+        command = 'the command'
+        request = build_request(command=command)
+        mock_controller, obj = mock.Mock(), mock.Mock()
+        error = Exception("uncaught exception")
+        mock_controller.handle_command.side_effect = error
+        response = www.handle_command(request, mock_controller, obj)
+        mock_controller.handle_command.assert_called_with(command)
+        assert_equal(response, self.respond.return_value)
+        self.respond.assert_called_with(
+            request,
+            {'error': mock.ANY},
+            code=http.INTERNAL_SERVER_ERROR,
+        )
+
 
 class ActionRunResourceTestCase(WWWTestCase):
     @setup

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import collections
 import datetime
 import logging
+import traceback
 
 import six
 
@@ -73,6 +74,10 @@ def handle_command(request, api_controller, obj, **kwargs):
     except controller.UnknownCommandError as e:
         log.warning("Unknown command %s for %s", command, obj)
         return respond(request, {'error': str(e)}, code=http.NOT_IMPLEMENTED)
+    except Exception as e:
+        log.exception('%r while executing command %s for %s', e, command, obj)
+        trace = traceback.format_exc()
+        return respond(request, {'error': trace}, code=http.INTERNAL_SERVER_ERROR)
 
 
 def resource_from_collection(collection, name, child_resource):


### PR DESCRIPTION
If you get an uncaught exception from a request, the twisted default is to return a bunch of HTML. This makes it easier to tell what happened when you use tronctl.

The motivation for this was, if kill_task in Mesos fails, the user will get better feedback and can retry the kill command. But I think it will be nice in general.