### PR TITLE
Update taskproc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ PyYAML>=3.0
 requests
 Sphinx-PyPI-upload>=0.2.1
 Sphinx>=1.1.2
-task_processing[mesos_executor]>=0.0.10
+task_processing[mesos_executor]>=0.0.14
 testify>=0.1.12
 Twisted>=17.0.0

--- a/tests/mesos_test.py
+++ b/tests/mesos_test.py
@@ -271,7 +271,7 @@ class MesosClusterTestCase(TestCase):
         self.mock_get_leader.assert_called_once_with('mesos-cluster-a.me')
         self.mock_processor.executor_from_config.assert_has_calls([
             mock.call(
-                provider='mesos',
+                provider='mesos_task',
                 provider_config={
                     'secret': MESOS_SECRET,
                     'mesos_address': self.mock_get_leader.return_value,

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -681,7 +681,9 @@ class MesosActionRun(ActionRun, Observer):
             mesos_cluster = MesosClusterRepository.get_cluster(
                 self.mesos_address
             )
-            mesos_cluster.kill(self.task_id)
+            succeeded = mesos_cluster.kill(self.task_id)
+            if not succeeded:
+                return "Error while killing task. Please try again."
         except AttributeError:
             return "Error: Can't find task id for the action."
 

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -321,7 +321,7 @@ class MesosCluster:
 
         framework_name = 'tron-{}'.format(socket.gethostname())
         executor = self.processor.executor_from_config(
-            provider='mesos',
+            provider='mesos_task',
             provider_config={
                 'secret': MESOS_SECRET,
                 'mesos_address': get_mesos_leader(mesos_address),
@@ -396,4 +396,4 @@ class MesosCluster:
             del self.tasks[key]
 
     def kill(self, task_id):
-        self.runner.kill(task_id)
+        return self.runner.kill(task_id)


### PR DESCRIPTION
* fixes logging (old taskproc was calling basicConfig before)
* stop using deprecated provider
* return feedback on killing tasks