### PR TITLE
catch command rendering type error

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -1122,14 +1122,20 @@ class BuildFormatStringValidatorTestCase(TestCase):
         assert_in("Unknown context variable", str(exception))
 
     def test_validator_no_type_error(self):
-        template = "The %(one) %(seven)s thing is %(stars)s"
-        exception = assert_raises(
-            ConfigError,
-            self.validator,
-            template,
-            NullConfigContext,
-        )
-        assert_in("Unknown context variable", str(exception))
+        templates = [
+            "The %(one) %(seven)s thing is %(stars)s",
+            "The %(one) %(seven) thing is %(stars)s",
+            "The %(one) something %(seven)s thing is %(stars)s",
+            "The %(one)s %(seven)s thing is %(stars)",
+        ]
+        for template in templates:
+            exception = assert_raises(
+                ConfigError,
+                self.validator,
+                template,
+                NullConfigContext,
+            )
+            assert_in("Wrong command format", str(exception))
 
     def test_validator_wrong_type_error(self):
         template = "The %(one)d %(seven)s thing is %(stars)s"
@@ -1139,7 +1145,7 @@ class BuildFormatStringValidatorTestCase(TestCase):
             template,
             NullConfigContext,
         )
-        assert_in("Unknown context variable", str(exception))
+        assert_in("Wrong command format", str(exception))
 
     def test_validator_passes_with_context(self):
         template = "The %(one)s thing I %(seven)s is %(mars)s"

--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -1111,8 +1111,28 @@ class BuildFormatStringValidatorTestCase(TestCase):
         template = "The %(one)s thing I %(seven)s is %(stars)s"
         assert self.validator(template, NullConfigContext)
 
-    def test_validator_error(self):
+    def test_validator_unknown_variable_error(self):
         template = "The %(one)s thing I %(seven)s is %(unknown)s"
+        exception = assert_raises(
+            ConfigError,
+            self.validator,
+            template,
+            NullConfigContext,
+        )
+        assert_in("Unknown context variable", str(exception))
+
+    def test_validator_no_type_error(self):
+        template = "The %(one) %(seven)s thing is %(stars)s"
+        exception = assert_raises(
+            ConfigError,
+            self.validator,
+            template,
+            NullConfigContext,
+        )
+        assert_in("Unknown context variable", str(exception))
+
+    def test_validator_wrong_type_error(self):
+        template = "The %(one)d %(seven)s thing is %(stars)s"
         exception = assert_raises(
             ConfigError,
             self.validator,

--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -1135,7 +1135,7 @@ class BuildFormatStringValidatorTestCase(TestCase):
                 template,
                 NullConfigContext,
             )
-            assert_in("Wrong command format", str(exception))
+            assert_in("Context variable expression is invalid", str(exception))
 
     def test_validator_wrong_type_error(self):
         template = "The %(one)d %(seven)s thing is %(stars)s"
@@ -1145,7 +1145,7 @@ class BuildFormatStringValidatorTestCase(TestCase):
             template,
             NullConfigContext,
         )
-        assert_in("Wrong command format", str(exception))
+        assert_in("Context variable expression is invalid", str(exception))
 
     def test_validator_passes_with_context(self):
         template = "The %(one)s thing I %(seven)s is %(mars)s"

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -25,6 +25,7 @@ from tron.config.config_utils import build_list_of_type_validator
 from tron.config.config_utils import ConfigContext
 from tron.config.config_utils import PartialConfigContext
 from tron.config.config_utils import valid_bool
+from tron.config.config_utils import valid_context_variable_expr
 from tron.config.config_utils import valid_dict
 from tron.config.config_utils import valid_float
 from tron.config.config_utils import valid_identifier
@@ -67,15 +68,15 @@ def build_format_string_validator(context_object):
         )
 
         try:
-            render_command = value % context
-            # This checks wrong format like "$(A) $(A)s"
-            if render_command != (render_command % context):
-                raise TypeError("type is not specified")
-
+            valid_context_variable_expr(value)
+            value % context
             return value
-        except (KeyError, ValueError, TypeError) as e:
+        except (KeyError, ValueError) as e:
             error_msg = "Unknown context variable %s at %s: %s"
             raise ConfigError(error_msg % (e, config_context.path, value))
+        except (TypeError) as e:
+            error_msg = "Wrong command format %s: %s at %s"
+            raise ConfigError(error_msg % (value, e, config_context.path))
 
     return validator
 

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -67,9 +67,13 @@ def build_format_string_validator(context_object):
         )
 
         try:
-            value % context
+            render_command = value % context
+            # This checks wrong format like "$(A) $(A)s"
+            if render_command != (render_command % context):
+                raise TypeError("type is not specified")
+
             return value
-        except (KeyError, ValueError) as e:
+        except (KeyError, ValueError, TypeError) as e:
             error_msg = "Unknown context variable %s at %s: %s"
             raise ConfigError(error_msg % (e, config_context.path, value))
 

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -68,7 +68,7 @@ def build_format_string_validator(context_object):
         )
 
         try:
-            valid_context_variable_expr(value)
+            valid_context_variable_expr(value, config_context)
             value % context
             return value
         except (KeyError, ValueError) as e:

--- a/tron/config/config_utils.py
+++ b/tron/config/config_utils.py
@@ -157,6 +157,18 @@ def valid_name_identifier(value, config_context):
     return '%s.%s' % (config_context.namespace, value)
 
 
+def valid_context_variable_expr(command):
+    """ This funtion checks wrong format like '$(A) $(A)s' """
+    prefix = command.find("%(")
+    while prefix >= 0:
+        postfix = command.find(")s", prefix)
+        if postfix < 0:
+            raise TypeError("Context variable expression is invalid")
+        prefix = command.find("%(", prefix + 1)
+        if prefix >= 0 and prefix < postfix:
+            raise TypeError("Context variable expression is invalid")
+
+
 def build_list_of_type_validator(item_validator, allow_empty=False):
     """Build a validator which validates a list contains items which pass
     item_validator.

--- a/tron/config/config_utils.py
+++ b/tron/config/config_utils.py
@@ -157,16 +157,18 @@ def valid_name_identifier(value, config_context):
     return '%s.%s' % (config_context.namespace, value)
 
 
-def valid_context_variable_expr(command):
-    """ This funtion checks wrong format like '$(A) $(A)s' """
+def valid_context_variable_expr(command, config_context):
+    """ This function verifies that all context variables have complete
+    string format specifiers.
+    """
     prefix = command.find("%(")
     while prefix >= 0:
         postfix = command.find(")s", prefix)
         if postfix < 0:
-            raise TypeError("Context variable expression is invalid")
+            raise ConfigError("Context variable expression is invalid: %s at %s" % (command, config_context.path))
         prefix = command.find("%(", prefix + 1)
         if prefix >= 0 and prefix < postfix:
-            raise TypeError("Context variable expression is invalid")
+            raise ConfigError("Context variable expression is invalid: %s at %s" % (command, config_context.path))
 
 
 def build_list_of_type_validator(item_validator, allow_empty=False):


### PR DESCRIPTION
This catch type errors of rendering command, plus a special case like "$(variable) $(variable)s"