### PR TITLE
add string format support

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -1143,6 +1143,26 @@ class TestBuildFormatStringValidator(TestCase):
         )
         assert self.validator(template, context)
 
+    def test_validator_valid_format_string(self):
+        template = "The {one} thing I {seven} is {mars}"
+        context = config_utils.ConfigContext(
+            None,
+            None,
+            {'mars': 'ok'},
+            None,
+        )
+        assert self.validator(template, context)
+
+    def test_validator_valid_percent_string(self):
+        template = "The %(one)s %(seven)s thing is %(mars)s -config {'a': 1}"
+        context = config_utils.ConfigContext(
+            None,
+            None,
+            {'mars': 'ok'},
+            None,
+        )
+        assert self.validator(template, context)
+
 
 class TestValidateConfigMapping(TestCase):
     config = dict(**BASE_CONFIG, command_context=dict(some_var="The string"))

--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -1146,20 +1146,20 @@ class TestBuildFormatStringValidator(TestCase):
     def test_validator_valid_format_string(self):
         template = "The {one} thing I {seven} is {mars}"
         context = config_utils.ConfigContext(
-            None,
-            None,
-            {'mars': 'ok'},
-            None,
+            path=None,
+            nodes=None,
+            command_context={'mars': 'ok'},
+            namespace=None,
         )
         assert self.validator(template, context)
 
     def test_validator_valid_percent_string(self):
         template = "The %(one)s %(seven)s thing is %(mars)s -config {'a': 1}"
         context = config_utils.ConfigContext(
-            None,
-            None,
-            {'mars': 'ok'},
-            None,
+            path=None,
+            nodes=None,
+            command_context={'mars': 'ok'},
+            namespace=None,
         )
         assert self.validator(template, context)
 

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -328,6 +328,16 @@ class TestActionRun(TestCase):
         self.action_run.bare_command = "%(stars)s"
         assert_equal(self.action_run.render_command(), 'bright')
 
+    def test_render_format_string_command(self):
+        self.action_run.context = {'stars': 'bright'}
+        self.action_run.bare_command = "{stars}"
+        assert_equal(self.action_run.render_command(), 'bright')
+
+    def test_render_valid_percent_invalid_format_string_command(self):
+        self.action_run.context = {'stars': 'bright'}
+        self.action_run.bare_command = "%(stars)s --config {'a': 1}"
+        assert_equal(self.action_run.render_command(), "bright --config {'a': 1}")
+
     def test_command_not_yet_rendered(self):
         assert_equal(self.action_run.command, self.rendered_command)
 

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -24,6 +24,7 @@ from tron.config.config_utils import build_dict_name_validator
 from tron.config.config_utils import build_list_of_type_validator
 from tron.config.config_utils import ConfigContext
 from tron.config.config_utils import PartialConfigContext
+from tron.config.config_utils import StringFormatter
 from tron.config.config_utils import valid_bool
 from tron.config.config_utils import valid_context_variable_expr
 from tron.config.config_utils import valid_dict
@@ -69,6 +70,7 @@ def build_format_string_validator(context_object):
         try:
             valid_context_variable_expr(value, config_context)
             value % context
+            StringFormatter(context).format(value)
             return value
         except (KeyError, ValueError) as e:
             error_msg = "Unknown context variable %s at %s: %s"

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -69,9 +69,14 @@ def build_format_string_validator(context_object):
 
         try:
             valid_context_variable_expr(value, config_context)
-            value % context
-            StringFormatter(context).format(value)
-            return value
+            try:
+                value % context
+                StringFormatter(context).format(value)
+                return value
+            except Exception as e:
+                value % context
+                log.warning("Invalid format string {} at {} {}.\nFall back to % string evaluation".format(e, config_context.path, value))
+                return value
         except (KeyError, ValueError) as e:
             error_msg = "Unknown context variable %s at %s: %s"
             raise ConfigError(error_msg % (e, config_context.path, value))

--- a/tron/config/config_utils.py
+++ b/tron/config/config_utils.py
@@ -6,6 +6,7 @@ import datetime
 import functools
 import itertools
 import re
+from string import Formatter
 
 import six
 from six import string_types
@@ -17,6 +18,21 @@ from tron.utils.dicts import FrozenDict
 
 MAX_IDENTIFIER_LENGTH = 255
 IDENTIFIER_RE = re.compile(r'^[A-Za-z_][\w\-]{0,254}$')
+
+
+class StringFormatter(Formatter):
+    def __init__(self, context=None):
+        Formatter.__init__(self)
+        self.context = context
+
+    def get_value(self, key, args, kwds):
+        if isinstance(key, str):
+            try:
+                return kwds[key]
+            except KeyError:
+                return self.context[key]
+        else:
+            Formatter.get_value(key, args, kwds)
 
 
 class UniqueNameDict(dict):

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -12,6 +12,7 @@ from tron import node
 from tron.actioncommand import ActionCommand
 from tron.actioncommand import NoActionRunnerFactory
 from tron.actioncommand import SubprocessActionRunnerFactory
+from tron.config.config_utils import StringFormatter
 from tron.config.schema import ExecutorTypes
 from tron.core import action
 from tron.mesos import MesosClusterRepository
@@ -499,7 +500,11 @@ class ActionRun(object):
 
     def render_command(self):
         """Render our configured command using the command context."""
-        return self.bare_command % self.context
+        if "%" in self.bare_command:
+            return self.bare_command % self.context
+        else:
+            fmt = StringFormatter(self.context)
+            return fmt.format(self.bare_command)
 
     @property
     def command(self):

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -500,8 +500,11 @@ class ActionRun(object):
 
     def render_command(self):
         """Render our configured command using the command context."""
-        parse_str = self.bare_command % self.context
-        return StringFormatter(self.context).format(parse_str)
+        try:
+            parse_str = self.bare_command % self.context
+            return StringFormatter(self.context).format(parse_str)
+        except Exception:
+            return self.bare_command % self.context
 
     @property
     def command(self):

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -500,11 +500,8 @@ class ActionRun(object):
 
     def render_command(self):
         """Render our configured command using the command context."""
-        if "%" in self.bare_command:
-            return self.bare_command % self.context
-        else:
-            fmt = StringFormatter(self.context)
-            return fmt.format(self.bare_command)
+        parse_str = self.bare_command % self.context
+        return StringFormatter(self.context).format(parse_str)
 
     @property
     def command(self):


### PR DESCRIPTION
I would like to hear other thought before I proceed...
Instead of formatting string in old fashion way like:
```
%(PYTHON_ENV)s %(BATCHDIR)s/run.py
```
we can also format commands as:
```
{PYTHON_ENV} {BATCHDIR}/run.py
```