### PR TITLE
Save Mesos framework IDs and re-register on restart

### DIFF
--- a/tron/mcp.py
+++ b/tron/mcp.py
@@ -90,6 +90,8 @@ class MasterControlProgram(object):
         master_config = config_container.get_master()
         apply_master_configuration(master_config_directives, master_config)
 
+        self.state_watcher.watch(MesosClusterRepository)
+
         # TODO: unify NOTIFY_STATE_CHANGE and simplify this
         factory = self.build_job_scheduler_factory(master_config)
         self.apply_collection_config(
@@ -149,9 +151,11 @@ class MasterControlProgram(object):
         to the configured Jobs.
         """
         self.event_recorder.notice('restoring')
-        job_states = self.state_watcher.restore(self.jobs.get_names())
+        states = self.state_watcher.restore(self.jobs.get_names())
 
-        self.jobs.restore_state(job_states, action_runner)
+        MesosClusterRepository.restore_state(states['mesos_state'])
+
+        self.jobs.restore_state(states['job_state'], action_runner)
         self.state_watcher.save_metadata()
 
     def __str__(self):

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -48,16 +48,27 @@ class MesosClusterRepository:
     dockercfg_location = None
     offer_timeout = None
 
+    name = 'frameworks'
+    state_data = {}
+    state_watcher = None
+
+    @classmethod
+    def attach(cls, _, observer):
+        cls.state_watcher = observer
+
     @classmethod
     def get_cluster(cls, master_address):
         if master_address not in cls.clusters:
-            cls.clusters[master_address] = MesosCluster(
+            framework_id = cls.state_data.get(master_address)
+            cluster = MesosCluster(
                 master_address,
+                framework_id,
                 cls.mesos_enabled,
                 cls.default_volumes,
                 cls.dockercfg_location,
                 cls.offer_timeout,
             )
+            cls.clusters[master_address] = cluster
         return cls.clusters[master_address]
 
     @classmethod
@@ -81,6 +92,21 @@ class MesosClusterRepository:
                 dockercfg_location=cls.dockercfg_location,
                 offer_timeout=cls.offer_timeout,
             )
+
+    @classmethod
+    def restore_state(cls, mesos_state):
+        cls.state_data = mesos_state.get(cls.name, {})
+
+    @classmethod
+    def save(cls, master_address, framework_id):
+        cls.state_data[master_address] = framework_id
+        cls.state_watcher.handler(cls, None)
+
+    @classmethod
+    def remove(cls, master_address):
+        if master_address in cls.state_data:
+            del cls.state_data[master_address]
+            cls.state_watcher.handler(cls, None)
 
 
 class MesosTask(ActionCommand):
@@ -193,6 +219,7 @@ class MesosCluster:
     def __init__(
         self,
         mesos_address,
+        framework_id=None,
         enabled=True,
         default_volumes=None,
         dockercfg_location=None,
@@ -203,6 +230,7 @@ class MesosCluster:
         self.default_volumes = default_volumes or []
         self.dockercfg_location = dockercfg_location
         self.offer_timeout = offer_timeout
+        self.framework_id = framework_id
 
         self.processor = TaskProcessor()
         self.queue = PyDeferredQueue()
@@ -262,6 +290,7 @@ class MesosCluster:
 
         if self.runner.stopping:
             # Last framework was terminated for some reason, re-connect.
+            log.info('Last framework stopped, re-connecting')
             self.connect()
         elif self.deferred.called:
             # Just in case callbacks are missing, re-add.
@@ -327,6 +356,8 @@ class MesosCluster:
                 'mesos_address': get_mesos_leader(mesos_address),
                 'role': MESOS_ROLE,
                 'framework_name': framework_name,
+                'framework_id': self.framework_id,
+                'failover': True,
             }
         )
 
@@ -357,10 +388,14 @@ class MesosCluster:
                 # Framework has been removed, stop it.
                 log.warn('Framework has been stopped: {}'.format(event.raw))
                 self.stop()
+                MesosClusterRepository.remove(self.mesos_address)
             elif message == 'unknown':
                 log.warn(
                     'Unknown error from Mesos master: {}'.format(event.raw)
                 )
+            elif message == 'registered':
+                framework_id = event.raw['framework_id']['value']
+                MesosClusterRepository.save(self.mesos_address, framework_id)
             else:
                 log.warn('Unknown type of control event: {}'.format(event))
 
@@ -384,10 +419,15 @@ class MesosCluster:
             log.warn('Unknown type of event: {}'.format(event))
 
     def stop(self):
+        self.framework_id = None
         if self.runner:
             self.runner.stop()
+
+        # Clear message queue
         if self.deferred:
             self.deferred.cancel()
+        self.queue = PyDeferredQueue()
+
         for key, task in list(self.tasks.items()):
             task.log.warning(
                 'Still running during Mesos shutdown, becoming unknown'

--- a/tron/serialize/runstate/__init__.py
+++ b/tron/serialize/runstate/__init__.py
@@ -3,3 +3,4 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 JOB_STATE = 'job_state'
 MCP_STATE = 'mcp_state'
+MESOS_STATE = 'mesos_state'

--- a/tron/serialize/runstate/statemanager.py
+++ b/tron/serialize/runstate/statemanager.py
@@ -10,6 +10,7 @@ import six
 
 from tron.config import schema
 from tron.core import job
+from tron.mesos import MesosClusterRepository
 from tron.serialize import runstate
 from tron.serialize.runstate.shelvestore import ShelveStateStore
 from tron.serialize.runstate.sqlalchemystore import SQLAlchemyStateStore
@@ -149,7 +150,12 @@ class PersistentStateManager(object):
         if not skip_validation:
             self._restore_metadata()
 
-        return self._restore_dicts(runstate.JOB_STATE, job_names)
+        jobs = self._restore_dicts(runstate.JOB_STATE, job_names)
+        frameworks = self._restore_dicts(runstate.MESOS_STATE, ['frameworks'])
+        return {
+            runstate.JOB_STATE: jobs,
+            runstate.MESOS_STATE: frameworks,
+        }
 
     def _restore_metadata(self):
         metadata = self._impl.restore([self.metadata_key])
@@ -254,9 +260,14 @@ class StateChangeWatcher(observer.Observer):
         """Handle a state change in an observable by saving its state."""
         if isinstance(observable, job.Job):
             self.save_job(observable)
+        elif observable == MesosClusterRepository:
+            self.save_frameworks(observable)
 
     def save_job(self, job):
         self._save_object(runstate.JOB_STATE, job)
+
+    def save_frameworks(self, clusters):
+        self._save_object(runstate.MESOS_STATE, clusters)
 
     def save_metadata(self):
         self._save_object(runstate.MCP_STATE, StateMetadata())


### PR DESCRIPTION
Goes with https://github.com/Yelp/task_processing/pull/117

The bulk of this is updating framework IDs in the state file when they change. Did some hacks with MesosClusterRepository instead of subclassing Observable, would be great if you all have ideas on better ways to do this :)