### PR TITLE
Make itests wait for tron to be connected to mesos

### DIFF
--- a/cluster_itests/config/MASTER.yaml
+++ b/cluster_itests/config/MASTER.yaml
@@ -24,7 +24,7 @@ nodes:
 time_zone: US/Eastern
 
 jobs:
-  - name: "test"
+  - name: "mesostest"
     node: localhost
     schedule: "cron * * * * *"
     time_zone: "US/Pacific"

--- a/cluster_itests/docker-compose.yml
+++ b/cluster_itests/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     build:
       context: ../
       dockerfile: ./yelp_package/itest_dockerfiles/tronmaster/Dockerfile
-    command: bash -c 'pip3 install -e /work && exec trond --debug -c /work/cluster_itests/config/   -l /work/example-cluster/logging.conf'
+    command: bash -c 'pip3 install -e /work && exec trond --debug -c /work/cluster_itests/config/   -l /work/example-cluster/logging.conf  -H 0.0.0.0'
     ports:
       - 8089
     depends_on:

--- a/cluster_itests/mesos.feature
+++ b/cluster_itests/mesos.feature
@@ -2,5 +2,7 @@ Feature: Tron can connect to a mesos cluster
 
   Scenario: Framework registration
     Given a working mesos cluster
+     When we run tronctl start MASTER.mesostest
+      And we sleep 3 seconds
      Then we should see 1 frameworks
      Then we should see tron in the list of frameworks

--- a/cluster_itests/steps/itest_utils.py
+++ b/cluster_itests/steps/itest_utils.py
@@ -1,0 +1,9 @@
+import subprocess
+
+
+def run(command):
+    process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+    process.wait()
+    returncode = process.returncode
+    output = "".join([l.decode('utf8') for l in process.stdout.readlines()])
+    return returncode, output

--- a/cluster_itests/steps/mesos_steps.py
+++ b/cluster_itests/steps/mesos_steps.py
@@ -11,9 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import time
+
+import itest_utils
 import requests
 from behave import given
 from behave import then
+from behave import when
 
 
 @given(u'a working mesos cluster')
@@ -21,10 +25,25 @@ def working_mesos_cluster(context):
     pass
 
 
+@when(u'we run tronctl {command}')
+def run_tronctl_command(context, command):
+    full_command = f'tronctl --server http://tronmaster:8089 {command}'
+    exit_code, context.output = itest_utils.run(full_command)
+    print(full_command)
+    print(exit_code)
+    print(context.output)
+    assert exit_code == 0, context.output
+
+
 @then(u'we should see {framework_string} in the list of frameworks')
 def see_framework_in_list(context, framework_string):
     frameworks = list_active_frameworks()
     assert any(framework_string in f for f in frameworks), frameworks
+
+
+@when(u'we sleep {num:d} seconds')
+def sleep(context, num):
+    time.sleep(num)
 
 
 @then(u'we should see {num:d} frameworks')

--- a/tox.ini
+++ b/tox.ini
@@ -45,13 +45,15 @@ commands =
 [testenv:cluster_itests]
 changedir=cluster_itests/
 passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
+whitelist_externals =
+    /bin/bash
 deps =
     docker-compose
 commands =
     docker-compose down
-    docker-compose --verbose build
+    docker-compose build
     docker-compose up -d mesosmaster mesosslave tronmaster
-    docker-compose run --rm tronmaster tox -i {env:PIP_INDEX_URL:https://pypi.python.org/simple} -e tron_itests_inside_container -- --no-capture {posargs}
+    bash -c "docker-compose run --rm tronmaster tox -i {env:PIP_INDEX_URL:https://pypi.python.org/simple} -e tron_itests_inside_container -- --no-capture {posargs} || (docker-compose logs && exit 1)"
     docker-compose stop
     docker-compose rm --force
 


### PR DESCRIPTION
Also it prints the logs now on failure for debugging.
And now also has a tronctl helper for the future.

In the mid term, I don't want tron to have to "wait" for a task to be launched before connecting to mesos, I think that should happen at the same time the reactor starts, do reconciliation, etc. But we'll get there.