### PR TITLE
[WIP] Put the paasta command equivalent into an actionrun output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ debian/tron.postinst.debhelper
 debian/tron.postrm.debhelper
 debian/tron.prerm.debhelper
 debian/debhelper-build-stamp
+
+# Dev pg stuff
+dev/tron_state
+dev/tron.pid

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ itest_%: test_in_docker_% debitest_%
 cluster_itests:
 	tox -e cluster_itests
 
-dev:
+dev: coffee_xenial
 	.tox/py36/bin/trond --debug --working-dir=dev -l logging.conf --host=$(shell hostname -f)
 
 example_cluster:

--- a/dev/config/MASTER.yaml
+++ b/dev/config/MASTER.yaml
@@ -13,3 +13,4 @@ jobs:
       actions:
         - name: "first"
           command: "echo hi"
+          docker_image: 'https://docker-dev.yelpcorp.com/paasta-foo'

--- a/tron/api/adapter.py
+++ b/tron/api/adapter.py
@@ -108,6 +108,7 @@ class ActionRunAdapter(RunAdapter):
         'node',
         'command',
         'raw_command',
+        'paasta_command',
         'requirements',
         'stdout',
         'stderr',
@@ -134,6 +135,9 @@ class ActionRunAdapter(RunAdapter):
 
     def get_raw_command(self):
         return self._obj.bare_command
+
+    def get_paasta_command(self):
+        return self._obj.paasta_command
 
     def get_command(self):
         return self._obj.rendered_command

--- a/tron/commands/display.py
+++ b/tron/commands/display.py
@@ -348,6 +348,7 @@ class DisplayActionRuns(TableDisplay):
         ('Node', 'node'),
         ('Command', 'command'),
         ('Bare command', 'raw_command'),
+        ('Paasta command', 'paasta_command'),
         ('Start time', 'start_time'),
         ('End time', 'end_time'),
         ('Final exit status', 'exit_status'),

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -508,6 +508,18 @@ class ActionRun(object):
         return self.rendered_command
 
     @property
+    def paasta_command(self):
+        if self.docker_image is None:
+            return "N/A"
+        service = parse_service_from_docker_image(self.docker_image)
+        # TODO
+        job_name = 'unknown'
+        instance = f"{job_name}.{self.action_name}"
+        # TODO
+        cluster = 'unknown'
+        return f"paasta local-run --service {service} --instance {instance} --cluster={cluster} --command {self.command}"
+
+    @property
     def is_valid_command(self):
         """Returns True if the bare_command was rendered without any errors.
         This has the side effect of actually rendering the bare_command.
@@ -887,3 +899,7 @@ class ActionRunCollection(object):
 
     def get(self, name):
         return self.run_map.get(name)
+
+
+def parse_service_from_docker_image(docker_image):
+    return 'unknown'

--- a/tronweb/coffee/actionrun.coffee
+++ b/tronweb/coffee/actionrun.coffee
@@ -118,6 +118,7 @@ class module.ActionRunListEntryView extends ClickableListEntry
             <%= formatName(action_name) %></a></td>
         <td><%= formatState(state) %></td>
         <td><code class="command"><%= command || raw_command %></code></td>
+        <td><code class="command"><%= paasta_command %></code></td>
         <td><%= displayNode(node) %></td>
         <td><%= dateFromNow(start_time, "None") %></td>
         <td><%= dateFromNow(end_time, "") %></td>
@@ -174,6 +175,8 @@ class module.ActionRunView extends Backbone.View
                     <tr><td>Command</td>
                         <td><code class="command"><%= command %></code></td></tr>
                     <% } %>
+                    <tr><td>Paasta command</td>
+                        <td><code class="command"><%= paasta_command %></code></td></tr>
                     <tr><td>Exit codes</td>
                         <td>
                             <%= modules.actionrun.formatExit(exit_status) %>


### PR DESCRIPTION
I want users to be able to run their (paasta) action commands outside of tron if they need to. I thought it would be nice to provide them with a command they can copy/paste edit.

However, because of the way we have designed this (strong separation of concerns) this actionrun object doesn't "know" anything about the service/instance/cluster, heck I don't even think it knows what job it is part of?

Any suggestions on what to do here? Fundamentally I think we want to keep "tron" from "knowing" too much about paasta, but for this (nice to have) feature... it kinda has to know.