### PR TITLE
Deprecate --nodaemon option

### DIFF
--- a/bin/trond
+++ b/bin/trond
@@ -51,7 +51,7 @@ def parse_cli():
         "--nodaemon",
         action="store_true",
         default=False,
-        help="Disable daemonizing, default %(default)s",
+        help="[DEPRECATED] Disable daemonizing, default %(default)s",
     )
 
     parser.add_argument(
@@ -129,9 +129,6 @@ def parse_cli():
         args.working_dir,
         args.config_path,
     )
-
-    if args.debug:
-        args.nodaemon = True
 
     return args
 

--- a/bin/tronrepl
+++ b/bin/tronrepl
@@ -53,7 +53,7 @@ def parse_cli():
         "--nodaemon",
         action="store_true",
         default=False,
-        help="Disable daemonizing, default %(default)s",
+        help="[DEPRECATED] Disable daemonizing, default %(default)s",
     )
 
     parser.add_argument(
@@ -131,9 +131,6 @@ def parse_cli():
         args.working_dir,
         args.config_path,
     )
-
-    if args.debug:
-        args.nodaemon = True
 
     return args
 

--- a/debian/tron.upstart
+++ b/debian/tron.upstart
@@ -15,5 +15,5 @@ script
       log_failure_msg "and then set RUN to 'yes' in /etc/default/$NAME to enable it."
       exit 0
   fi
-  exec start-stop-daemon --start -c $DAEMONUSER --exec /usr/bin/trond -- --nodaemon $DAEMON_OPTS
+  exec start-stop-daemon --start -c $DAEMONUSER --exec /usr/bin/trond -- $DAEMON_OPTS
 end script

--- a/docs/man/trond.8
+++ b/docs/man/trond.8
@@ -61,7 +61,7 @@ Verbose logging
 Debug mode, extra error reporting, no daemonizing
 .TP
 .B \fB\-\-nodaemon\fP
-Indicates we should not fork and daemonize the process (default False)
+(DEPRECATED in 0.9.4) Indicates we should not fork and daemonize the process (default False)
 .TP
 .B \fB\-\-pid\-file=PIDFILE\fP
 Where to store pid of the executing process (default /var/run/tron.pid)
@@ -97,7 +97,7 @@ Does some cleanup before shutting down.
 Reload the configuration file.
 .TP
 .B \fISIGUSR1\fP
-If running with \fB\-\-nodaemon\fP will drop into an ipdb debugging prompt.
+Will drop into an ipdb debugging prompt.
 .UNINDENT
 .SH LOGGING
 .sp

--- a/docs/man_trond.rst
+++ b/docs/man_trond.rst
@@ -38,7 +38,7 @@ Options
     Debug mode, extra error reporting, no daemonizing
 
 ``--nodaemon``
-    Indicates we should not fork and daemonize the process (default False)
+    [DEPRECATED in 0.9.4] Indicates we should not fork and daemonize the process (default False)
 
 ``--pid-file=PIDFILE``
     Where to store pid of the executing process (default /var/run/tron.pid)
@@ -75,7 +75,7 @@ Signals
     Reload the configuration file.
 
 `SIGUSR1`
-    If running with ``--nodaemon`` will drop into an ipdb debugging prompt.
+    Will drop into an ipdb debugging prompt.
 
 Logging
 -------

--- a/example-cluster/start.sh
+++ b/example-cluster/start.sh
@@ -28,7 +28,6 @@ FAKETIME_X=${FAKETIME_X:-10}
 exec faketime -f "+0.0y x$FAKETIME_X" \
   trond \
     -l logging.conf \
-    --nodaemon \
     --working-dir=/nail/tron \
     -v \
     --host 0.0.0.0

--- a/itest.sh
+++ b/itest.sh
@@ -29,7 +29,7 @@ export TRON_WORKDIR=/nail/tron
 mkdir -p $TRON_WORKDIR
 export TRON_START_TIME=$(date +%s)
 
-trond --nodaemon --working-dir=$TRON_WORKDIR &
+trond --working-dir=$TRON_WORKDIR &
 TRON_PID=$!
 
 for i in {1..5}; do

--- a/tests/trondaemon_test.py
+++ b/tests/trondaemon_test.py
@@ -71,7 +71,6 @@ class TronDaemonTestCase(TestCase):
     def setup(self):
         self.tmpdir = tempfile.TemporaryDirectory()
         trond_opts = mock.Mock()
-        trond_opts.nodaemon = True
         trond_opts.working_dir = self.tmpdir.name
         trond_opts.pid_file = os.path.join(self.tmpdir.name, "pidfile")
         self.trond = TronDaemon(trond_opts)


### PR DESCRIPTION
We're only using NoDaemonContext anyway, also:

- move debug handler to MCP class where signal loop lives
- keep manhole.sock path in MCP's attribute
- set pthread mask on every iteration in signal loop
- more logging
