### PR TITLE
Remove enableall and disableall from JobCollections in tron controller

### DIFF
--- a/tests/api/controller_test.py
+++ b/tests/api/controller_test.py
@@ -13,6 +13,7 @@ from tron import mcp
 from tron.api import controller
 from tron.api.controller import ConfigController
 from tron.api.controller import JobCollectionController
+from tron.api.controller import UnknownCommandError
 from tron.config import config_parse
 from tron.config import ConfigError
 from tron.config import manager
@@ -31,13 +32,10 @@ class TestJobCollectionController(TestCase):
         )
         self.controller = JobCollectionController(self.collection)
 
-    def test_handle_command_enabled(self):
-        self.controller.handle_command('enableall')
-        self.collection.enable.assert_called_with()
-
-    def test_handle_command_disable(self):
-        self.controller.handle_command('disableall')
-        self.collection.disable.assert_called_with()
+    def test_handle_command_unknown(self):
+        with self.assertRaises(UnknownCommandError):
+            self.controller.handle_command('enableall')
+            self.controller.handle_command('disableall')
 
 
 class TestActionRunController(TestCase):

--- a/tron/api/controller.py
+++ b/tron/api/controller.py
@@ -25,14 +25,7 @@ class JobCollectionController(object):
         self.job_collection = job_collection
 
     def handle_command(self, command):
-        if command == 'disableall':
-            self.job_collection.disable()
-            return "Disabled all jobs."
-
-        if command == 'enableall':
-            self.job_collection.enable()
-            return "Enabled all jobs."
-
+        # No commands to handle, enableall/disableall have been deprecated
         raise UnknownCommandError("Unknown command %s" % command)
 
 


### PR DESCRIPTION
### Description:
- @solarkennedy previously removed enableall/disableall from tronctl when he added the backfill command, but there was some related code in the api controller that was left behind, which I have now also removed.
- Note that the JobCollectionController can no longer handle any commands.
- The controller's tests have been updated to check that any command received will raise an UnknownCommandError.

### Testing done:
- pytest on the updated controller tests