### PR TITLE
Increase upstart timeout

### DIFF
--- a/debian/tron.upstart
+++ b/debian/tron.upstart
@@ -4,6 +4,7 @@ start on filesystem and (started networking)
 stop on shutdown
 
 respawn
+kill timeout 20
 
 script
   set -a

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -496,9 +496,6 @@ class MesosCluster:
         self.queue = PyDeferredQueue()
 
         for key, task in list(self.tasks.items()):
-            task.log.warning(
-                'Still running during Mesos shutdown, becoming unknown'
-            )
             task.exited(None)
             del self.tasks[key]
 


### PR DESCRIPTION
The `runner.stop()` call was the actual problem, I timed it and it takes up to 10 sec. The upstart default is 5 sec.

But I also took out the extra logging, which writes to the task's stderr file, since I don't think it's really necessary with reconciliation and it could increase the time as well.