### PR TITLE
Better feedback on killing Mesos actions if not running

### DIFF
--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -1048,6 +1048,8 @@ class TestMesosActionRun(TestCase):
     def test_kill_task(self, mock_cluster_repo):
         mock_get_cluster = mock_cluster_repo.get_cluster
         self.action_run.mesos_task_id = 'fake_task_id'
+        self.action_run.machine.state = ActionRun.STATE_RUNNING
+
         error_message = self.action_run.kill()
         mock_get_cluster.return_value.kill.assert_called_once_with(
             self.action_run.mesos_task_id
@@ -1059,6 +1061,14 @@ class TestMesosActionRun(TestCase):
 
     @mock.patch('tron.core.actionrun.MesosClusterRepository', autospec=True)
     def test_kill_task_not_running(self, mock_cluster_repo):
+        mock_get_cluster = mock_cluster_repo.get_cluster
+        self.action_run.machine.state = ActionRun.STATE_SUCCEEDED
+        assert 'not running' in self.action_run.kill()
+        assert mock_get_cluster.return_value.kill.call_count == 0
+
+    @mock.patch('tron.core.actionrun.MesosClusterRepository', autospec=True)
+    def test_kill_task_no_task_id(self, mock_cluster_repo):
+        self.action_run.machine.state = ActionRun.STATE_RUNNING
         error_message = self.action_run.kill()
         assert_equal(
             error_message, "Error: Can't find task id for the action."
@@ -1068,6 +1078,8 @@ class TestMesosActionRun(TestCase):
     def test_stop_task(self, mock_cluster_repo):
         mock_get_cluster = mock_cluster_repo.get_cluster
         self.action_run.mesos_task_id = 'fake_task_id'
+        self.action_run.machine.state = ActionRun.STATE_RUNNING
+
         self.action_run.stop()
         mock_get_cluster.return_value.kill.assert_called_once_with(
             self.action_run.mesos_task_id
@@ -1075,6 +1087,14 @@ class TestMesosActionRun(TestCase):
 
     @mock.patch('tron.core.actionrun.MesosClusterRepository', autospec=True)
     def test_stop_task_not_running(self, mock_cluster_repo):
+        mock_get_cluster = mock_cluster_repo.get_cluster
+        self.action_run.machine.state = ActionRun.STATE_SUCCEEDED
+        assert 'not running' in self.action_run.stop()
+        assert mock_get_cluster.return_value.kill.call_count == 0
+
+    @mock.patch('tron.core.actionrun.MesosClusterRepository', autospec=True)
+    def test_stop_task_no_task_id(self, mock_cluster_repo):
+        self.action_run.machine.state = ActionRun.STATE_RUNNING
         error_message = self.action_run.stop()
         assert_equal(
             error_message, "Error: Can't find task id for the action."

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv =
 usedevelop = true
 passenv = USER
 commands =
-    py.test -s
+    py.test -s {posargs:tests}
     pre-commit install -f --install-hooks
     pre-commit run --all-files
 

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -721,6 +721,9 @@ class MesosActionRun(ActionRun, Observer):
         return task
 
     def stop(self):
+        if not self.is_active:
+            return f'Action is {self.state}, not running.'
+
         if self.retries_remaining is not None:
             self.retries_remaining = -1
 
@@ -730,6 +733,9 @@ class MesosActionRun(ActionRun, Observer):
         return self._kill_mesos_task()
 
     def kill(self, final=True):
+        if not self.is_active:
+            return f'Action is {self.state}, not running.'
+
         if self.retries_remaining is not None and final:
             self.retries_remaining = -1
 


### PR DESCRIPTION
If the task hasn't started or is already done, the "Can't find task id" message is kind of confusing.