### PR TITLE
Scheme optional for Mesos master address

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 
 import mock
+import pytest
 import pytz
 
 from testifycompat import assert_equal
@@ -1426,6 +1427,35 @@ class TestValidateVolume(TestCase):
             mesos_options,
             self.context,
         )
+
+
+class TestValidMasterAddress:
+
+    @pytest.fixture
+    def context(self):
+        return config_utils.NullConfigContext
+
+    @pytest.mark.parametrize('url', [
+        'http://blah.com',
+        'http://blah.com/',
+        'blah.com',
+        'blah.com/',
+    ])
+    def test_valid(self, url, context):
+        normalized = 'http://blah.com'
+        result = config_parse.valid_master_address(url, context)
+        assert result == normalized
+
+    @pytest.mark.parametrize('url', [
+        'https://blah.com',
+        'http://blah.com/something',
+        'blah.com/other',
+        'http://',
+        'blah.com?a=1',
+    ])
+    def test_invalid(self, url, context):
+        with pytest.raises(ConfigError):
+            config_parse.valid_master_address(url, context)
 
 
 if __name__ == '__main__':

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 def get_mesos_leader(master_address, mesos_master_port):
-    url = "http://%s:%s/redirect" % (master_address, mesos_master_port)
+    url = "%s:%s/redirect" % (master_address, mesos_master_port)
     response = requests.get(url)
     return '{}:{}'.format(urlparse(response.url).hostname, mesos_master_port)
 


### PR DESCRIPTION
This was failing to connect if the address already had http in it, e.g. 'http://leader.yelp'. 
I wanted to make it more flexible, so that `http` was optional, and it could end in a `/` without breaking things.

The logic turned out to be more complicated than I thought, but the test cases should cover it.