### PR TITLE
Fix: restarting tron will restore outdated scheduled jobs

### DIFF
--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -340,7 +340,10 @@ class JobScheduler(Observer):
         # also possible this job was run (or is running) manually by a user.
         # Alternatively, if run_queued is True, this job_run is already queued.
         if not run_queued and not job_run.is_scheduled:
-            log.info(f"Scheduling {job_run} in state {job_run.state}")
+            log.info(
+                f"{job_run} in state {job_run.state} is not scheduled, "
+                "scheduling a new run instead of running"
+            )
             return self.schedule()
 
         node = job_run.node if self.job.all_nodes else None

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import datetime
 import logging
 
 import humanize
@@ -288,6 +287,8 @@ class JobScheduler(Observer):
     def create_and_schedule_runs(self, ignore_last_run_time=False):
         for job_run in self.get_runs_to_schedule(ignore_last_run_time):
             self._set_callback(job_run)
+        # Eagerly save new runs in case tron gets restarted
+        self.job.notify(Job.NOTIFY_STATE_CHANGE)
 
     def disable(self):
         """Disable the job and cancel and pending scheduled jobs."""
@@ -319,13 +320,8 @@ class JobScheduler(Observer):
     def _set_callback(self, job_run):
         """Set a callback for JobRun to fire at the appropriate time."""
         seconds = job_run.seconds_until_run_time()
-        human_time = humanize.naturaltime(datetime.timedelta(seconds=seconds))
-        log.info(
-            "Scheduling next Jobrun for %s about %s from now (%d seconds)",
-            self.job.name,
-            human_time,
-            seconds,
-        )
+        human_time = humanize.naturaltime(seconds, future=True)
+        log.info(f"Scheduling {job_run} {human_time} ({seconds} seconds)")
         eventloop.call_later(seconds, self.run_job, job_run)
 
     # TODO: new class for this method
@@ -336,7 +332,7 @@ class JobScheduler(Observer):
         # If the Job has been disabled after this run was scheduled, then cancel
         # the JobRun and do not schedule another
         if not self.job.enabled:
-            log.info("%s cancelled because job has been disabled." % job_run)
+            log.info(f"Cancelled {job_run} because job has been disabled.")
             return job_run.cancel()
 
         # If the JobRun was cancelled we won't run it.  A JobRun may be
@@ -344,12 +340,7 @@ class JobScheduler(Observer):
         # also possible this job was run (or is running) manually by a user.
         # Alternatively, if run_queued is True, this job_run is already queued.
         if not run_queued and not job_run.is_scheduled:
-            log.info(
-                "%s in state %s already out of scheduled state." % (
-                    job_run,
-                    job_run.state,
-                )
-            )
+            log.info(f"Scheduling {job_run} in state {job_run.state}")
             return self.schedule()
 
         node = job_run.node if self.job.all_nodes else None
@@ -370,10 +361,10 @@ class JobScheduler(Observer):
 
     def _queue_or_cancel_active(self, job_run):
         if self.job.queueing:
-            log.info("%s still running, queueing %s." % (self.job, job_run))
+            log.info(f"{self.job} still running, queueing {job_run}")
             return job_run.queue()
 
-        log.info("%s still running, cancelling %s." % (self.job, job_run))
+        log.info(f"{self.job} still running, cancelling {job_run}")
         job_run.cancel()
         self.schedule()
 
@@ -402,7 +393,7 @@ class JobScheduler(Observer):
     def get_runs_to_schedule(self, ignore_last_run_time):
         """Build and return the runs to schedule."""
         if self.job.runs.has_pending:
-            log.info("%s has pending runs, can't schedule more." % self.job)
+            log.info(f"{self.job} has pending runs, can't schedule more.")
             return []
 
         if ignore_last_run_time:
@@ -414,7 +405,7 @@ class JobScheduler(Observer):
         return self.job.build_new_runs(next_run_time)
 
     def __str__(self):
-        return "%s(%s)" % (self.__class__.__name__, self.job)
+        return f"{self.__class__.__name__}({self.job})"
 
     def get_name(self):
         return self.job.name
@@ -442,7 +433,7 @@ class JobSchedulerFactory(object):
         self.action_runner = action_runner
 
     def build(self, job_config):
-        log.debug("Building new job %s", job_config.name)
+        log.debug(f"Building new job {job_config.name}")
         output_path = filehandler.OutputPath(self.output_stream_dir)
         time_zone = job_config.time_zone or self.time_zone
         scheduler = scheduler_from_config(job_config.schedule, time_zone)
@@ -490,7 +481,7 @@ class JobCollection(object):
         return self.jobs.add(job_scheduler, self.update)
 
     def update(self, new_job_scheduler):
-        log.info("Updating %s", new_job_scheduler)
+        log.info(f"Updating {new_job_scheduler}")
         job_scheduler = self.get_by_name(new_job_scheduler.get_name())
         job_scheduler.get_job().update_from_job(new_job_scheduler.get_job())
         job_scheduler.schedule_reconfigured()
@@ -499,7 +490,7 @@ class JobCollection(object):
     def restore_state(self, job_state_data, config_action_runner):
         for name, state in job_state_data.items():
             self.jobs[name].restore_state(state, config_action_runner)
-        log.info("Loaded state for %d jobs", len(job_state_data))
+        log.info(f"Loaded state for {len(job_state_data)} jobs")
 
     def get_by_name(self, name):
         return self.jobs.get(name)

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -342,16 +342,8 @@ class JobRunCollection(object):
         and return it.
         """
         run_num = self.next_run_num()
-        log.info(
-            "Building JobRun %s for %s on %s at %s" % (
-                run_num,
-                job,
-                node,
-                run_time,
-            )
-        )
-
         run = JobRun.for_job(job, run_num, run_time, node, manual)
+        log.info(f"Created {run} on {node.name} at {run_time}")
         self.runs.appendleft(run)
         self.remove_old_runs()
         return run

--- a/tron/mcp.py
+++ b/tron/mcp.py
@@ -50,9 +50,9 @@ class MasterControlProgram(object):
             self._load_config(reconfigure=True)
         except Exception as e:
             log.exception(
-                "reconfigure failure: %s: %s" % (e.__class__.__name__, e)
+                f"reconfigure failure: {e.__class__.__name__}: {e}"
             )
-            raise
+            raise e
 
     def _load_config(self, reconfigure=False):
         """Read config data and apply it."""

--- a/tron/serialize/runstate/statemanager.py
+++ b/tron/serialize/runstate/statemanager.py
@@ -179,7 +179,10 @@ class PersistentStateManager(object):
         """Persist an items state."""
         key = self._impl.build_key(type_enum, name)
         log.debug("Buffering state save for: %s", key)
-        if self._buffer.save(key, state_data) and self.enabled:
+        if self._buffer.save(key, state_data):
+            if not self.enabled:
+                log.debug(f"State manager disabled, not persisting {key}")
+                return
             self._save_from_buffer()
 
     def _save_from_buffer(self):


### PR DESCRIPTION
When jobs are reconfigured and new runs are created, they don't trigger STATE_CHANGED handlers. If tron is restarted with such scheduled jobs, they will not be restored and older runs with stale config may be restored instead.

In this PR:

- eagerly save new scheduled runs
- f-stringify some log messages