### PR TITLE
Make fail final and move retries and exit logic out

### DIFF
--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -335,7 +335,7 @@ class ActionRun(object):
         if run.is_running:
             run._done('fail_unknown')
         if run.is_starting:
-            run.fail(None)
+            run._exit_unsuccessful(None)
         return run
 
     def start(self):
@@ -403,7 +403,7 @@ class ActionRun(object):
             self.retries_remaining = 1
 
         if self.is_done:
-            return self.fail(self.exit_status)
+            return self._exit_unsuccessful(self.exit_status)
         else:
             log.info(f"Killing action run {self.id} for a retry")
             return self.kill(final=False)
@@ -427,7 +427,13 @@ class ActionRun(object):
             self.machine.reset()
             return self.start()
 
-    def fail(self, exit_status=0):
+    def fail(self, exit_status=None):
+        if self.retries_remaining:
+            self.retries_remaining = -1
+
+        return self._done('fail', exit_status)
+
+    def _exit_unsuccessful(self, exit_status=None):
         if self.retries_remaining is not None:
             if self.retries_remaining > 0:
                 self.retries_remaining -= 1
@@ -439,8 +445,7 @@ class ActionRun(object):
                         len(self.exit_statuses),
                     )
                 )
-
-        return self._done('fail', exit_status)
+        return self.fail(exit_status)
 
     def success(self):
         return self._done('success')
@@ -581,7 +586,7 @@ class SSHActionRun(ActionRun, Observer):
             self.node.submit_command(action_command)
         except node.Error as e:
             log.warning("Failed to start %s: %r", self.id, e)
-            self.fail(-2)
+            self._exit_unsuccessful(-2)
             return
         return True
 
@@ -630,7 +635,7 @@ class SSHActionRun(ActionRun, Observer):
             return self.machine.transition('started')
 
         if event == ActionCommand.FAILSTART:
-            return self.fail(None)
+            return self._exit_unsuccessful(None)
 
         if event == ActionCommand.EXITING:
             if action_command.exit_status is None:
@@ -639,7 +644,7 @@ class SSHActionRun(ActionRun, Observer):
             if not action_command.exit_status:
                 return self.success()
 
-            return self.fail(action_command.exit_status)
+            return self._exit_unsuccessful(action_command.exit_status)
 
     handler = handle_action_command_state_change
 
@@ -721,9 +726,6 @@ class MesosActionRun(ActionRun, Observer):
         return task
 
     def stop(self):
-        if not self.is_active:
-            return f'Action is {self.state}, not running.'
-
         if self.retries_remaining is not None:
             self.retries_remaining = -1
 
@@ -733,27 +735,31 @@ class MesosActionRun(ActionRun, Observer):
         return self._kill_mesos_task()
 
     def kill(self, final=True):
-        if not self.is_active:
-            return f'Action is {self.state}, not running.'
-
         if self.retries_remaining is not None and final:
             self.retries_remaining = -1
 
         if self.cancel_delay():
             return
 
-        error_message = self._kill_mesos_task()
-        if error_message is not None:
-            return error_message
-        return "Warning: It might take up to docker_stop_timeout (current setting is 2 mins) for killing."
+        return self._kill_mesos_task()
 
     def _kill_mesos_task(self):
+        msgs = []
+        if not self.is_active:
+            msgs.append(f'Action is {self.state}, not running. Continuing anyway.')
+
         mesos_cluster = MesosClusterRepository.get_cluster()
         if self.mesos_task_id is None:
-            return "Error: Can't find task id for the action."
-        succeeded = mesos_cluster.kill(self.mesos_task_id)
-        if not succeeded:
-            return "Error while killing task. Please try again."
+            msgs.append("Error: Can't find task id for the action.")
+        else:
+            msgs.append(f"Sending kill for {self.mesos_task_id}...")
+            succeeded = mesos_cluster.kill(self.mesos_task_id)
+            if succeeded:
+                msgs.append("Sent! It can take up to docker_stop_timeout (current setting is 2 mins) to stop.")
+            else:
+                msgs.append("Error while sending kill request. Please try again.")
+
+        return '\n'.join(msgs)
 
     def handle_action_command_state_change(self, action_command, event):
         """Observe ActionCommand state changes."""
@@ -764,7 +770,7 @@ class MesosActionRun(ActionRun, Observer):
             return self.machine.transition('started')
 
         if event == ActionCommand.FAILSTART:
-            return self.fail(None)
+            return self._exit_unsuccessful(None)
 
         if event == ActionCommand.EXITING:
             if action_command.exit_status is None:
@@ -773,7 +779,7 @@ class MesosActionRun(ActionRun, Observer):
             if not action_command.exit_status:
                 return self.success()
 
-            return self.fail(action_command.exit_status)
+            return self._exit_unsuccessful(action_command.exit_status)
 
     handler = handle_action_command_state_change
 


### PR DESCRIPTION
If someone uses `tronctl fail` on an action with retries, even if that action hasn't started yet, it will trigger restarts. So I've made fail move straight to the failed state, and replaced `fail` with `_exit_unsuccessful` everywhere we want to consider retries.

I also took back my change in https://github.com/Yelp/Tron/pull/522 so that you can still send kill requests to Mesos even if Tron thinks it's not running - for instance, if you manually failed it.

Internal ticket TRON-438.