### PR TITLE
replace colon by pound for format string

### DIFF
--- a/docs/command_context.rst
+++ b/docs/command_context.rst
@@ -67,4 +67,4 @@ Context variables only available to Jobs
 **last_success**
     The last successful run date (defaults to current date if there was no
     previous successful run). Supports date arithmetic using the form
-    ``%(last_success:shortdate-1)s``.
+    ``%(last_success#shortdate-1)s``.

--- a/tests/command_context_test.py
+++ b/tests/command_context_test.py
@@ -152,19 +152,19 @@ class TestJobContext(TestCase):
         assert_equal(self.context.name, self.job.name)
 
     def test__getitem__last_success(self):
-        item = self.context["last_success:day-1"]
+        item = self.context["last_success#day-1"]
         expected_date = self.last_success.run_time - datetime.timedelta(days=1)
         assert_equal(item, str(expected_date.day))
 
-        item = self.context["last_success:shortdate"]
+        item = self.context["last_success#shortdate"]
         assert_equal(item, "2012-03-14")
 
     def test__getitem__last_success_bad_date_spec(self):
-        name = "last_success:beers-3"
+        name = "last_success#beers-3"
         assert_raises(KeyError, lambda: self.context[name])
 
     def test__getitem__last_success_bad_date_name(self):
-        name = "first_success:shortdate-1"
+        name = "first_success#shortdate-1"
         assert_raises(KeyError, lambda: self.context[name])
 
     def test__getitem__last_success_no_date_spec(self):
@@ -227,7 +227,7 @@ class TestFiller(TestCase):
     def test_filler_with_job__getitem__(self):
         context = command_context.JobContext(self.filler)
         todays_date = datetime.date.today().strftime("%Y-%m-%d")
-        assert_equal(context['last_success:shortdate'], todays_date)
+        assert_equal(context['last_success#shortdate'], todays_date)
 
     def test_filler_with_job_run__getitem__(self):
         context = command_context.JobRunContext(self.filler)

--- a/tron/command_context.py
+++ b/tron/command_context.py
@@ -106,7 +106,7 @@ class JobContext(object):
         raise KeyError(item)
 
     def _get_date_spec_parts(self, name):
-        parts = name.rsplit(':', 1)
+        parts = name.rsplit('#', 1)
         if len(parts) != 2:
             return name, None
         return parts


### PR DESCRIPTION
According to [this document ](https://docs.python.org/2/library/string.html#format-string-syntax), there is no way to escape colon for format strings. Hence, I would like to use the pound sign instead. If the change gets merged, users would use "%(last_success#shortdate)s" rather than "%(last_success:shortdate)s". I will comment out the old_format action at yelpsoa-config later.