### PR TITLE
Allow actions to be a dict instead of a list

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -211,9 +211,9 @@ def make_master_jobs():
                 expected_runtime=datetime.timedelta(1),
                 cleanup_action=None,
             ),
-        'MASTER.test_job3':
+        'MASTER.test_job_actions_dict':
             make_job(
-                name='MASTER.test_job3',
+                name='MASTER.test_job_actions_dict',
                 node='node1',
                 schedule=ConfigConstantScheduler(),
                 actions=FrozenDict({
@@ -347,19 +347,18 @@ class ConfigTestCase(TestCase):
                 actions=[dict(name="action2_0", command="test_command2.0")]
             ),
             dict(
-                name="test_job3",
+                name="test_job_actions_dict",
                 node='node1',
                 schedule="constant",
-                actions=[
-                    dict(name="action", command="command"),
-                    dict(name="action1", command="command"),
-                    dict(
-                        name="action2",
+                actions=dict(
+                    action=dict(command="command"),
+                    action1=dict(command="command"),
+                    action2=dict(
                         node='node0',
                         command="command",
                         requires=['action', 'action1']
                     )
-                ]
+                )
             ),
             dict(
                 name="test_job4",
@@ -408,7 +407,7 @@ class ConfigTestCase(TestCase):
         assert test_config.time_zone == expected.time_zone
         assert test_config.nodes == expected.nodes
         assert test_config.node_pools == expected.node_pools
-        for key in ['0', '1', '2', '3', '4', '_mesos']:
+        for key in ['0', '1', '2', '_actions_dict', '4', '_mesos']:
             job_name = f"MASTER.test_job{key}"
             assert job_name in test_config.jobs, f"{job_name} in test_config.jobs"
             assert job_name in expected.jobs, f"{job_name} in test_config.jobs"
@@ -1198,7 +1197,7 @@ class TestConfigContainer(TestCase):
         expected = [
             'test_job1',
             'test_job0',
-            'test_job3',
+            'test_job_actions_dict',
             'test_job2',
             'test_job4',
             'test_job_mesos',
@@ -1209,7 +1208,7 @@ class TestConfigContainer(TestCase):
         expected = [
             'test_job1',
             'test_job0',
-            'test_job3',
+            'test_job_actions_dict',
             'test_job2',
             'test_job4',
             'test_job_mesos',

--- a/tron/config/config_utils.py
+++ b/tron/config/config_utils.py
@@ -211,10 +211,13 @@ def build_list_of_type_validator(item_validator, allow_empty=False):
 
 
 def build_dict_name_validator(item_validator, allow_empty=False):
-    """Build a validator which validates a list, and returns a dict."""
+    """Build a validator which validates a list or dict, and returns a dict."""
     valid = build_list_of_type_validator(item_validator, allow_empty)
 
     def validator(value, config_context):
+        if isinstance(value, dict):
+            value = [{'name': name, **config} for name, config in value.items()]
+
         msg = "Duplicate name %%s at %s" % config_context.path
         name_dict = UniqueNameDict(msg)
         for item in valid(value, config_context):


### PR DESCRIPTION
For Mesos actions, it would be nice to have actions be a dict so we can use YAML anchors.
e.g.
```
actions:
  one: &template
    command: echo 1
    cpus: 0.1
    ...
  two:
    <<: *template
    command: echo 2
```  
rather than
```
actions:
  - name: one
    command: echo 1
    cpus: 0.1
    ...
  - name: two
    command: echo 2
    cpus: 0.1
    ...
``` 

Will also need to make changes to paasta_tools to allow dicts, if we like this change.