### PR TITLE
Add handlers check in MesosTask logger to prevent duplicate log lines

### DIFF
--- a/tests/mesos_test.py
+++ b/tests/mesos_test.py
@@ -254,11 +254,11 @@ class TestMesosTask(TestCase):
         Ensures that only a single handler (for stderr) is added to the
         MesosTask event logger, to prevent duplicate log output.
         """
-        log1 = self.task.get_event_logger()
-        log2 = self.task.get_event_logger()
+        # Call 2 times to make sure 2nd call doesn't add another handler
+        logger = self.task.get_event_logger()
+        logger = self.task.get_event_logger()
 
-        assert len(log1.handlers) == len(log2.handlers)
-        assert len(log2.handlers) == 1
+        assert len(logger.handlers) == 1
 
 
 class TestMesosCluster(TestCase):

--- a/tests/mesos_test.py
+++ b/tests/mesos_test.py
@@ -249,6 +249,17 @@ class TestMesosTask(TestCase):
             assert mock_log_event.called
         assert self.task.state == MesosTask.RUNNING
 
+    def test_get_event_logger_add_unique_handlers(self):
+        """
+        Ensures that only a single handler (for stderr) is added to the
+        MesosTask event logger, to prevent duplicate log output.
+        """
+        log1 = self.task.get_event_logger()
+        log2 = self.task.get_event_logger()
+
+        assert len(log1.handlers) == len(log2.handlers)
+        assert len(log2.handlers) == 1
+
 
 class TestMesosCluster(TestCase):
     @setup_teardown

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -138,6 +138,7 @@ class MesosTask(ActionCommand):
     def __init__(self, id, task_config, serializer=None):
         super(MesosTask, self).__init__(id, task_config.cmd, serializer)
         self.task_config = task_config
+
         self.log = self.get_event_logger()
         self.setup_output_logging()
 
@@ -150,9 +151,14 @@ class MesosTask(ActionCommand):
 
     def get_event_logger(self):
         log = logging.getLogger(__name__ + '.' + self.id)
-        handler = logging.StreamHandler(self.stderr)
-        handler.setFormatter(logging.Formatter(TASK_LOG_FORMAT))
-        log.addHandler(handler)
+        # Every time a task gets created, this function runs and will add
+        # more stderr handlers to the logger, which results in duplicate log
+        # output. We only want to add the stderr handler if the logger does not
+        # have a handler yet.
+        if not len(log.handlers):
+            handler = logging.StreamHandler(self.stderr)
+            handler.setFormatter(logging.Formatter(TASK_LOG_FORMAT))
+            log.addHandler(handler)
         return log
 
     def setup_output_logging(self):


### PR DESCRIPTION
# Description
- Bug (behavior): Retrying Mesos actions would produce duplicate log lines by the same number of retries attempted so far.
- Bug (code): Whenever a Mesos task was created and its logger initialized, it adds a handler to the logger to log output to stderr. Unfortunately, there was no check in place to prevent duplicate handlers from being added, so each task (retry) added another handler, producing another duplicate log output.
- Fix: Whenever we initialize a Mesos task, we check the number of handlers in the logger, and only add the stderr handler if there are no handlers present.
- Additional changes: Added a test for MesosTask's log initializer function to ensure only 1 handler is ever added to the logger.

# Testing done
- make dev