### PR TITLE
Remove to_timestamp method in favor of datetime.timestamp()

### DIFF
--- a/tests/utils/timeutils_test.py
+++ b/tests/utils/timeutils_test.py
@@ -15,29 +15,6 @@ from tron.utils.timeutils import duration
 from tron.utils.timeutils import macro_timedelta
 
 
-class TestToTimestamp(TestCase):
-    def test_normal_time_with_timezone(self):
-        # 62 minutes after the epoch
-        start_date = pytz.utc.localize(datetime.datetime(1970, 1, 1, 1, 2))
-        assert_equal(timeutils.to_timestamp(start_date), 62 * 60)
-
-    def test_ambiguous_times(self):
-        pacific_tz = pytz.timezone("US/Pacific")
-        before_fall_back = timeutils.to_timestamp(
-            pacific_tz.localize(
-                datetime.datetime(2017, 11, 5, 1, 23),
-                is_dst=True,
-            ),
-        )
-        after_fall_back = timeutils.to_timestamp(
-            pacific_tz.localize(
-                datetime.datetime(2017, 11, 5, 1, 23),
-                is_dst=False,
-            ),
-        )
-        assert_equal(after_fall_back - before_fall_back, 60 * 60)
-
-
 class TestTimeDelta(TestCase):
     @setup
     def make_dates(self):
@@ -269,15 +246,15 @@ class DateArithmeticTestCase(testingutils.MockTimeTestCase):
             self._cmp_year('year-%s' % i, dt)
 
     def test_unixtime(self):
-        timestamp = int(timeutils.to_timestamp(self.now))
+        timestamp = int(self.now.timestamp())
         assert_equal(DateArithmetic.parse('unixtime'), timestamp)
 
     def test_unixtime_plus(self):
-        timestamp = int(timeutils.to_timestamp(self.now)) + 100
+        timestamp = int(self.now.timestamp()) + 100
         assert_equal(DateArithmetic.parse('unixtime+100'), timestamp)
 
     def test_unixtime_minus(self):
-        timestamp = int(timeutils.to_timestamp(self.now)) - 99
+        timestamp = int(self.now.timestamp()) - 99
         assert_equal(DateArithmetic.parse('unixtime-99'), timestamp)
 
     def test_daynumber(self):

--- a/tron/utils/timeutils.py
+++ b/tron/utils/timeutils.py
@@ -5,8 +5,6 @@ from __future__ import unicode_literals
 
 import datetime
 import re
-import time
-from calendar import timegm
 
 
 def current_time(tz=None):
@@ -16,15 +14,7 @@ def current_time(tz=None):
 
 def current_timestamp():
     """Return the current time as a timestamp."""
-    return to_timestamp(current_time())
-
-
-def to_timestamp(time_val):
-    """Generate a unix timestamp for the given datetime instance"""
-    # TODO: replace with datetime.timestamp() after python3.6
-    if time_val.tzinfo:
-        return timegm(time_val.utctimetuple())
-    return time.mktime(time_val.utctimetuple())
+    return current_time().timestamp()
 
 
 def delta_total_seconds(td):
@@ -110,7 +100,7 @@ class DateArithmetic(object):
             return dt.strftime(cls.DATE_FORMATS[attr])
 
         if attr == 'unixtime':
-            return int(to_timestamp(dt)) + delta
+            return int(dt.timestamp()) + delta
 
         if attr == 'daynumber':
             return dt.toordinal() + delta


### PR DESCRIPTION
Tested manually to check that the behavior works as expected with and without timezones, but no unit tests because it's not our code anymore (yay!)

No timezone:
```
>>> import tron.utils.timeutils as timeutils
>>> timeutils.current_timestamp()
1537828767.0  # old value, an hour ahead
>>> timeutils.current_time().timestamp()
1537825185.666668  # new value
>>> 
(py36) qui@dev10-uswest1cdevc:~/work/Tron (010d171...) $ date +%s
1537825204  # a few seconds later, but new value is definitely correct
```

with timezone:
```
(py36) qui@dev10-uswest1cdevc:~/work/Tron (010d171...) $ python
Python 3.6.0 (default, Jan 13 2017, 00:00:00) 
[GCC 4.8.4] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pytz
>>> import tron.utils.timeutils as timeutils
>>> pacific_tz = pytz.timezone("US/Pacific")
>>> with_tz = pacific_tz.localize(timeutils.current_time())
>>> with_tz.tzinfo
<DstTzInfo 'US/Pacific' PDT-1 day, 17:00:00 DST>
>>> with_tz.timestamp()
1537825405.90734
>>> 
(py36) qui@dev10-uswest1cdevc:~/work/Tron (010d171...) $ date +%s
1537825427
```