### PR TITLE
Remove http stacktraces from tronview and tronctl error messages

### DIFF
--- a/bin/tronctl
+++ b/bin/tronctl
@@ -83,7 +83,7 @@ def parse_cli():
     )
     parser.add_argument(
         'id',
-        nargs='*',
+        nargs='+',
         help='job name, job run id, or action id',
     ).completer = cmd_utils.tron_jobs_completer
 
@@ -102,7 +102,7 @@ def edit(args, uri):
     response = client.request(uri, data=data)
 
     if response.error:
-        log.error(response.content)
+        print(f'Error: {response.content}')
         return
 
     print(response.content['result'])
@@ -163,11 +163,6 @@ def main():
 
     if args.command == "backfill":
         sys.exit(backfill(args))
-    elif not args.id:
-        # our only non-object commands are for enabling and disabling jobs, so
-        # just direct those commands here
-        if not edit(args, client.get_job_url('')):
-            sys.exit(ExitCode.fail)
     else:
         if not all(control_objects(args)):
             sys.exit(ExitCode.fail)

--- a/bin/tronview
+++ b/bin/tronview
@@ -99,8 +99,7 @@ def view_job_run(args, job_run_id, client):
     try:
         actions = client.job_runs(job_run_id.url)
     except RequestError as e:
-        response = e.args[1]
-        raise SystemExit(f"Error: {response.content}")
+        raise SystemExit(f"Error: {e}")
 
     display_action = display.DisplayActionRuns()
     return display_action.format(actions)
@@ -113,8 +112,7 @@ def view_action_run(args, act_run_id, client):
             num_lines=args.num_displays,
         )
     except RequestError as e:
-        response = e.args[1]
-        raise SystemExit(f"Error: {response.content}")
+        raise SystemExit(f"Error: {e}")
 
     return display.format_action_run_details(content)
 

--- a/bin/tronview
+++ b/bin/tronview
@@ -12,6 +12,7 @@ from tron.commands import cmd_utils
 from tron.commands import display
 from tron.commands.client import Client
 from tron.commands.client import get_object_type_from_identifier
+from tron.commands.client import RequestError
 from tron.commands.client import TronObjectType
 from tron.commands.cmd_utils import ExitCode
 from tron.commands.cmd_utils import suggest_possibilities
@@ -95,16 +96,26 @@ def view_job(args, job_id, client):
 
 
 def view_job_run(args, job_run_id, client):
-    actions = client.job_runs(job_run_id.url)
+    try:
+        actions = client.job_runs(job_run_id.url)
+    except RequestError as e:
+        response = e.args[1]
+        raise SystemExit(f"Error: {response.content}")
+
     display_action = display.DisplayActionRuns()
     return display_action.format(actions)
 
 
 def view_action_run(args, act_run_id, client):
-    content = client.action_runs(
-        act_run_id.url,
-        num_lines=args.num_displays,
-    )
+    try:
+        content = client.action_runs(
+            act_run_id.url,
+            num_lines=args.num_displays,
+        )
+    except RequestError as e:
+        response = e.args[1]
+        raise SystemExit(f"Error: {response.content}")
+
     return display.format_action_run_details(content)
 
 

--- a/bin/tronview
+++ b/bin/tronview
@@ -96,24 +96,16 @@ def view_job(args, job_id, client):
 
 
 def view_job_run(args, job_run_id, client):
-    try:
-        actions = client.job_runs(job_run_id.url)
-    except RequestError as e:
-        raise SystemExit(f"Error: {e}")
-
+    actions = client.job_runs(job_run_id.url)
     display_action = display.DisplayActionRuns()
     return display_action.format(actions)
 
 
 def view_action_run(args, act_run_id, client):
-    try:
-        content = client.action_runs(
-            act_run_id.url,
-            num_lines=args.num_displays,
-        )
-    except RequestError as e:
-        raise SystemExit(f"Error: {e}")
-
+    content = client.action_runs(
+        act_run_id.url,
+        num_lines=args.num_displays,
+    )
     return display.format_action_run_details(content)
 
 
@@ -137,7 +129,11 @@ def get_view_output(name, args, client):
 
     if tron_id.type not in obj_type_to_view_map:
         return
-    return obj_type_to_view_map[tron_id.type](args, tron_id, client)
+
+    try:
+        return obj_type_to_view_map[tron_id.type](args, tron_id, client)
+    except RequestError as e:
+        raise SystemExit(f"Error: {e}")
 
 
 def main():

--- a/tests/api/resource_test.py
+++ b/tests/api/resource_test.py
@@ -77,14 +77,14 @@ class TestHandleCommand(TestCase):
         command = 'the command'
         request = build_request(command=command)
         mock_controller, obj = mock.Mock(), mock.Mock()
-        error = controller.UnknownCommandError("No")
+        error = controller.UnknownCommandError()
         mock_controller.handle_command.side_effect = error
         response = www.handle_command(request, mock_controller, obj)
         mock_controller.handle_command.assert_called_with(command)
         assert_equal(response, self.respond.return_value)
         self.respond.assert_called_with(
             request,
-            {'error': str(error)},
+            {'error': f"Unknown command '{command}' for '{obj}'"},
             code=http.NOT_IMPLEMENTED,
         )
 

--- a/tests/commands/client_test.py
+++ b/tests/commands/client_test.py
@@ -15,6 +15,7 @@ from tests.assertions import assert_raises
 from tests.testingutils import autospec_method
 from tron.commands import client
 from tron.commands.client import get_object_type_from_identifier
+from tron.commands.client import Response
 from tron.commands.client import TronObjectType
 
 
@@ -103,12 +104,19 @@ class TestClientRequest(TestCase):
             yield
 
     def test_request_error(self):
+        error_response = Response(
+            error='404',
+            msg='Not Found',
+            content='big kahuna error'
+        )
+        client.request = mock.Mock(return_value=error_response)
         exception = assert_raises(
             client.RequestError,
             self.client.request,
             '/jobs',
         )
-        assert_in(self.url, str(exception))
+
+        assert str(exception) == error_response.content
 
     def test_request_success(self):
         ok_response = {'ok': 'ok'}

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -155,8 +155,8 @@ class JobRunResource(resource.Resource):
             action_run = self.job_run.action_runs[action_name]
             return ActionRunResource(action_run, self.job_run)
 
-        msg = "Cannot find action '%s' for '%s'"
-        return ErrorResource(msg % (action_name, self.job_run))
+        return ErrorResource(f"Cannot find action '{action_name}' for "
+                             f"'{self.job_run}'")
 
     @AsyncResource.bounded
     def render_GET(self, request):
@@ -207,8 +207,7 @@ class JobResource(resource.Resource):
             action_runs = job.runs.get_action_runs(run_id)
             return ActionRunHistoryResource(action_runs)
 
-        msg = "Cannot find job run '%s' for '%s'"
-        return ErrorResource(msg % (run_id, job))
+        return ErrorResource(f"Cannot find job run '{run_id}' for '{job}'")
 
     @AsyncResource.bounded
     def render_GET(self, request):

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -70,9 +70,10 @@ def handle_command(request, api_controller, obj, **kwargs):
     try:
         response = api_controller.handle_command(command, **kwargs)
         return respond(request, {'result': response})
-    except controller.UnknownCommandError as e:
-        log.warning("Unknown command %s for %s", command, obj)
-        return respond(request, {'error': str(e)}, code=http.NOT_IMPLEMENTED)
+    except controller.UnknownCommandError:
+        error_msg = f"Unknown command '{command}' for '{obj}'"
+        log.warning(error_msg)
+        return respond(request, {'error': error_msg}, code=http.NOT_IMPLEMENTED)
     except Exception as e:
         log.exception('%r while executing command %s for %s', e, command, obj)
         trace = traceback.format_exc()
@@ -81,13 +82,34 @@ def handle_command(request, api_controller, obj, **kwargs):
         )
 
 
+class ErrorResource(resource.Resource):
+    """ Equivalent to resource.NoResource, except error message is returned
+    as JSON, not HTML """
+    def __init__(self, error='No Such Resource', code=http.NOT_FOUND):
+        resource.Resource.__init__(self)
+        self.code = code
+        self.error = error
+
+    @AsyncResource.bounded
+    def render_GET(self, request):
+        return respond(request, {'error': self.error}, code=self.code)
+
+    @AsyncResource.exclusive
+    def render_POST(self, request):
+        return respond(request, {'error': self.error}, code=self.code)
+
+    def getChild(self, chnam, request):
+        """ Overrided getChild to ensure a NoResource is not returned """
+        return self
+
+
 def resource_from_collection(collection, name, child_resource):
     """Return a child resource from a collection by name.  If no item is found,
-    return NoResource.
+    return ErrorResource.
     """
     item = collection.get_by_name(name)
     if item is None:
-        return resource.NoResource("Cannot find child %s" % name)
+        return ErrorResource("Cannot find child '%s'" % name)
     return child_resource(item)
 
 
@@ -133,8 +155,8 @@ class JobRunResource(resource.Resource):
             action_run = self.job_run.action_runs[action_name]
             return ActionRunResource(action_run, self.job_run)
 
-        msg = "Cannot find action %s for %s"
-        return resource.NoResource(msg % (action_name, self.job_run))
+        msg = "Cannot find action '%s' for '%s'"
+        return ErrorResource(msg % (action_name, self.job_run))
 
     @AsyncResource.bounded
     def render_GET(self, request):
@@ -184,8 +206,9 @@ class JobResource(resource.Resource):
         if run_id in job.action_graph.names:
             action_runs = job.runs.get_action_runs(run_id)
             return ActionRunHistoryResource(action_runs)
-        msg = "Cannot find job run %s for %s"
-        return resource.NoResource(msg % (run_id, job))
+
+        msg = "Cannot find job run '%s' for '%s'"
+        return ErrorResource(msg % (run_id, job))
 
     @AsyncResource.bounded
     def render_GET(self, request):

--- a/tron/commands/client.py
+++ b/tron/commands/client.py
@@ -179,11 +179,12 @@ class Client(object):
         return self.request(build_get_url(url, data))
 
     def request(self, url, data=None):
-        log.info("Request: %s, %s, %s", self.url_base, url, data)
+        log.info(f'Request: {self.url_base}, {url}, {data}')
         uri = urllib.parse.urljoin(self.url_base, url)
         response = request(uri, data)
         if response.error:
-            raise RequestError("%s: %s" % (uri, response), response)
+            print('in here', response.content)
+            raise RequestError(f'{response.content}')
         return response.content
 
 

--- a/tron/commands/client.py
+++ b/tron/commands/client.py
@@ -183,7 +183,6 @@ class Client(object):
         uri = urllib.parse.urljoin(self.url_base, url)
         response = request(uri, data)
         if response.error:
-            print('in here', response.content)
             raise RequestError(f'{response.content}')
         return response.content
 

--- a/tron/commands/client.py
+++ b/tron/commands/client.py
@@ -183,7 +183,7 @@ class Client(object):
         uri = urllib.parse.urljoin(self.url_base, url)
         response = request(uri, data)
         if response.error:
-            raise RequestError("%s: %s" % (uri, response))
+            raise RequestError("%s: %s" % (uri, response), response)
         return response.content
 
 
@@ -255,4 +255,4 @@ def get_object_type_from_identifier(url_index, identifier):
     if id_obj:
         return id_obj
 
-    raise ValueError("Unknown identifier: %s" % identifier)
+    raise ValueError("Unknown job identifier: %s" % identifier)

--- a/tron/commands/cmd_utils.py
+++ b/tron/commands/cmd_utils.py
@@ -187,11 +187,13 @@ def save_config(options):
 
 def setup_logging(options):
     if options.verbose is None:
-        level = logging.WARNING
+        level = logging.CRITICAL
     elif options.verbose == 1:
+        level = logging.WARNING
+    elif options.verbose == 2:
         level = logging.INFO
     else:
-        level = logging.DEBUG
+        level = logging.NOTSET
 
     logging.basicConfig(
         level=level,


### PR DESCRIPTION
### Description
- Bug (behavior): If `tronview` and `tronctl` were given erroneous commands in some way, the programs show HTTP stacktraces (and other related errors), which ideally should not be shown to the user. 
- Bug (code):
  1. `tronview`: Did not handle RequestErrors if raised when bad identifiers (for job runs or actions) were used.
  2. `tronctl`: Despite the fact that we deprecated non-id commands, we still allowed tronctl to run without an id.
  3. tron api: Although the tron client expects JSON error messages, the tron api returns HTML (with an error message embedded).
- Fix:
  1. `tronview`: Ensure RequestErrors are handled, and an error message from tron api is displayed to the user.
  2. `tronctl`: Enforce the need for at least job/jobrun/actionrun id as a positional argument
  3. tron api:
    - Create a new resource type that returns JSON messages in the event of an error
    - Since some errors are printed no matter what because they are logs, I modified the logging levels according to verbosity requested.
      - None: only critical
      - -v: warning, error, critical
      - -vv: info, warning, error, critical
      - -vvv: all

### Testing
- make test
- make dev
- Sample output:
1. In `tronview`, when querying the status for nonexistent jobs, there were no problems to begin with:
`---@---:~$ tronview foo`
`Error: Unknown identifier: foo`
    - But when querying a nonexistent job run (or action run) for an existing job, we originally got a stack trace:
`---@---:~$ tronview video.retry_video_processing.foo`
`tron.commands.client ERROR Received error response: HTTP Error 404: Not Found`
`tron.commands.client WARNING Incorrectly formatted error`
`<html>`
`<head><title>404 - No Such Resource</title></head>`
...
    - Now we get:
`---@---:~$ tronview MASTER.test.foo`
`Error: Cannot find job run 'foo' for 'Job:MASTER.test'`
    - Even if we query an action for a nonexistent job run, tron will recognize that the job run identifier, and not the action run identifier, is the problem:
`---@---:~$ tronview MASTER.test.foo.bar`
`Error: Cannot find job run 'foo' for 'Job:MASTER.test'`
    - But, if the job run identifier is good, but the action identifier is bad, tron also recognizes that:
`---@---:~$ tronview MASTER.test.0.bar`
`Error: Cannot find action 'bar' for 'JobRun:MASTER.test.0'`
2. For `tronctl`, when using a bad command, the program identifies that it is invalid:
`---@---:~$ tronctl foo`
...
`tronctl: error: argument command: invalid choice: 'foo' (choose from 'start', 'rerun', 'retry', 'cancel', 'backfill', 'disable', 'enable', 'fail', 'success', 'skip', 'stop', 'kill')`
    - But when using a command that requires an argument (i.e. all of them), tron originally saw them as 'Not Implemented':
`---@---:~$ tronctl start`
`tron.commands.client ERROR Received error response: HTTP Error 501: Not Implemented`
`tronctl ERROR Unknown command start`
    - Now, `tronctl` will require that at least 1 identifier is passed:
`---@---:~$ tronctl start`
`tronctl: error: the following arguments are required: id`
3. For `tronctl`, when using a command with an invalid job id, the program already identifies the job is invalid, but not when the job run (or action) is bad:
`---@---:~$ tronctl start foo`
`Error: Unknown identifier: foo`
`---@---:~$ tronctl start video.retry_video_processing.foo`
`tron.commands.client ERROR Received error response: HTTP Error 404: Not Found`
`tron.commands.client WARNING Incorrectly formatted error`
`<html>`
`<head><title>404 - No Such Resource</title></head>`
...
    - Now, tron will correctly identify that a job run (or action) is incorrect:
`---@---:~$ tronctl start MASTER.test.foo`
`Error: Cannot find job run 'foo' for 'Job:MASTER.test'`
    - And if a command doesn't work for a certain identifier (say, disable a job run, even though `disable` is only valid for a job), tron will also identify that:
`tronctl disable MASTER.test.0`
`Error: Unknown command 'disable' for 'JobRun:MASTER.test.0'`