### PR TITLE
Convert Action to dataclass

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bsddb3
 cryptography>=2.1.4
+dataclasses>=0.6
 docutils>=0.8.1
 ipdb
 ipython

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ setup(
         'ipdb',
         'task_processing[mesos_executor]>=0.1.2',
         'requests',
-        'psutil'
+        'psutil',
+        'dataclasses>=0.6',
     ],
     packages=find_packages(exclude=['tests.*', 'tests']) + ['tronweb'],
     scripts=glob.glob('bin/*'),

--- a/tests/core/action_test.py
+++ b/tests/core/action_test.py
@@ -1,26 +1,14 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import mock
-
-from testifycompat import assert_equal
-from testifycompat import run
-from testifycompat import setup
-from testifycompat import TestCase
-from tron import node
 from tron.config.schema import ConfigAction
 from tron.config.schema import ConfigConstraint
 from tron.config.schema import ConfigParameter
 from tron.config.schema import ConfigVolume
-from tron.core import action
+from tron.core.action import Action
 
 
-class TestAction(TestCase):
-    @setup
-    def setup_action(self):
-        self.node_pool = mock.create_autospec(node.NodePool)
-        self.action = action.Action("my_action", "doit", self.node_pool)
-
+class TestAction:
     def test_from_config_full(self):
         config = ConfigAction(
             name="ted",
@@ -54,19 +42,19 @@ class TestAction(TestCase):
             trigger_downstreams=True,
             triggered_by=["foo.bar"],
         )
-        new_action = action.Action.from_config(config)
-        assert_equal(new_action.name, config.name)
-        assert_equal(new_action.command, config.command)
-        assert_equal(new_action.node_pool, None)
-        assert_equal(new_action.required_actions, set())
-        assert_equal(new_action.executor, config.executor)
-        assert_equal(new_action.cpus, config.cpus)
-        assert_equal(new_action.mem, config.mem)
-        assert_equal(new_action.constraints, {('pool', 'LIKE', 'default')})
-        assert_equal(new_action.docker_image, config.docker_image)
-        assert_equal(new_action.docker_parameters, {('test', 123)})
-        assert_equal(new_action.env, config.env)
-        assert_equal(new_action.extra_volumes, {('/nail/tmp', '/tmp', 'RO')})
+        new_action = Action.from_config(config)
+        assert new_action.name == config.name
+        assert new_action.command == config.command
+        assert new_action.node_pool is None
+        assert new_action.required_actions == set()
+        assert new_action.executor == config.executor
+        assert new_action.cpus == config.cpus
+        assert new_action.mem == config.mem
+        assert new_action.constraints == {('pool', 'LIKE', 'default')}
+        assert new_action.docker_image == config.docker_image
+        assert new_action.docker_parameters == {('test', 123)}
+        assert new_action.env == config.env
+        assert new_action.extra_volumes == {('/nail/tmp', '/tmp', 'RO')}
         assert new_action.trigger_downstreams is True
         assert new_action.triggered_by == ['foo.bar']
 
@@ -77,25 +65,13 @@ class TestAction(TestCase):
             node="first",
             executor="ssh",
         )
-        new_action = action.Action.from_config(config)
-        assert_equal(new_action.name, config.name)
-        assert_equal(new_action.command, config.command)
-        assert_equal(new_action.required_actions, set())
-        assert_equal(new_action.executor, config.executor)
-        assert_equal(new_action.constraints, set())
-        assert_equal(new_action.docker_image, None)
-        assert_equal(new_action.docker_parameters, set())
-        assert_equal(new_action.env, {})
-        assert_equal(new_action.extra_volumes, set())
-
-    def test__eq__(self):
-        new_action = action.Action(
-            self.action.name,
-            self.action.command,
-            self.node_pool,
-        )
-        assert_equal(new_action, self.action)
-
-
-if __name__ == '__main__':
-    run()
+        new_action = Action.from_config(config)
+        assert new_action.name == config.name
+        assert new_action.command == config.command
+        assert new_action.required_actions == set()
+        assert new_action.executor == config.executor
+        assert new_action.constraints == set()
+        assert new_action.docker_image is None
+        assert new_action.docker_parameters == set()
+        assert new_action.env == {}
+        assert new_action.extra_volumes == set()

--- a/tests/core/action_test.py
+++ b/tests/core/action_test.py
@@ -58,28 +58,15 @@ class TestAction(TestCase):
         assert_equal(new_action.name, config.name)
         assert_equal(new_action.command, config.command)
         assert_equal(new_action.node_pool, None)
-        assert_equal(new_action.required_actions, [])
+        assert_equal(new_action.required_actions, set())
         assert_equal(new_action.executor, config.executor)
         assert_equal(new_action.cpus, config.cpus)
         assert_equal(new_action.mem, config.mem)
-        assert_equal(new_action.constraints, [['pool', 'LIKE', 'default']])
+        assert_equal(new_action.constraints, {('pool', 'LIKE', 'default')})
         assert_equal(new_action.docker_image, config.docker_image)
-        assert_equal(
-            new_action.docker_parameters,
-            [{
-                'key': 'test',
-                'value': 123
-            }],
-        )
+        assert_equal(new_action.docker_parameters, {('test', 123)})
         assert_equal(new_action.env, config.env)
-        assert_equal(
-            new_action.extra_volumes,
-            [{
-                'container_path': '/nail/tmp',
-                'host_path': '/tmp',
-                'mode': 'RO'
-            }],
-        )
+        assert_equal(new_action.extra_volumes, {('/nail/tmp', '/tmp', 'RO')})
         assert new_action.trigger_downstreams is True
         assert new_action.triggered_by == ['foo.bar']
 
@@ -93,13 +80,13 @@ class TestAction(TestCase):
         new_action = action.Action.from_config(config)
         assert_equal(new_action.name, config.name)
         assert_equal(new_action.command, config.command)
-        assert_equal(new_action.required_actions, [])
+        assert_equal(new_action.required_actions, set())
         assert_equal(new_action.executor, config.executor)
-        assert_equal(new_action.constraints, [])
+        assert_equal(new_action.constraints, set())
         assert_equal(new_action.docker_image, None)
-        assert_equal(new_action.docker_parameters, [])
+        assert_equal(new_action.docker_parameters, set())
         assert_equal(new_action.env, {})
-        assert_equal(new_action.extra_volumes, [])
+        assert_equal(new_action.extra_volumes, set())
 
     def test__eq__(self):
         new_action = action.Action(

--- a/tests/core/actiongraph_test.py
+++ b/tests/core/actiongraph_test.py
@@ -52,12 +52,12 @@ class TestActionGraph(TestCase):
         assert_equal(graph_base_names, {'base_one', 'base_two'})
         assert_equal(
             set(am['dep_multi'].required_actions),
-            {am['dep_one_one'], am['base_two']},
+            {'dep_one_one', 'base_two'},
         )
 
         assert_equal(set(am.keys()), set(self.action_names))
-        assert_equal(am['base_one'].dependent_actions, [am['dep_one']])
-        assert_equal(am['dep_one'].dependent_actions, [am['dep_one_one']])
+        assert_equal(am['base_one'].dependent_actions, {'dep_one'})
+        assert_equal(am['dep_one'].dependent_actions, {'dep_one_one'})
 
     def test_actions_for_names(self):
         actions = list(

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -911,7 +911,7 @@ class TestActionRunCollectionIsRunBlocked(TestCase):
             action_graph.append(m)
 
         self.second_act = second_act = action_graph.pop(1)
-        second_act.required_actions.append(action_graph[0])
+        second_act.required_actions.append(action_graph[0].name)
         action_map = {a.name: a for a in action_graph}
         action_map['second_name'] = second_act
         self.action_graph = actiongraph.ActionGraph(action_graph, action_map)
@@ -942,7 +942,7 @@ class TestActionRunCollectionIsRunBlocked(TestCase):
         assert not self.collection._is_run_blocked(self.run_map['second_name'])
 
     def test_is_run_blocked_required_actions_blocked(self):
-        third_act = MagicMock(required_actions=[self.second_act], )
+        third_act = MagicMock(required_actions=[self.second_act.name], )
         third_act.name = 'third_act'
         self.action_graph.action_map['third_act'] = third_act
         self.run_map['third_act'] = self._build_run('third_act')

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -1,80 +1,37 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
+import datetime
 import logging
+
+from dataclasses import dataclass
+from dataclasses import field
 
 from tron import node
 from tron.config.schema import CLEANUP_ACTION_NAME
-from tron.utils import maybe_decode
 
 log = logging.getLogger(__name__)
 
 
-class Action(object):
+@dataclass
+class Action:
     """A configurable data object for an Action."""
-
-    equality_attributes = [
-        'name',
-        'command',
-        'node_pool',
-        'is_cleanup',
-        'retries',
-        'expected_runtime',
-        'executor',
-        'cpus',
-        'mem',
-        'constraints',
-        'docker_image',
-        'docker_parameters',
-        'env',
-        'extra_volumes',
-        'retries_delay',
-        'trigger_downstreams',
-        'triggered_by',
-        'on_upstream_rerun',
-    ]
-
-    def __init__(
-        self,
-        name,
-        command,
-        node_pool,
-        required_actions=None,
-        dependent_actions=None,
-        retries=None,
-        retries_delay=None,
-        expected_runtime=None,
-        executor=None,
-        cpus=None,
-        mem=None,
-        constraints=None,
-        docker_image=None,
-        docker_parameters=None,
-        env=None,
-        extra_volumes=None,
-        trigger_downstreams=None,
-        triggered_by=None,
-        on_upstream_rerun=None,
-    ):
-        self.name = maybe_decode(name)
-        self.command = command
-        self.node_pool = node_pool
-        self.retries = retries
-        self.retries_delay = retries_delay
-        self.required_actions = required_actions or []
-        self.dependent_actions = dependent_actions or []
-        self.expected_runtime = expected_runtime
-        self.executor = executor
-        self.cpus = cpus
-        self.mem = mem
-        self.constraints = constraints or []
-        self.docker_image = docker_image
-        self.docker_parameters = docker_parameters or []
-        self.env = env or {}
-        self.extra_volumes = extra_volumes or []
-        self.trigger_downstreams = trigger_downstreams
-        self.triggered_by = triggered_by
-        self.on_upstream_rerun = on_upstream_rerun
+    name: str
+    command: str
+    node_pool: str
+    retries: int = None
+    retries_delay: datetime.timedelta = None
+    expected_runtime: datetime.timedelta = None
+    executor: str = None
+    cpus: float = None
+    mem: float = None
+    constraints: set = field(default_factory=set)
+    docker_image: str = None
+    docker_parameters: set = field(default_factory=set)
+    env: dict = field(default_factory=dict)
+    extra_volumes: set = field(default_factory=set)
+    trigger_downstreams: (bool, dict) = None
+    triggered_by: set = None
+    on_upstream_rerun: str = None
+    required_actions: set = field(default_factory=set)
+    dependent_actions: set = field(default_factory=set)
 
     @property
     def is_cleanup(self):
@@ -85,19 +42,7 @@ class Action(object):
         """Factory method for creating a new Action."""
         node_repo = node.NodePoolRepository.get_instance()
 
-        # Only convert config values if they are not None.
-        constraints = config.constraints
-        if constraints:
-            constraints = [[c.attribute, c.operator, c.value]
-                           for c in constraints]
-        docker_parameters = config.docker_parameters
-        if docker_parameters:
-            docker_parameters = [c._asdict() for c in docker_parameters]
-        extra_volumes = config.extra_volumes
-        if extra_volumes:
-            extra_volumes = [c._asdict() for c in extra_volumes]
-
-        return cls(
+        kwargs = dict(
             name=config.name,
             command=config.command,
             node_pool=node_repo.get_by_name(config.node),
@@ -107,30 +52,29 @@ class Action(object):
             executor=config.executor,
             cpus=config.cpus,
             mem=config.mem,
-            constraints=constraints,
             docker_image=config.docker_image,
-            docker_parameters=docker_parameters,
-            env=config.env,
-            extra_volumes=extra_volumes,
             trigger_downstreams=config.trigger_downstreams,
             triggered_by=config.triggered_by,
             on_upstream_rerun=config.on_upstream_rerun,
         )
 
-    def __eq__(self, other):
-        attributes_match = all(
-            getattr(self, attr, None) == getattr(other, attr, None)
-            for attr in self.equality_attributes
-        )
-        return attributes_match and all(
-            self_act == other_act for (
-                self_act,
-                other_act,
-            ) in zip(self.required_actions, other.required_actions)
-        )
+        # Only convert config values if they are not None.
+        constraints = config.constraints
+        if constraints:
+            constraints = set((c.attribute, c.operator, c.value) for c in constraints)
+            kwargs['constraints'] = constraints
 
-    def __ne__(self, other):
-        return not self == other
+        docker_parameters = config.docker_parameters
+        if docker_parameters:
+            docker_parameters = set((c.key, c.value) for c in docker_parameters)
+            kwargs['docker_parameters'] = docker_parameters
 
-    def __hash__(self):
-        return hash(self.name)
+        extra_volumes = config.extra_volumes
+        if extra_volumes:
+            extra_volumes = set((c.container_path, c.host_path, c.mode) for c in extra_volumes)
+            kwargs['extra_volumes'] = extra_volumes
+
+        if config.env:
+            kwargs['env'] = config.env
+
+        return cls(**kwargs)

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -56,25 +56,10 @@ class Action:
             trigger_downstreams=config.trigger_downstreams,
             triggered_by=config.triggered_by,
             on_upstream_rerun=config.on_upstream_rerun,
+            constraints=set(config.constraints or []),
+            docker_parameters=set(config.docker_parameters or []),
+            extra_volumes=set(config.extra_volumes or []),
+            env=config.env or {},
         )
-
-        # Only convert config values if they are not None.
-        constraints = config.constraints
-        if constraints:
-            constraints = set((c.attribute, c.operator, c.value) for c in constraints)
-            kwargs['constraints'] = constraints
-
-        docker_parameters = config.docker_parameters
-        if docker_parameters:
-            docker_parameters = set((c.key, c.value) for c in docker_parameters)
-            kwargs['docker_parameters'] = docker_parameters
-
-        extra_volumes = config.extra_volumes
-        if extra_volumes:
-            extra_volumes = set((c.container_path, c.host_path, c.mode) for c in extra_volumes)
-            kwargs['extra_volumes'] = extra_volumes
-
-        if config.env:
-            kwargs['env'] = config.env
 
         return cls(**kwargs)

--- a/tron/core/actiongraph.py
+++ b/tron/core/actiongraph.py
@@ -42,8 +42,8 @@ class ActionGraph(object):
 
             for dependency in dependencies:
                 dependency_action = actions[dependency]
-                a.required_actions.append(dependency_action)
-                dependency_action.dependent_actions.append(a)
+                a.required_actions.add(dependency_action.name)
+                dependency_action.dependent_actions.add(a.name)
         return base
 
     @classmethod
@@ -61,10 +61,20 @@ class ActionGraph(object):
         """
         if name not in self.action_map:
             return []
-        return self.action_map[name].required_actions
+
+        return (
+            self.action_map[action]
+            for action in self.action_map[name].required_actions
+        )
 
     def get_dependent_actions(self, name):
-        return self.action_map[name].dependent_actions
+        if name not in self.action_map:
+            return []
+
+        return (
+            self.action_map[action]
+            for action in self.action_map[name].dependent_actions
+        )
 
     def get_actions(self):
         return iter(val for _, val in self.action_map.items())

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -675,11 +675,11 @@ class MesosActionRun(ActionRun, Observer):
             command=self.command,
             cpus=self.cpus,
             mem=self.mem,
-            constraints=self.constraints,
+            constraints=[e._asdict() for e in self.constraints],
             docker_image=self.docker_image,
-            docker_parameters=self.docker_parameters,
+            docker_parameters=[e._asdict() for e in self.docker_parameters],
             env=self.env,
-            extra_volumes=self.extra_volumes,
+            extra_volumes=[e._asdict() for e in self.extra_volumes],
             serializer=serializer,
         )
         if not task:  # Mesos is disabled


### PR DESCRIPTION
`dataclass` will be in stdlib in python 3.7 and there are clear benefits to using it as opposed to custom made objects with attributes so let's just gradually convert everything. I'm starting with Action here  because  that's the lowest level object and therefore smallest possible change.