### PR TITLE
Fix constraints passing incorrectly in actionrun

### DIFF
--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -21,6 +21,7 @@ from tests.assertions import assert_length
 from tests.testingutils import autospec_method
 from tron import actioncommand
 from tron import node
+from tron.config.schema import ConfigConstraint
 from tron.config.schema import ExecutorTypes
 from tron.core import actiongraph
 from tron.core import jobrun
@@ -980,7 +981,7 @@ class TestMesosActionRun(TestCase):
             'cpus': 1,
             'mem': 50,
             'docker_image': 'container:v2',
-            'constraints': [],
+            'constraints': [ConfigConstraint('an attr', 'an op', 'a val')],
             'env': {
                 'TESTING': 'true'
             },
@@ -1010,6 +1011,7 @@ class TestMesosActionRun(TestCase):
 
             mock_get_cluster = mock_cluster_repo.get_cluster
             mock_get_cluster.assert_called_once_with()
+            self.other_task_kwargs['constraints'] = [['an attr', 'an op', 'a val']]
             mock_get_cluster.return_value.create_task.assert_called_once_with(
                 action_run_id=self.action_run.id,
                 command=self.command,

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -675,7 +675,8 @@ class MesosActionRun(ActionRun, Observer):
             command=self.command,
             cpus=self.cpus,
             mem=self.mem,
-            constraints=[e._asdict() for e in self.constraints],
+            constraints=[[c.attribute, c.operator, c.value]
+                         for c in self.constraints],
             docker_image=self.docker_image,
             docker_parameters=[e._asdict() for e in self.docker_parameters],
             env=self.env,


### PR DESCRIPTION
### Description
While switching actions to dataclasses (#544), @keymone changed where `constraints`, `docker_parameters` and `extra_volumes` were 'assembled' for a new action. While the code for the latter two attributes were copied correctly (using `e._as_dict()`), the code for `constraints` was not, resulting in a KeyError from taskproc when actions were scheduled to run on Mesos.

This PR is a small fix.

### Testing
`make dev`: test running a job using `tronctl start`