### PR TITLE
Add option for alerting every job in check_tron_jobs

### DIFF
--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -50,10 +50,6 @@ Optional Fields
       A comma-separated string of email destinations. Defaults to the "team"
       default.
 
-    **irc_channels**
-      A list of IRC channels to send alerts to. Defaults to the team setting.
-      Set an empty list to specify no IRC notifications.
-
     **slack_channels**
       A list of Slack channels to send alerts to. Defaults to the team setting.
       Set an empty list to specify no Slack notifications.
@@ -68,12 +64,6 @@ Optional Fields
     **tags** (default **None**)
       A list of arbitrary tags that can be used in handlers for different
       metadata needs.
-
-    **ttl** (default **None**)
-      A human readable time unit to set the check TTL. If the monitoring
-      framework does not hear from the check after this time unit, it will
-      spawn a new failing event. Defaults to None, meaning the framework will
-      only spawn events when it receives them.
 
     **component** (default **None**)
       A list of components affected by the event. A good example here would be

--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -30,8 +30,64 @@ Optional Fields
 ---------------
 
 **monitoring** (default **{}**)
-    (Beta Feature) Dictionary of key: value pairs to inform the monitoring
-    framework on how to alert teams for job failures.
+    Dictionary of key: value pairs to inform the monitoring framework on how to
+    alert teams for job failures.
+
+    **team**
+      Team responsible for the job. Must already be defined in the monitoring
+      framework.
+
+    **page** (default **False**)
+      Boolean on whether or not an alert for this job is page-worthy.
+
+    **runbook**
+      Runbook associated with the job.
+
+    **tip** (default **None**)
+      A short 1-line version of the runbook.
+
+    **notification_email**
+      A comma-separated string of email destinations. Defaults to the "team"
+      default.
+
+    **irc_channels**
+      A list of IRC channels to send alerts to. Defaults to the team setting.
+      Set an empty list to specify no IRC notifications.
+
+    **slack_channels**
+      A list of Slack channels to send alerts to. Defaults to the team setting.
+      Set an empty list to specify no Slack notifications.
+
+    **ticket** (default **False**)
+      A Boolean value to enable ticket creation.
+
+    **project** (default **None**)
+      A string representing the JIRA project that the ticket should go under.
+      Defaults to the team value.
+
+    **tags** (default **None**)
+      A list of arbitrary tags that can be used in handlers for different
+      metadata needs.
+
+    **ttl** (default **None**)
+      A human readable time unit to set the check TTL. If the monitoring
+      framework does not hear from the check after this time unit, it will
+      spawn a new failing event. Defaults to None, meaning the framework will
+      only spawn events when it receives them.
+
+    **component** (default **None**)
+      A list of components affected by the event. A good example here would be
+      to include the job that is being affected.
+
+    **description** (default **None**)
+      Human readable text giving more context on any monitoring events.
+
+    **check_that_every_day_has_a_successful_run** (default **False**)
+      If **True**, the latest job run each day will be checked to see if it was
+      successful.
+
+      If **False**, only the latest overall run will be checked to see if it was
+      successful.
 
 **queueing** (default **True**)
     If a job run is still running when the next job run is to be scheduled,

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -986,7 +986,7 @@ class TestCheckJobs(TestCase):
 
 # These tests test job without succeeded/failed run scenarios
 
-    def test_job_waiting_for_first_run(self):
+    def test_job_no_runs_to_check(self):
         job_runs = {
             'status':
                 'scheduled',
@@ -1008,7 +1008,7 @@ class TestCheckJobs(TestCase):
         }
         run, state = check_tron_jobs.get_relevant_run_and_state(job_runs)
         assert_equal(run['id'], 'MASTER.test.1')
-        assert_equal(state, State.WAITING_FOR_FIRST_RUN)
+        assert_equal(state, State.NO_RUNS_TO_CHECK)
 
     def test_job_has_no_runs_at_all(self):
         job_runs = {

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1374,6 +1374,7 @@ class TestCheckPreciousJobs(TestCase):
         assert latest_run['run_num'] == 5
         assert state == check_tron_jobs.State.SUCCEEDED
 
+    @patch('time.time', mock.Mock(return_value=1539460800.0), autospec=None)
     def test_sort_runs_by_interval_day(self):
         run_buckets = check_tron_jobs.sort_runs_by_interval(self.job, 'day')
 
@@ -1415,9 +1416,11 @@ class TestCheckPreciousJobs(TestCase):
         assert results[0]['output'] == \
             "OK: fake_job is disabled and won't be checked."
 
+    @patch('time.time', mock.Mock(return_value=1539460800.0), autospec=None)
     @patch('check_tron_jobs.Client', autospec=True)
     def test_compute_check_result_for_job_enabled(self, mock_client):
         client = mock_client('fake_server')
+        self.job['monitoring']['check_every'] = 500
         check_tron_jobs.guess_realert_every = mock.Mock(return_value=1)
         check_tron_jobs.get_object_type_from_identifier = \
             mock.Mock(return_value=mock.Mock())
@@ -1435,3 +1438,6 @@ class TestCheckPreciousJobs(TestCase):
             'check_tron_job.fake_job-2018.10.12',
             'check_tron_job.fake_job-2018.10.13',
         ])
+        for res in results:
+            assert res['check_every'] == '300s'
+            assert check_tron_jobs.PRECIOUS_JOB_ATTR not in res


### PR DESCRIPTION
### Description
For most jobs, alerting using their latest run is sufficient. Our current Sensu monitoring follows this model, such that if a run fails on one day and succeeds on the next, job owners will get an alert event followed by a resolved event. 

There are some jobs for which every run is precious; that is, if a run fails on one day but succeeds on the next, it does not mean the former run was fixed. Our monitoring currently DOES NOT cater to these jobs.

This PR modifies tron job monitoring via the check_tron_job script, such that if a job opts into it, owners can be alerted according to whether or not a there was a successful run on each given day, as opposed to a job's overall latest run was successful.

If a job does not opt in, job owners will still receive alerts the original way.

Key changes:
- Opt-in monitoring attribute: Setting the `check_that_every_day_has_a_successful_run` attribute to `True` in a job's monitoring config will make the job precious.
- Adding shortdate to job name in alert: Owners of precious jobs will have the runs bucketed by date, which will be reflected in the Sensu alerts they receive.

### Testing done
Note: Although this PR enforces daily run success, I used minute-based or hourly run success to gather data more quickly.
- `make dev` (local) and job in stage environment (remote): Running a job that was designed to succeed or fail every interval in an alternating manner. This interval was either 30 seconds, 1 minute, or 3 minutes.
- `make test`

### Notes to reviewers
- Example of a job opting into daily alerts: https://gist.github.com/kawaiwanyelp/f51041dfbd2256cb5ec4e2e326822a23
- Example of an ALERT event: https://gist.github.com/kawaiwanyelp/0b9ce31a9fa96d88e4f36f843b69cc8f
- Example of a RESOLVED event: https://gist.github.com/kawaiwanyelp/7bf35bae04967f904bfd0fedf000951d
