### PR TITLE
create pidfile for manhole socket

### DIFF
--- a/tron/trondaemon.py
+++ b/tron/trondaemon.py
@@ -169,7 +169,7 @@ class TronDaemon(object):
 
     def _run_manhole(self):
         self.manhole = make_manhole(dict(trond=self, mcp=self.mcp))
-        reactor.listenUNIX(self.manhole_sock, self.manhole)
+        reactor.listenUNIX(self.manhole_sock, self.manhole, wantPID=1)
         log.info(f"manhole started on {self.manhole_sock}")
 
     def _run_www_api(self):


### PR DESCRIPTION
When we restarted Tron at prod yesterday, Tron crashed after running for 2 mins. And the error message from the log at /upstart was shown as follows:

https://fluffy.yelpcorp.com/i/CDhTDjD58zp2WmVSg9F3hZ3HlfLT4mNx.html

Setting wantPID = 1 should fix this issue.