### PR TITLE
add tronctl move command

### DIFF
--- a/bin/tronctl
+++ b/bin/tronctl
@@ -146,7 +146,7 @@ def move(args):
     if old_name not in job_index.keys():
         raise SystemExit(f"Error: {old_name} doesn't exist")
     if new_name in job_index.keys():
-        raise SystemExit(f"Error: {new_name} has existed already")
+        raise SystemExit(f"Error: {new_name} exists already")
 
     return edit(args, '/api/jobs')
 

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -34,7 +34,7 @@ COMMAND_HELP = (
     ('skip', 'Skip a failed action, runs dependent actions.'),
     ('stop', 'Stop the action run (SIGTERM)'),
     ('kill', 'Force kill the action run (SIGKILL)'),
-    ('move', 'Move a job to the new namespace'),
+    ('move', 'Rename a job'),
 )
 
 log = logging.getLogger('tronctl')

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -34,6 +34,7 @@ COMMAND_HELP = (
     ('skip', 'Skip a failed action, runs dependent actions.'),
     ('stop', 'Stop the action run (SIGTERM)'),
     ('kill', 'Force kill the action run (SIGKILL)'),
+    ('move', 'Move a job to the new namespace'),
 )
 
 log = logging.getLogger('tronctl')
@@ -97,6 +98,9 @@ def edit(args, uri):
     data = {'command': args.command}
     if args.command == "start" and args.run_date:
         data['run_time'] = str(args.run_date)
+    elif args.command == "move":
+        data['old_name'] = args.id[0]
+        data['new_name'] = args.id[1]
 
     uri = urljoin(args.server, uri)
     response = client.request(uri, data=data)
@@ -127,6 +131,24 @@ def control_objects(args):
             )
             raise SystemExit(f"Error: {e}{suggestions}")
         yield edit(args, tron_id.url)
+
+
+def move(args):
+    try:
+        old_name = args.id[0]
+        new_name = args.id[1]
+    except IndexError as e:
+        raise SystemExit(f"Error: Move command needs two arguments.\n{e}")
+
+    tron_client = client.Client(args.server)
+    url_index = tron_client.index()
+    job_index = url_index['jobs']
+    if old_name not in job_index.keys():
+        raise SystemExit(f"Error: {old_name} doesn't exist")
+    if new_name in job_index.keys():
+        raise SystemExit(f"Error: {new_name} has existed already")
+
+    return edit(args, '/api/jobs')
 
 
 def backfill(args):
@@ -163,6 +185,8 @@ def main():
 
     if args.command == "backfill":
         sys.exit(backfill(args))
+    elif args.command == "move":
+        sys.exit(move(args))
     else:
         if not all(control_objects(args)):
             sys.exit(ExitCode.fail)

--- a/tests/api/controller_test.py
+++ b/tests/api/controller_test.py
@@ -33,6 +33,9 @@ class TestJobCollectionController(TestCase):
             self.controller.handle_command('enableall')
             self.controller.handle_command('disableall')
 
+    def test_handle_command_move(self):
+        self.controller.handle_command('move', old_name='old.test', new_name='new.test')
+
 
 class TestActionRunController(TestCase):
     @setup

--- a/tests/api/controller_test.py
+++ b/tests/api/controller_test.py
@@ -33,6 +33,16 @@ class TestJobCollectionController(TestCase):
             self.controller.handle_command('enableall')
             self.controller.handle_command('disableall')
 
+    def test_handle_command_move_non_exiting_job(self):
+        self.collection.get_names.return_value = []
+        result = self.controller.handle_command('move', old_name='old.test', new_name='new.test')
+        assert "doesn't exist" in result
+
+    def test_handle_command_move_to_exiting_job(self):
+        self.collection.get_names.return_value = ['old.test', 'new.test']
+        result = self.controller.handle_command('move', old_name='old.test', new_name='new.test')
+        assert "has existed already" in result
+
     def test_handle_command_move(self):
         self.controller.handle_command('move', old_name='old.test', new_name='new.test')
 

--- a/tests/api/controller_test.py
+++ b/tests/api/controller_test.py
@@ -33,18 +33,20 @@ class TestJobCollectionController(TestCase):
             self.controller.handle_command('enableall')
             self.controller.handle_command('disableall')
 
-    def test_handle_command_move_non_exiting_job(self):
+    def test_handle_command_move_non_existing_job(self):
         self.collection.get_names.return_value = []
         result = self.controller.handle_command('move', old_name='old.test', new_name='new.test')
         assert "doesn't exist" in result
 
-    def test_handle_command_move_to_exiting_job(self):
+    def test_handle_command_move_to_existing_job(self):
         self.collection.get_names.return_value = ['old.test', 'new.test']
         result = self.controller.handle_command('move', old_name='old.test', new_name='new.test')
-        assert "has existed already" in result
+        assert "exists already" in result
 
     def test_handle_command_move(self):
-        self.controller.handle_command('move', old_name='old.test', new_name='new.test')
+        self.collection.get_names.return_value = ['old.test']
+        result = self.controller.handle_command('move', old_name='old.test', new_name='new.test')
+        assert "Error" not in result
 
 
 class TestActionRunController(TestCase):

--- a/tron/api/controller.py
+++ b/tron/api/controller.py
@@ -21,7 +21,7 @@ class JobCollectionController(object):
             if old_name not in self.job_collection.get_names():
                 return f"Error: {old_name} doesn't exist"
             if new_name in self.job_collection.get_names():
-                return f"Error: {new_name} has existed already"
+                return f"Error: {new_name} exists already"
             return self.job_collection.move(old_name, new_name)
 
         raise UnknownCommandError("Unknown command %s" % command)

--- a/tron/api/controller.py
+++ b/tron/api/controller.py
@@ -16,8 +16,10 @@ class JobCollectionController(object):
     def __init__(self, job_collection):
         self.job_collection = job_collection
 
-    def handle_command(self, command):
-        # No commands to handle, enableall/disableall have been deprecated
+    def handle_command(self, command, old_name=None, new_name=None):
+        if command == 'move':
+            return self.job_collection.move(old_name, new_name)
+
         raise UnknownCommandError("Unknown command %s" % command)
 
 

--- a/tron/api/controller.py
+++ b/tron/api/controller.py
@@ -18,6 +18,10 @@ class JobCollectionController(object):
 
     def handle_command(self, command, old_name=None, new_name=None):
         if command == 'move':
+            if old_name not in self.job_collection.get_names():
+                return f"Error: {old_name} doesn't exist"
+            if new_name in self.job_collection.get_names():
+                return f"Error: {new_name} has existed already"
             return self.job_collection.move(old_name, new_name)
 
         raise UnknownCommandError("Unknown command %s" % command)

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -327,9 +327,9 @@ class JobCollectionResource(resource.Resource):
         old_name = requestargs.get_string(request, 'old_name')
         new_name = requestargs.get_string(request, 'new_name')
         return handle_command(
-            request = request,
-            api_controller = self.controller,
-            obj = self.job_collection,
+            request=request,
+            api_controller=self.controller,
+            obj=self.job_collection,
             old_name=old_name,
             new_name=new_name,
         )

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -324,7 +324,15 @@ class JobCollectionResource(resource.Resource):
 
     @AsyncResource.exclusive
     def render_POST(self, request):
-        return handle_command(request, self.controller, self.job_collection)
+        old_name = requestargs.get_string(request, 'old_name')
+        new_name = requestargs.get_string(request, 'new_name')
+        return handle_command(
+            request = request,
+            api_controller = self.controller,
+            obj = self.job_collection,
+            old_name=old_name,
+            new_name=new_name,
+        )
 
 
 class ConfigResource(resource.Resource):

--- a/tron/core/job_collection.py
+++ b/tron/core/job_collection.py
@@ -8,6 +8,7 @@ from tron.utils import collections
 from tron.utils import iteration
 from tron.utils import proxy
 
+
 log = logging.getLogger(__name__)
 
 
@@ -45,15 +46,17 @@ class JobCollection:
         return self.jobs.add(job_scheduler, self.update)
 
     def move(self, old_name, new_name):
+        job_scheduler = self.get_by_name(old_name)
+
         # check if job is running
-        if self.get_by_name(old_name).job.status == Job.STATUS_RUNNING:
-            return f"Job moving failed. Job is still running"
+        if job_scheduler.get_job().status == Job.STATUS_RUNNING:
+            return f"Moving {old_name} to {new_name} failed. Job is still running."
 
         log.info(f"Moving {old_name} to {new_name}")
-        self.get_by_name(old_name).update_name(new_name)
+        job_scheduler.update_name(new_name)
         self.add(self.jobs.pop(old_name))
 
-        return f"Move the job {old_name} to {new_name} successfully"
+        return f"Moving {old_name} to {new_name} succeeded."
 
     def update(self, new_job_scheduler):
         log.info(f"Updating {new_job_scheduler}")

--- a/tron/core/job_collection.py
+++ b/tron/core/job_collection.py
@@ -3,10 +3,10 @@ import logging
 import six
 from six.moves import filter
 
+from tron.core.job import Job
 from tron.utils import collections
 from tron.utils import iteration
 from tron.utils import proxy
-
 
 log = logging.getLogger(__name__)
 
@@ -43,6 +43,17 @@ class JobCollection:
 
     def add(self, job_scheduler):
         return self.jobs.add(job_scheduler, self.update)
+
+    def move(self, old_name, new_name):
+        # check if job is running
+        if self.get_by_name(old_name).job.status == Job.STATUS_RUNNING:
+            return f"Job moving failed. Job is still running"
+
+        log.info(f"Moving {old_name} to {new_name}")
+        self.get_by_name(old_name).update_name(new_name)
+        self.add(self.jobs.pop(old_name))
+
+        return f"Move the job {old_name} to {new_name} successfully"
 
     def update(self, new_job_scheduler):
         log.info(f"Updating {new_job_scheduler}")

--- a/tron/core/job_scheduler.py
+++ b/tron/core/job_scheduler.py
@@ -195,6 +195,12 @@ class JobScheduler(Observer):
         next_run_time = self.job.scheduler.next_run_time(last_run_time)
         return self.job.build_new_runs(next_run_time)
 
+    def update_name(self, name):
+        self.job.name = name
+        self.job.update_from_job(self.get_job())
+        self.job.runs.remove_pending()
+        self.create_and_schedule_runs(ignore_last_run_time=False)
+
     def __str__(self):
         return f"{self.__class__.__name__}({self.job})"
 

--- a/tron/core/job_scheduler.py
+++ b/tron/core/job_scheduler.py
@@ -197,7 +197,6 @@ class JobScheduler(Observer):
 
     def update_name(self, name):
         self.job.name = name
-        self.job.update_from_job(self.get_job())
         self.job.runs.remove_pending()
         self.create_and_schedule_runs(ignore_last_run_time=False)
 


### PR DESCRIPTION
For example, if we want to move MASTER.test to test.test. the procedure would be:
  1. review for the change at yelpsoa-configs
  1. stop cron
  2. tronctl move MASTER.test test.test
  3. merge the change at yelpsoa-configs
  4. start cron

Need to test: Is it OK to let tron_deployment_tool to deploy the new change? I think so, but need to test it.