### PR TITLE
Handle non-Mesos events from taskproc

### DIFF
--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -186,18 +186,17 @@ class MesosTask(ActionCommand):
             agent = get_deep(event.raw, 'offer.agent_id.value')
             hostname = get_deep(event.raw, 'offer.hostname')
             self.log.info(
-                'Staging task on agent {agent} (hostname {hostname})'.format(
-                    agent=agent,
-                    hostname=hostname,
-                ),
+                f'Staging task on agent {agent} (hostname {hostname})'
             )
         elif mesos_type == 'running':
             agent = get_deep(event.raw, 'agent_id.value')
-            self.log.info('Running on agent {agent}'.format(agent=agent))
+            self.log.info(f'Running on agent {agent}')
         elif mesos_type == 'finished':
             pass
         elif mesos_type in self.ERROR_STATES:
-            self.log.error('Error from Mesos: {}'.format(event.raw))
+            self.log.error(f'Error from Mesos: {event.raw}')
+        elif mesos_type is None:
+            self.log.info(f'Non-Mesos event: {event.raw}')
 
     def handle_event(self, event):
         event_id = getattr(event, 'task_id', None)
@@ -229,8 +228,10 @@ class MesosTask(ActionCommand):
             self.exited(None)
         elif mesos_type in self.ERROR_STATES:
             self.exited(1)
+        elif mesos_type is None:
+            pass
         else:
-            self.log.warning(
+            self.log.info(
                 'Did not handle unknown type of event: {}'.format(event),
             )
 
@@ -241,7 +242,7 @@ class MesosTask(ActionCommand):
             # Returns False if we've already exited normally above
             unexpected_error = self.exited(exit_code)
             if unexpected_error:
-                self.log.error('Unknown failure, exiting')
+                self.log.error('Unexpected failure, exiting')
 
             self.done()
 


### PR DESCRIPTION
None-type events are a normal case from taskproc that we should handle. For example, [offer timeouts](https://github.com/Yelp/task_processing/blob/2ebda4035e518b742d2e8e71267c510148526af5/task_processing/plugins/mesos/execution_framework.py#L149). This makes it easier to see the error message 'Failed due to offer timeout' from taskproc.

Otherwise the `Did not handle unknown type of event: {event}' logging can get verbose, since it includes the task config. 

also some f-strings