### PR TITLE
Initial metrics endpoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'requests',
         'psutil',
         'dataclasses>=0.6',
+        'pyformance',
     ],
     packages=find_packages(exclude=['tests.*', 'tests']) + ['tronweb'],
     scripts=glob.glob('bin/*') + glob.glob('tron/bin/*.py'),

--- a/tests/api/resource_test.py
+++ b/tests/api/resource_test.py
@@ -154,6 +154,7 @@ class TestApiRootResource(WWWTestCase):
         expected_children = [
             b'jobs',
             b'config',
+            b'metrics',
             b'status',
             b'',
         ]
@@ -330,6 +331,28 @@ class TestConfigResource:
             'error': self.controller.delete_config.return_value,
         }
         mock_respond.assert_called_with(request, response_content)
+
+
+class TestMetricsResource:
+
+    @mock.patch('tron.api.resource.view_all_metrics', autospec=True)
+    def test_render_GET(self, mock_view_metrics, request, mock_respond):
+        resource = www.MetricsResource()
+        resource.render_GET(request)
+        mock_respond.assert_called_with(request, mock_view_metrics.return_value)
+
+
+class TestTronSite:
+
+    @mock.patch('tron.api.resource.meter', autospec=True)
+    def test_log_request(self, mock_meter):
+        site = www.TronSite.create(
+            mock.create_autospec(mcp.MasterControlProgram),
+            'webpath',
+        )
+        request = mock.Mock(code=500)
+        site.log(request)
+        assert mock_meter.call_count == 1
 
 
 if __name__ == '__main__':

--- a/tests/mesos_test.py
+++ b/tests/mesos_test.py
@@ -113,6 +113,9 @@ class TestMesosTask(TestCase):
             task_config=mock.Mock(
                 cmd='echo hello world',
                 task_id=self.task_id,
+                cpus=0.1,
+                mem=100,
+                disk=100,
             ),
         )
         # Suppress logging

--- a/tests/metrics_test.py
+++ b/tests/metrics_test.py
@@ -1,0 +1,138 @@
+import mock
+import pytest
+
+import tron.metrics as metrics
+
+
+@pytest.fixture(autouse=True)
+def all_metrics():
+    with mock.patch.object(metrics, 'all_metrics', new=dict()) as mock_all:
+        yield mock_all
+
+
+def test_get_metric(all_metrics):
+    timer = metrics.get_metric('timer', 'api.requests', {'method': 'GET'}, mock.Mock())
+    same_timer = metrics.get_metric('timer', 'api.requests', {'method': 'GET'}, mock.Mock())
+    other_timer = metrics.get_metric('timer', 'api.requests', {'method': 'POST'}, mock.Mock())
+    metrics.get_metric('something', 'name', None, mock.Mock())
+    assert timer == same_timer
+    assert other_timer != timer
+    assert len(all_metrics) == 3
+
+
+@mock.patch('tron.metrics.get_metric', autospec=True)
+def test_timer(mock_get_metric):
+    test_metric = metrics.Timer()
+    mock_get_metric.return_value = test_metric
+    metrics.timer('my_metric', 110)
+    metrics.timer('my_metric', 84)
+    mock_get_metric.assert_called_with(
+        'timer',
+        'my_metric',
+        None,
+        mock.ANY,
+    )
+    result = metrics.view_timer(test_metric)
+    assert result['count'] == 2
+
+
+@mock.patch('tron.metrics.get_metric', autospec=True)
+def test_count(mock_get_metric):
+    test_metric = metrics.Counter()
+    mock_get_metric.return_value = test_metric
+    metrics.count('my_metric', 13)
+    metrics.count('my_metric', -1)
+    mock_get_metric.assert_called_with(
+        'counter',
+        'my_metric',
+        None,
+        mock.ANY,
+    )
+    result = metrics.view_counter(test_metric)
+    assert result['count'] == 12
+
+
+@mock.patch('tron.metrics.get_metric', autospec=True)
+def test_meter(mock_get_metric):
+    test_metric = metrics.Meter()
+    mock_get_metric.return_value = test_metric
+    metrics.meter('my_metric')
+    metrics.meter('my_metric')
+    mock_get_metric.assert_called_with(
+        'meter',
+        'my_metric',
+        None,
+        mock.ANY,
+    )
+    result = metrics.view_meter(test_metric)
+    assert result['count'] == 2
+
+
+@mock.patch('tron.metrics.get_metric', autospec=True)
+def test_gauge(mock_get_metric):
+    test_metric = metrics.SimpleGauge()
+    mock_get_metric.return_value = test_metric
+    metrics.gauge('my_metric', 23)
+    metrics.gauge('my_metric', 102)
+    mock_get_metric.assert_called_with(
+        'gauge',
+        'my_metric',
+        None,
+        mock.ANY,
+    )
+    result = metrics.view_gauge(test_metric)
+    assert result['value'] == 102
+
+
+@mock.patch('tron.metrics.get_metric', autospec=True)
+def test_histogram(mock_get_metric):
+    test_metric = metrics.Histogram()
+    mock_get_metric.return_value = test_metric
+    metrics.histogram('my_metric', 2)
+    metrics.histogram('my_metric', 92)
+    mock_get_metric.assert_called_with(
+        'histogram',
+        'my_metric',
+        None,
+        mock.ANY,
+    )
+    result = metrics.view_histogram(test_metric)
+    assert result['count'] == 2
+
+
+def test_view_all_metrics_empty():
+    result = metrics.view_all_metrics()
+    assert result == {
+        'counter': [],
+        'gauge': [],
+        'histogram': [],
+        'meter': [],
+        'timer': [],
+    }
+
+
+def test_view_all_metrics():
+    metrics.timer('a', 1)
+    metrics.count('b', 9, dimensions={'method': 'GET'})
+    metrics.meter('c')
+    metrics.gauge('d', 3)
+    metrics.histogram('e', 2)
+    metrics.histogram('f', 3)
+    result = metrics.view_all_metrics()
+
+    assert len(result['timer']) == 1
+    assert result['timer'][0]['name'] == 'a'
+
+    assert len(result['counter']) == 1
+    assert result['counter'][0]['name'] == 'b'
+    assert result['counter'][0]['dimensions'] == {'method': 'GET'}
+
+    assert len(result['meter']) == 1
+    assert result['meter'][0]['name'] == 'c'
+
+    assert len(result['gauge']) == 1
+    assert result['gauge'][0]['name'] == 'd'
+
+    assert len(result['histogram']) == 2
+    names = set(metric['name'] for metric in result['histogram'])
+    assert names == set(['e', 'f'])

--- a/tron/api/async_resource.py
+++ b/tron/api/async_resource.py
@@ -1,7 +1,18 @@
 import threading
+import time
 
 from twisted.internet import threads
 from twisted.web import server
+
+from tron.metrics import timer
+
+
+def report_resource_request(resource, request, duration_ms):
+    timer(
+        name=f'tron.api.{resource.__class__.__name__}',
+        delta=duration_ms,
+        dimensions={'method': request.method}
+    )
 
 
 class AsyncResource():
@@ -10,14 +21,19 @@ class AsyncResource():
     lock = threading.Lock()
 
     @staticmethod
-    def finish(result, request):
+    def finish(result, request, resource):
+        result, duration_ms = result
         request.write(result)
         request.finish()
+        report_resource_request(resource, request, duration_ms)
 
     @staticmethod
     def process(fn, resource, request):
+        start = time.time()
         with AsyncResource.semaphore:
-            return fn(resource, request)
+            result = fn(resource, request)
+        duration_ms = 1000 * (time.time() - start)
+        return result, duration_ms
 
     @staticmethod
     def bounded(fn):
@@ -25,24 +41,27 @@ class AsyncResource():
             d = threads.deferToThread(
                 AsyncResource.process, fn, resource, request
             )
-            d.addCallback(AsyncResource.finish, request)
-            d.addErrback(lambda f: f)
+            d.addCallback(AsyncResource.finish, request, resource)
+            d.addErrback(request.processingFailed)
             return server.NOT_DONE_YET
 
         return wrapper
 
     @staticmethod
     def exclusive(fn):
-        def wrapper(*args, **kwargs):
+        def wrapper(resource, request):
             # ensures only one exclusive request starts consuming the semaphore
+            start = time.time()
             with AsyncResource.lock:
                 # this will wait until all bounded requests finished processing
                 for _ in range(AsyncResource.capacity):
                     AsyncResource.semaphore.acquire()
                 try:
-                    return fn(*args, **kwargs)
+                    return fn(resource, request)
                 finally:
                     for _ in range(AsyncResource.capacity):
                         AsyncResource.semaphore.release()
+                    duration_ms = 1000 * (time.time() - start)
+                    report_resource_request(resource, request, duration_ms)
 
         return wrapper

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -20,9 +20,12 @@ except ImportError:
 
 from twisted.web import http, resource, static, server
 
+from tron import __version__
 from tron.api import adapter, controller
 from tron.api import requestargs
 from tron.api.async_resource import AsyncResource
+from tron.metrics import view_all_metrics
+from tron.metrics import meter
 from tron.utils import maybe_decode
 
 log = logging.getLogger(__name__)
@@ -403,7 +406,22 @@ class StatusResource(resource.Resource):
 
     @AsyncResource.bounded
     def render_GET(self, request):
-        return respond(request, {'status': "I'm alive."})
+        return respond(request, {
+            'status': "I'm alive.",
+            'version': __version__,
+        })
+
+
+class MetricsResource(resource.Resource):
+
+    isLeaf = True
+
+    def __init__(self):
+        resource.Resource.__init__(self)
+
+    @AsyncResource.exclusive
+    def render_GET(self, request):
+        return respond(request, view_all_metrics())
 
 
 class ApiRootResource(resource.Resource):
@@ -419,6 +437,7 @@ class ApiRootResource(resource.Resource):
 
         self.putChild(b'config', ConfigResource(mcp))
         self.putChild(b'status', StatusResource(mcp))
+        self.putChild(b'metrics', MetricsResource())
         self.putChild(b'', self)
 
     @AsyncResource.bounded
@@ -472,6 +491,17 @@ class TronSite(server.Site):
     def startFactory(self):
         server.Site.startFactory(self)
         self.logFile = LogAdapter(self.access_log)
+
+    def log(self, request):
+        super().log(request)
+        if 200 <= request.code < 300:
+            meter('tron.site.2xx')
+        if 300 <= request.code < 400:
+            meter('tron.site.3xx')
+        if 400 <= request.code < 500:
+            meter('tron.site.4xx')
+        if 500 <= request.code < 600:
+            meter('tron.site.5xx')
 
     def __repr__(self):
         return '%s(%s)' % (self.__class__.__name__, self.resource)

--- a/tron/config/schedule_parse.py
+++ b/tron/config/schedule_parse.py
@@ -250,7 +250,7 @@ def build_groc_schedule_parser_re():
     DATE_SUFFIXES = 'st|nd|rd|th'
 
     # every|1st|2nd|3rd (also would accept 3nd, 1rd, 4st)
-    MONTH_DAYS_EXPR = '(?P<month_days>every|((\d+(%s),?)+))?' % DATE_SUFFIXES
+    MONTH_DAYS_EXPR = r'(?P<month_days>every|((\d+(%s),?)+))?' % DATE_SUFFIXES
     DAYS_EXPR = r'((?P<days>((%s),?)+))?' % DAY_VALUES
     MONTHS_EXPR = r'((in|of)\s+(?P<months>((%s),?)+))?' % MONTH_VALUES
 

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -4,6 +4,7 @@
 import logging
 from collections import deque
 
+import tron.metrics as metrics
 from tron import command_context
 from tron import node
 from tron.core.actionrun import ActionRun
@@ -227,6 +228,7 @@ class JobRun(Observable, Observer):
 
         # propagate all state changes (from action runs) up to state serializer
         self.notify(self.NOTIFY_STATE_CHANGED)
+        metrics.meter(f'tron.actionrun.{event}')
 
         if not action_run.is_done:
             return

--- a/tron/metrics.py
+++ b/tron/metrics.py
@@ -1,0 +1,96 @@
+from pyformance.meters import Counter
+from pyformance.meters import Histogram
+from pyformance.meters import Meter
+from pyformance.meters import SimpleGauge
+from pyformance.meters import Timer
+
+
+all_metrics = {}
+
+
+def get_metric(metric_type, name, dimensions, default):
+    global all_metrics
+    dimensions = tuple(sorted(dimensions.items())) if dimensions else ()
+    key = (metric_type, name, dimensions)
+    return all_metrics.setdefault(key, default)
+
+
+def timer(name, delta, dimensions=None):
+    timer = get_metric('timer', name, dimensions, Timer())
+    timer._update(delta)
+
+
+def count(name, inc=1, dimensions=None):
+    counter = get_metric('counter', name, dimensions, Counter())
+    counter.inc(inc)
+
+
+def meter(name, dimensions=None):
+    meter = get_metric('meter', name, dimensions, Meter())
+    meter.mark()
+
+
+def gauge(name, value, dimensions=None):
+    gauge = get_metric('gauge', name, dimensions, SimpleGauge())
+    gauge.set_value(value)
+
+
+def histogram(name, value, dimensions=None):
+    histogram = get_metric('histogram', name, dimensions, Histogram())
+    histogram.add(value)
+
+
+def view_timer(timer):
+    data = view_meter(timer)
+    data.update(view_histogram(timer))
+    return data
+
+
+def view_counter(counter):
+    return {'count': counter.get_count()}
+
+
+def view_meter(meter):
+    return {
+        'count': meter.get_count(),
+        'm1_rate': meter.get_one_minute_rate(),
+        'm5_rate': meter.get_five_minute_rate(),
+        'm15_rate': meter.get_fifteen_minute_rate(),
+    }
+
+
+def view_gauge(gauge):
+    return {'value': gauge.get_value()}
+
+
+def view_histogram(histogram):
+    snapshot = histogram.get_snapshot()
+    return {
+        'count': histogram.get_count(),
+        'mean': histogram.get_mean(),
+        'min': histogram.get_min(),
+        'max': histogram.get_max(),
+        'p50': snapshot.get_median(),
+        'p75': snapshot.get_75th_percentile(),
+        'p95': snapshot.get_95th_percentile(),
+        'p99': snapshot.get_99th_percentile(),
+    }
+
+
+metrics_to_viewers = {
+    'counter': view_counter,
+    'gauge': view_gauge,
+    'histogram': view_histogram,
+    'meter': view_meter,
+    'timer': view_timer,
+}
+
+
+def view_all_metrics():
+    all_data = {metric_type: [] for metric_type in metrics_to_viewers}
+    for (metric_type, name, dims), metric in all_metrics.items():
+        data = {'name': name, **metrics_to_viewers[metric_type](metric)}
+        if dims:
+            data.update({'dimensions': dict(dims)})
+        all_data[metric_type].append(data)
+    return all_data


### PR DESCRIPTION
Need to add some tests, but otherwise ready for some comments.

Includes:
* timers for successful requests
* meters for all HTTP status codes
* meters for action run state changes
* counters for how many resources are being requested from Mesos

Example response: https://fluffy.yelpcorp.com/i/0VMHJDKh42PpNbkN3sFTbVJ8hZVffCx4.html

I would have to make some changes to taskproc for it to be able to use these gauges/timers instead of yelp_meteorite. Review soon! Either way, I think it's worth having these Tron metrics available. Planning to add a collector to put them into our system later.
