### PR TITLE
Prevent Pymesos thread abort from interrupting main thread

### DIFF
--- a/tests/trondaemon_test.py
+++ b/tests/trondaemon_test.py
@@ -78,3 +78,30 @@ class TronDaemonTestCase(TestCase):
     @teardown
     def teardown(self):
         self.tmpdir.cleanup()
+
+    def test_make_sigint_handler_keyboardinterrupt(self):
+        daemon = TronDaemon.__new__(TronDaemon)  # skip __init__
+        daemon._handle_shutdown = mock.Mock()
+
+        def prev_handler(signum, frame):
+            raise KeyboardInterrupt
+
+        handler = daemon._make_sigint_handler(prev_handler)
+        handler('fake_signum', 'fake_frame')
+
+        daemon._handle_shutdown.call_args == mock.call(
+            'fake_signum',
+            'fake_frame',
+        )
+
+    def test_make_sigint_handler_exception(self):
+        daemon = TronDaemon.__new__(TronDaemon)  # skip __init__
+        daemon._handle_shutdown = mock.Mock()
+
+        def prev_handler(signum, frame):
+            raise Exception
+
+        handler = daemon._make_sigint_handler(prev_handler)
+        handler('fake_signum', 'fake_frame')
+
+        daemon._handle_shutdown.call_count == 0

--- a/tron/trondaemon.py
+++ b/tron/trondaemon.py
@@ -238,8 +238,8 @@ class TronDaemon(object):
             except KeyboardInterrupt:
                 signum = signal.SIGINT
 
+            logging.info(f"Got signal {str(signum)}")
             if signum in signal_map:
-                logging.info(f"Got signal {str(signum)}")
                 signal_map[signum](signum, None)
 
     def _make_sigint_handler(self, prev_handler=None):
@@ -264,7 +264,7 @@ class TronDaemon(object):
                 # We received a SIGINT, but was caused by another thread
                 # aborting due to its own error. In this case, we don't want to
                 # stop running.
-                log.info(f"Non-reactor thread raised: {e}")
+                log.error(f"Non-reactor thread raised: {e}")
                 return
             self._handle_shutdown(signum, frame)
         return handler

--- a/tron/trondaemon.py
+++ b/tron/trondaemon.py
@@ -9,6 +9,7 @@ import logging
 import logging.config
 import os
 import signal
+import threading
 import time
 
 import ipdb
@@ -144,7 +145,7 @@ class NoDaemonContext(object):
             signal.signal(signum, handler)
 
     def terminate(self, signal_number, *_):
-        raise SystemExit(f"Terminating on signal {signal_number!r}")
+        raise SystemExit(f"Terminating on signal {str(signal_number)}")
 
 
 class TronDaemon(object):
@@ -153,35 +154,10 @@ class TronDaemon(object):
     def __init__(self, options):
         self.options = options
         self.mcp = None
+        self._sigint_handler = self._make_sigint_handler(
+            signal.getsignal(signal.SIGINT))
         self.context = self._build_context(options)
         self.manhole_sock = f"{self.options.working_dir}/manhole.sock"
-
-    def _make_sigint_handler(self, prev_handler=None):
-        """ Creates a SIGINT handler that takes into account a previous
-        handler to differentiate between a user request to shutdown, versus
-        another source we want to prevent from interrupting the reactor.
-
-        :type prev_handler: function
-        :param prev_handler: The previous SIGINT handler, set by another source.
-                             We use it to verify whether or not a SIGINT we
-                             received is a genuine shutdown request.
-        """
-        def handler(signum, frame):
-            try:
-                if prev_handler is not None:
-                    prev_handler(signum, frame)
-            except KeyboardInterrupt:
-                # Previous signal handler didn't raise another exception,
-                # so must be user requesting shutdown.
-                pass
-            except Exception as e:
-                # We received a SIGINT, but was caused by another thread
-                # aborting due to its own error. In this case, we don't want to
-                # stop running.
-                log.info(f"Non-reactor thread raised: {e}")
-                return
-            self._handle_shutdown(signum, frame)
-        return handler
 
     def _build_context(self, options):
         pidfile = PIDFile(options.pid_file)
@@ -190,13 +166,11 @@ class TronDaemon(object):
             umask=0o022,
             pidfile=pidfile,
             signal_map={
-                signal.SIGHUP: self._handle_reconfigure,
-                signal.SIGINT: self._make_sigint_handler(
-                    signal.getsignal(signal.SIGINT)
-                ),
-                signal.SIGTERM: self._handle_shutdown,
-                signal.SIGQUIT: self._handle_shutdown,
-                signal.SIGUSR1: self._handle_debug,
+                signal.SIGHUP: signal.SIG_DFL,
+                signal.SIGINT: signal.default_int_handler,
+                signal.SIGTERM: signal.SIG_DFL,
+                signal.SIGQUIT: signal.SIG_DFL,
+                signal.SIGUSR1: signal.SIG_DFL,
             },
             files_preserve=[pidfile.lock.file],
         )
@@ -237,10 +211,66 @@ class TronDaemon(object):
 
     def _run_reactor(self):
         """Run the twisted reactor."""
-        reactor.run()
+        signal_map = {
+            signal.SIGHUP: self._handle_reconfigure,
+            signal.SIGINT: self._sigint_handler,
+            signal.SIGTERM: self._handle_shutdown,
+            signal.SIGQUIT: self._handle_shutdown,
+            signal.SIGUSR1: self._handle_debug,
+        }
+        signal.pthread_sigmask(signal.SIG_BLOCK, signal_map.keys())
+
+        threading.Thread(
+            target=reactor.run,
+            daemon=True,
+            kwargs=dict(installSignalHandlers=0)
+        ).start()
+
+        while True:
+            try:
+                # We use a sigtimedwait instead of a sigwait here because in the
+                # event other threads try to interrupt the main thread, a
+                # KeyboardInterrupt will be thrown. A sigwait will not unblock,
+                # but a sigtimedwait will.
+                signum = signal.sigtimedwait(set(signal_map.keys()), 0)
+                if signum is not None:
+                    signum = signal.Signals(signum.si_signo)
+            except KeyboardInterrupt:
+                signum = signal.SIGINT
+
+            if signum in signal_map:
+                logging.info(f"Got signal {str(signum)}")
+                signal_map[signum](signum, None)
+
+    def _make_sigint_handler(self, prev_handler=None):
+        """ Creates a SIGINT handler that takes into account a previous
+        handler to differentiate between a user request to shutdown, versus
+        another source we want to prevent from interrupting the reactor.
+
+        :type prev_handler: function
+        :param prev_handler: The previous SIGINT handler, set by another source.
+                             We use it to verify whether or not a SIGINT we
+                             received is a genuine shutdown request.
+        """
+        def handler(signum, frame):
+            try:
+                if prev_handler is not None:
+                    prev_handler(signum, frame)
+            except KeyboardInterrupt:
+                # Previous signal handler didn't raise another exception,
+                # so must be user requesting shutdown.
+                pass
+            except Exception as e:
+                # We received a SIGINT, but was caused by another thread
+                # aborting due to its own error. In this case, we don't want to
+                # stop running.
+                log.info(f"Non-reactor thread raised: {e}")
+                return
+            self._handle_shutdown(signum, frame)
+        return handler
 
     def _handle_shutdown(self, sig_num, stack_frame):
-        log.info("Shutdown requested via %s" % sig_num)
+        log.info(f"Shutdown requested via {str(sig_num)}")
         reactor.callLater(0, reactor.stop)
         waited = 0
         while reactor.running:


### PR DESCRIPTION
### Description
- Problems:
    - In the event a pymesos process encounters an error, it will attempt to shutdown the main thread via `thread.interrupt_main` (which raises a `KeyboardInterrupt`)
    - @keymone, in #516, moved `reactor.run` and signal handlers around, which prevented us from properly handling signals ourselves.
        - Instead of explicitly setting signal handlers, he opted to use `signal.sigwait`, which blocks the main thread until a signal is received. However, if a `KeyboardInterrupt` is thrown (say, by pymesos), it is never translated to a `SIGINT` because the main thread is blocked. In some ways, this defeats the purpose of using `signal.sigwait`.
        - Although the intent was to prevent reactor shutdown before state changes complete and are saved, @qui and I found that, through testing, this wasn't true. **This will need to be addressed in a separate PR.**
- Solution:
    - Explicitly set signal handlers (as `DaemonContext` before it was deprecated) so signals can be properly handled (instead of waiting forever on `signal.sigwait`)
    - Add a meta-function that uses the previous SIGINT handler to set our own. To prevent pymesos from shutting down the main thread, we need to differentiate a SIGINT thrown by pymesos from one thrown when, say, a user does a Ctrl-C. By default, pymesos sets its own SIGINT handler, which can differentiate by checking if pymesos threw an exception that led to a SIGINT. In order to preserve our power to handle a SIGINT, my new meta-function generates a handler that calls a 'previous handler' (in this case, pymesos' handler) to see if it thinks the SIGINT was caused by a user-generated `KeyboardInterrupt` or some internal exception from another thread. If it is the former, we shutdown; otherwise, we simply log and continue on.

### Testing
- `tox -e trond_inside_container`: In a simulated, dockerized cluster, caused an error that triggered a `thread.interrupt_main` from pymesos.
- `make test` (including some new tests to test the new meta-function)