### PR TITLE
make sure the response objects can be serializable

### DIFF
--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -52,6 +52,11 @@ def respond(request, response_dict, code=http.OK, headers=None):
     for key, val in six.iteritems((headers or {})):
         request.setHeader(str(key), str(val))
 
+    # make sure the object can be serializable
+    for key, value in response_dict.items():
+        if isinstance(value, set):
+            response_dict[key] = list(value)
+
     result = json.dumps(
         response_dict,
         cls=JSONEncoder,


### PR DESCRIPTION
When I tried to upgrade Tron at devc today, I got the error messages: 
https://fluffy.yelpcorp.com/i/375hk3b6X24v0zmxqgnjTNxxG8cJTZWR.html

Tron response_dict should contain list rather than set so it can be serializable.

Test through "make dev" at my devbox.