### PR TITLE
Convert action deps to list in repr adapter

### DIFF
--- a/tests/api/adapter_test.py
+++ b/tests/api/adapter_test.py
@@ -147,7 +147,7 @@ class TestActionRunGraphAdapter(TestCase):
         result = self.adapter.get_repr()
         assert len(result) == 2
         assert self.a1.id == result[0]['id']
-        assert self.a1.dependent_actions == result[0]['dependent']
+        assert ['a2'] == result[0]['dependent']
 
 
 class TestJobRunAdapter(TestCase):

--- a/tron/api/adapter.py
+++ b/tron/api/adapter.py
@@ -193,7 +193,7 @@ class ActionGraphAdapter(object):
             return {
                 'name': action.name,
                 'command': action.command,
-                'dependent': action.dependent_actions,
+                'dependent': [dep for dep in action.dependent_actions],
             }
 
         return [build(action) for action in self.action_graph.get_actions()]
@@ -214,7 +214,7 @@ class ActionRunGraphAdapter(object):
                 'state': action_run.state,
                 'start_time': action_run.start_time,
                 'end_time': action_run.end_time,
-                'dependent': action.dependent_actions,
+                'dependent': [dep for dep in action.dependent_actions],
             }
 
         return [build(action_run) for action_run in self.action_runs]


### PR DESCRIPTION
Action's dependents is a set which JSON encoder refuses to encode, make it a list in repr adapter.