### PR TITLE
Don't log other signals

### DIFF
--- a/tron/trondaemon.py
+++ b/tron/trondaemon.py
@@ -238,8 +238,8 @@ class TronDaemon(object):
             except KeyboardInterrupt:
                 signum = signal.SIGINT
 
-            logging.info(f"Got signal {str(signum)}")
             if signum in signal_map:
+                logging.info(f"Got signal {str(signum)}")
                 signal_map[signum](signum, None)
 
     def _make_sigint_handler(self, prev_handler=None):


### PR DESCRIPTION
It logs "Got signal None" every time it goes through the loop...

You were right, it should be after the conditional. We only block the signals in the signal map, so we're only going to get those anyway. 

