### PR TITLE
Add get_tron_metrics script and tests

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,3 +1,3 @@
 mock>=0.8
-pre-commit
+pre-commit<1.12.0
 yapf

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1199,9 +1199,7 @@ class TestCheckJobs(TestCase):
         assert_equal(run['id'], 'MASTER.test.2')
         assert_equal(state, State.UNKNOWN)
 
-
-# These tests test guess realert feature
-
+    # These tests test guess realert feature
     def test_guess_realert_every(self):
         job_runs = {
             'status':

--- a/tests/bin/get_tron_metrics_test.py
+++ b/tests/bin/get_tron_metrics_test.py
@@ -19,9 +19,9 @@ def test_send_data_metric():
         autospec=None,
     ) as mock_popen:
         get_tron_metrics.send_data_metric(
-            'fake_name',
-            'fake_metric_type',
-            'fake_value',
+            name='fake_name',
+            metric_type='fake_metric_type',
+            value='fake_value',
             dimensions={'fake_dim_key': 'fake_dim_value'},
             dry_run=False,
         )
@@ -37,9 +37,9 @@ def test_send_data_metric():
 def test_send_data_metric_dry_run():
     with mock.patch('subprocess.Popen', autospec=True) as mock_popen:
         get_tron_metrics.send_data_metric(
-            'fake_name',
-            'fake_metric_type',
-            'fake_value',
+            name='fake_name',
+            metric_type='fake_metric_type',
+            value='fake_value',
             dimensions='fake_dimensions',
             dry_run=True,
         )
@@ -55,9 +55,11 @@ def test_send_counter(mock_send_data_metric):
 
     assert mock_send_data_metric.call_count == 1
     assert mock_send_data_metric.call_args == mock.call(
-        'fake_name',
-        'counter',
-        'fake_count',
+        name='fake_name',
+        metric_type='counter',
+        value='fake_count',
+        dimensions={},
+        dry_run=False,
     )
 
 
@@ -69,9 +71,11 @@ def test_send_gauge(mock_send_data_metric):
 
     assert mock_send_data_metric.call_count == 1
     assert mock_send_data_metric.call_args == mock.call(
-        'fake_name',
-        'gauge',
-        'fake_value',
+        name='fake_name',
+        metric_type='gauge',
+        value='fake_value',
+        dimensions={},
+        dry_run=False,
     )
 
 
@@ -100,7 +104,7 @@ def test_send_histogram(mock_send_gauge):
 
     assert mock_send_gauge.call_count == len(kwargs)
     assert mock_send_gauge.call_args_list[0] == mock.call(
-        'fake_name-p50',
+        'fake_name.p50',
         **p50_kwargs,
     )
 

--- a/tests/bin/get_tron_metrics_test.py
+++ b/tests/bin/get_tron_metrics_test.py
@@ -1,0 +1,134 @@
+import subprocess
+
+import mock
+
+from tron.bin import get_tron_metrics
+
+
+def test_send_data_metric():
+    process = mock.Mock()
+    process.communicate = mock.Mock(return_value=(b'fake_output', b'fake_error'))
+    cmd_str = (
+        'meteorite data -v fake_name fake_metric_type fake_value '
+        '-d fake_dim_key:fake_dim_value'
+    )
+
+    with mock.patch(
+        'subprocess.Popen',
+        mock.Mock(return_value=process),
+        autospec=None,
+    ) as mock_popen:
+        get_tron_metrics.send_data_metric(
+            'fake_name',
+            'fake_metric_type',
+            'fake_value',
+            dimensions={'fake_dim_key': 'fake_dim_value'},
+            dry_run=False,
+        )
+
+        assert mock_popen.call_count == 1
+        assert mock_popen.call_args == mock.call(
+            cmd_str.split(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+
+def test_send_data_metric_dry_run():
+    with mock.patch('subprocess.Popen', autospec=True) as mock_popen:
+        get_tron_metrics.send_data_metric(
+            'fake_name',
+            'fake_metric_type',
+            'fake_value',
+            dimensions='fake_dimensions',
+            dry_run=True,
+        )
+
+        assert mock_popen.call_count == 0
+
+
+@mock.patch('tron.bin.get_tron_metrics.send_data_metric', autospec=True)
+def test_send_counter(mock_send_data_metric):
+    kwargs = dict(count='fake_count')
+
+    get_tron_metrics.send_counter('fake_name', **kwargs)
+
+    assert mock_send_data_metric.call_count == 1
+    assert mock_send_data_metric.call_args == mock.call(
+        'fake_name',
+        'counter',
+        'fake_count',
+    )
+
+
+@mock.patch('tron.bin.get_tron_metrics.send_data_metric', autospec=True)
+def test_send_gauge(mock_send_data_metric):
+    kwargs = dict(value='fake_value')
+
+    get_tron_metrics.send_gauge('fake_name', **kwargs)
+
+    assert mock_send_data_metric.call_count == 1
+    assert mock_send_data_metric.call_args == mock.call(
+        'fake_name',
+        'gauge',
+        'fake_value',
+    )
+
+
+@mock.patch('tron.bin.get_tron_metrics.send_counter', autospec=True)
+def test_send_meter(mock_send_counter):
+    get_tron_metrics.send_meter('fake_name')
+
+    assert mock_send_counter.call_count == 1
+    assert mock_send_counter.call_args == mock.call('fake_name')
+
+
+@mock.patch('tron.bin.get_tron_metrics.send_gauge', autospec=True)
+def test_send_histogram(mock_send_gauge):
+    kwargs = dict(
+        p50='fake_p50',
+        p75='fake_p75',
+        p95='fake_p95',
+        p99='fake_p99',
+    )
+    p50_kwargs = dict(
+        **kwargs,
+        value='fake_p50'
+    )
+
+    get_tron_metrics.send_histogram('fake_name', **kwargs)
+
+    assert mock_send_gauge.call_count == len(kwargs)
+    assert mock_send_gauge.call_args_list[0] == mock.call(
+        'fake_name-p50',
+        **p50_kwargs,
+    )
+
+
+@mock.patch('tron.bin.get_tron_metrics.send_meter', autospec=True)
+@mock.patch('tron.bin.get_tron_metrics.send_histogram', autospec=True)
+def test_send_timer(mock_send_meter, mock_send_histogram):
+    get_tron_metrics.send_timer('fake_name')
+
+    assert mock_send_meter.call_count == 1
+    assert mock_send_meter.call_args == mock.call('fake_name')
+    assert mock_send_histogram.call_count == 1
+    assert mock_send_histogram.call_args == mock.call('fake_name')
+
+
+def test_send_metrics():
+    mock_send_counter = mock.Mock()
+    metrics = dict(counter=[dict(name='fake_name')])
+
+    with mock.patch(
+        'tron.bin.get_tron_metrics._METRIC_SENDERS',
+        dict(counter=mock_send_counter),
+        autospec=None,
+    ):
+        get_tron_metrics.send_metrics(metrics, True)
+
+    assert mock_send_counter.call_count == 1
+    assert mock_send_counter.call_args == mock.call(
+        'fake_name',
+        dry_run=True,
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
     pre-commit run --all-files
 
 [flake8]
-ignore = E501,E265,E241,E704,E251
+ignore = E501,E265,E241,E704,E251,W504
 
 [testenv:docs]
 deps =

--- a/tron/bin/get_tron_metrics.py
+++ b/tron/bin/get_tron_metrics.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3.6
+#
+# get_tron_metrics.py
+#   This script is designed to retrieve metrics from Tron via its API and send
+#   send them to meteorite.
+import logging
+import pprint
+import subprocess
+import sys
+import textwrap
+
+from tron.commands import cmd_utils
+from tron.commands.client import Client
+
+log = logging.getLogger('get_tron_metrics')
+
+
+def parse_cli():
+    parser = cmd_utils.build_option_parser()
+    parser.description = (
+        "Collects metrics from Tron via its API and forwards them to "
+        "meteorite."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Don't actually send metrics out. Defaults: %(default)s"
+    )
+    args = parser.parse_args()
+    return args
+
+
+def check_bin_exists(bin):
+    """
+    Checks if an executable binary exists
+
+    :param bin: (str) Name of the executable; could be a path to one
+    """
+    try:
+        subprocess.call(['which', bin])
+    except OSError:
+        return False
+    return True
+
+
+def send_data_metric(
+    name, metric_type, value,
+    dimensions={}, dry_run=False, **kwargs
+):
+    """
+    Sends a single data point to meteorite via bash command
+
+    :param name: (str) Name of the metric
+    :param metric_type: (str) Type of the meteorite metric. Must be in
+        METEORITE_TYPES
+    :param value: (float) Value of the metric
+    :param dimensions: (dict) Metric dimensions as key-value pairs
+    :param dry_run: (bool) Whether or not to send metrics to meteorite
+    """
+    if dry_run:
+        metric_args = dict(
+            name=name,
+            metric_type=metric_type,
+            value=value,
+            dimensions=dimensions,
+        )
+        log.info(
+            f"Would have sent this to meteorite:\n"
+            f"{pprint.pformat(metric_args)}"
+        )
+        return
+
+    cmd = ['meteorite', 'data', '-v', name, metric_type, str(value)]
+    for k, v in dimensions.items():
+        cmd.extend(['-d', f"{k}:{v}"])
+
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    output, error = process.communicate()
+    output = output.decode('utf-8').rstrip()
+    error = error.decode('utf-8').rstrip()
+
+    if process.returncode:
+        log.error(
+            "Meteorite failed with:\n"
+            f"{textwrap.indent(error, '    ')}"
+        )
+    else:
+        log.debug(f"From meteorite: {output}")
+
+
+def send_counter(name, **kwargs):
+    send_data_metric(name, 'counter', kwargs.pop('count'), **kwargs)
+
+
+def send_gauge(name, **kwargs):
+    send_data_metric(name, 'gauge', kwargs.pop('value'), **kwargs)
+
+
+def send_meter(name, **kwargs):
+    send_counter(name, **kwargs)  # We ignore mX_rate args
+
+
+def send_histogram(name, **kwargs):
+    for k in ['p50', 'p75', 'p95', 'p99']:  # Only send p50-99
+        gauge_name = f"{name}-{k}"
+        kwargs['value'] = kwargs[k]  # set for gauge
+        send_gauge(gauge_name, **kwargs)
+
+
+def send_timer(name, **kwargs):
+    # We mirror the metrics implementation in Tron by splitting timer into a
+    # meter and a histogram
+    send_meter(name, **kwargs)
+    send_histogram(name, **kwargs)
+
+
+_METRIC_SENDERS = {
+    'counter': send_counter,
+    'gauge': send_gauge,
+    'meter': send_meter,
+    'histogram': send_histogram,
+    'timer': send_timer,
+}
+
+
+def send_metrics(metrics, dry_run=False):
+    """
+    Send metrics via meteorite
+
+    :param metrics: Dictionary of metrics types and their data
+    """
+    for metric_type, data in metrics.items():
+        for kwargs in data:
+            name = kwargs.pop('name')
+            kwargs['dry_run'] = dry_run
+            _METRIC_SENDERS[metric_type](name, **kwargs)
+
+
+def main():
+    args = parse_cli()
+    cmd_utils.setup_logging(args)
+    cmd_utils.load_config(args)
+    client = Client(args.server)
+
+    if check_bin_exists('meteorite'):
+        metrics = client.metrics()
+        send_metrics(metrics, dry_run=args.dry_run)
+    else:
+        log.error("'meteorite' was not found")
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tron/bin/get_tron_metrics.py
+++ b/tron/bin/get_tron_metrics.py
@@ -81,7 +81,7 @@ def send_data_metric(name, metric_type, value, dimensions={}, dry_run=False):
     output = output.decode('utf-8').rstrip()
     error = error.decode('utf-8').rstrip()
 
-    if process.returncode:
+    if process.returncode != 0:
         log.error(
             "Meteorite failed with:\n"
             f"{textwrap.indent(error, '    ')}"

--- a/tron/bin/get_tron_metrics.py
+++ b/tron/bin/get_tron_metrics.py
@@ -44,10 +44,7 @@ def check_bin_exists(bin):
     return True
 
 
-def send_data_metric(
-    name, metric_type, value,
-    dimensions={}, dry_run=False, **kwargs
-):
+def send_data_metric(name, metric_type, value, dimensions={}, dry_run=False):
     """
     Sends a single data point to meteorite via bash command
 
@@ -94,11 +91,23 @@ def send_data_metric(
 
 
 def send_counter(name, **kwargs):
-    send_data_metric(name, 'counter', kwargs.pop('count'), **kwargs)
+    send_data_metric(
+        name=name,
+        metric_type='counter',
+        value=kwargs.pop('count'),
+        dimensions=kwargs.pop('dimensions', {}),
+        dry_run=kwargs.pop('dry_run', False),
+    )
 
 
 def send_gauge(name, **kwargs):
-    send_data_metric(name, 'gauge', kwargs.pop('value'), **kwargs)
+    send_data_metric(
+        name=name,
+        metric_type='gauge',
+        value=kwargs.pop('value'),
+        dimensions=kwargs.pop('dimensions', {}),
+        dry_run=kwargs.pop('dry_run', False),
+    )
 
 
 def send_meter(name, **kwargs):
@@ -107,7 +116,7 @@ def send_meter(name, **kwargs):
 
 def send_histogram(name, **kwargs):
     for k in ['p50', 'p75', 'p95', 'p99']:  # Only send p50-99
-        gauge_name = f"{name}-{k}"
+        gauge_name = f"{name}.{k}"
         kwargs['value'] = kwargs[k]  # set for gauge
         send_gauge(gauge_name, **kwargs)
 

--- a/tron/commands/client.py
+++ b/tron/commands/client.py
@@ -110,6 +110,9 @@ class Client(object):
     def status(self):
         return self.http_get('/api/status')
 
+    def metrics(self):
+        return self.http_get('/api/metrics')
+
     def config(
         self,
         config_name,


### PR DESCRIPTION
### Description
- In #559, @qui added a generic metrics endpoint. This script pulls metrics from that endpoint and sends them to meteorite via its bash interface (so we don't need to import it). 
- The script is intended to be run as a cron job.

### Testing
- manual testing with bogus metrics + dry-runs
- make test

### Notes to reviewers
- Should I be adding docs for this? I'm thinking not since this is rather Yelp specific.
- Too many tests? I just added that amount just in case things change later on.
- pre-commit was pinned because it was, at the time of writing, changed recently to use importlib_resources but there aren't wheels available for them yet.