### PR TITLE
Combine DST code into one place

### DIFF
--- a/tron/scheduler.py
+++ b/tron/scheduler.py
@@ -25,9 +25,6 @@ import datetime
 import logging
 import random
 
-from pytz import AmbiguousTimeError
-from pytz import NonExistentTimeError
-
 from tron.config import schedule_parse
 from tron.utils import timeutils
 from tron.utils import trontimespec
@@ -186,25 +183,7 @@ class GeneralScheduler(object):
             ) is None:
                 # tz-naive start times need to be localized first to the requested
                 # time zone.
-                try:
-                    start_time = self.time_zone.localize(
-                        start_time,
-                        is_dst=None,
-                    )
-                except AmbiguousTimeError:
-                    # We are in the infamous 1 AM block which happens twice on
-                    # fall-back. Pretend like it's the first time, every time.
-                    start_time = self.time_zone.localize(
-                        start_time,
-                        is_dst=True,
-                    )
-                except NonExistentTimeError:
-                    # We are in the infamous 2:xx AM block which does not
-                    # exist. Pretend like it's the later time, every time.
-                    start_time = self.time_zone.localize(
-                        start_time,
-                        is_dst=True,
-                    )
+                start_time = trontimespec.naive_as_timezone(start_time, self.time_zone)
 
         return self.time_spec.get_match(start_time) + get_jitter(self.jitter)
 


### PR DESCRIPTION
This changes existing behavior in one way: if you have a timezone set, the trontimespec used to always schedule for the second hour in the ambiguous case. Now, it will schedule for the first.

I tested this pretty extensively on playground by changing the system clock. Now in all cases, whether or not there is a timezone set, jobs will run in the first 1AM hour, and not the second 1AM.

e.g. on November 4th, a job that runs every 30 min would run at:
- [x] 00:30 PDT
- [x] 01:00 PDT
- [x] 01:30 PDT
- [ ] 01:00 PST
- [ ] 01:30 PST
- [x] 02:00 PST