### PR TITLE
Allow tron to run after unclean shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,14 @@ tron.iml
 __pycache__/
 .pytest_cache/
 tron_state
+tron.lock
+manhole.sock
+manhole.sock.lock
 
 # Example cluster
 example-cluster/config
 example-cluster/MASTER.*
-example-cluster/tron-repl.pid
+example-cluster/tron-repl.lock
 example-cluster/tron_state*
 example-cluster/manhole.sock*
 example-cluster/_events/

--- a/bin/trond
+++ b/bin/trond
@@ -20,8 +20,8 @@ log = logging.getLogger(__name__)
 DEFAULT_CONF = 'default_config.yaml'
 DEFAULT_CONF_PATH = 'config/'
 DEFAULT_WORKING_DIR = '/var/lib/tron/'
-DEFAULT_PIDFILE = 'tron.pid'
-DEFAULT_PIDPATH = '/var/run/' + DEFAULT_PIDFILE
+DEFAULT_LOCKFILE = 'tron.lock'
+DEFAULT_LOCKPATH = '/var/run/' + DEFAULT_LOCKFILE
 
 
 def parse_cli():
@@ -54,11 +54,16 @@ def parse_cli():
         help="[DEPRECATED] Disable daemonizing, default %(default)s",
     )
 
-    parser.add_argument(
+    parser.add_argument(  # for backwards compatibility
         "--pid-file",
-        help="File path to PID file, defaults to %s if working directory "
+        help="[DEPRECATED] File path to pid file. Use --lock-file instead."
+    )
+
+    parser.add_argument(
+        "--lock-file",
+        help="File path to lock file, defaults to %s if working directory "
         "is default. Otherwise defaults to <working dir>/%s" %
-        (DEFAULT_PIDPATH, DEFAULT_PIDFILE),
+        (DEFAULT_LOCKPATH, DEFAULT_LOCKFILE),
     )
 
     logging_group = parser.add_argument_group('logging', '')
@@ -118,13 +123,15 @@ def parse_cli():
         if not os.path.exists(args.log_conf):
             parser.error("Logging config file not found: %s" % args.log_conf, )
 
-    if not args.pid_file:
-        if args.working_dir == DEFAULT_WORKING_DIR:
-            args.pid_file = DEFAULT_PIDPATH
+    if not args.lock_file:
+        if args.pid_file:  # for backwards compatibility
+            args.lock_file = args.pid_file
+        elif args.working_dir == DEFAULT_WORKING_DIR:
+            args.lock_file = DEFAULT_LOCKPATH
         else:
-            args.pid_file = DEFAULT_PIDFILE
+            args.lock_file = DEFAULT_LOCKFILE
 
-    args.pid_file = os.path.join(args.working_dir, args.pid_file)
+    args.lock_file = os.path.join(args.working_dir, args.lock_file)
     args.config_path = os.path.join(
         args.working_dir,
         args.config_path,

--- a/bin/tronrepl
+++ b/bin/tronrepl
@@ -21,8 +21,8 @@ log = logging.getLogger(__name__)
 DEFAULT_CONF = 'default_config.yaml'
 DEFAULT_CONF_PATH = 'config/'
 DEFAULT_WORKING_DIR = '/var/lib/tron/'
-DEFAULT_PIDFILE = 'tron-repl.pid'
-DEFAULT_PIDPATH = '/var/run/' + DEFAULT_PIDFILE
+DEFAULT_LOCKFILE = 'tron-repl.lock'
+DEFAULT_LOCKPATH = '/var/run/' + DEFAULT_LOCKFILE
 
 
 def parse_cli():
@@ -55,11 +55,16 @@ def parse_cli():
         help="[DEPRECATED] Disable daemonizing, default %(default)s",
     )
 
-    parser.add_argument(
+    parser.add_argument(  # for backwards compatibility
         "--pid-file",
-        help="File path to PID file, defaults to %s if working directory "
+        help="[DEPRECATED] File path to pid file. Use --lock-file instead."
+    )
+
+    parser.add_argument(
+        "--lock-file",
+        help="File path to lock file, defaults to %s if working directory "
         "is default. Otherwise defaults to <working dir>/%s" %
-        (DEFAULT_PIDPATH, DEFAULT_PIDFILE),
+        (DEFAULT_LOCKPATH, DEFAULT_LOCKFILE),
     )
 
     logging_group = parser.add_argument_group('logging', '')
@@ -119,13 +124,15 @@ def parse_cli():
         if not os.path.exists(args.log_conf):
             parser.error("Logging config file not found: %s" % args.log_conf, )
 
-    if not args.pid_file:
-        if args.working_dir == DEFAULT_WORKING_DIR:
-            args.pid_file = DEFAULT_PIDPATH
+    if not args.lock_file:
+        if args.pid_file:  # for backwards compatibility
+            args.lock_file = args.pid_file
+        elif args.working_dir == DEFAULT_WORKING_DIR:
+            args.lock_file = DEFAULT_LOCKPATH
         else:
-            args.pid_file = DEFAULT_PIDFILE
+            args.lock_file = DEFAULT_LOCKFILE
 
-    args.pid_file = os.path.join(args.working_dir, args.pid_file)
+    args.lock_file = os.path.join(args.working_dir, args.lock_file)
     args.config_path = os.path.join(
         args.working_dir,
         args.config_path,

--- a/contrib/sync-from-yelp-prod.sh
+++ b/contrib/sync-from-yelp-prod.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 rsync --exclude=.stderr --exclude=.stdout -aPv tron-prod:/nail/tron/*  example-cluster/
 git checkout example-cluster/logging.conf
-rm -f example-cluser/tron.lock
 
 echo ""
 echo "Now Run:"

--- a/contrib/sync-from-yelp-prod.sh
+++ b/contrib/sync-from-yelp-prod.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 rsync --exclude=.stderr --exclude=.stdout -aPv tron-prod:/nail/tron/*  example-cluster/
 git checkout example-cluster/logging.conf
-rm -f example-cluser/tron.pid
+rm -f example-cluser/tron.lock
 
 echo ""
 echo "Now Run:"

--- a/debian/tron.service
+++ b/debian/tron.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=tron
 EnvironmentFile=/etc/default/tron
-ExecStart=/usr/bin/trond --pid-file=${PIDFILE} --working-dir=${WORKINGDIR} -H 0.0.0.0 -P 8089 -l ${LOGCONF}
+ExecStart=/usr/bin/trond --lock-file=${LOCKFILE:-$PIDFILE} --working-dir=${WORKING+DIR} -H 0.0.0.0 -P 8089 -l ${LOGCONF}
 TimeoutStopSec=20
 Restart=on-failure
 

--- a/debian/tron.service
+++ b/debian/tron.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=tron
 EnvironmentFile=/etc/default/tron
-ExecStart=/usr/bin/trond --lock-file=${LOCKFILE:-$PIDFILE} --working-dir=${WORKING+DIR} -H 0.0.0.0 -P 8089 -l ${LOGCONF}
+ExecStart=/usr/bin/trond --lock-file=${LOCKFILE:-$PIDFILE} --working-dir=${WORKINGDIR} -H 0.0.0.0 -P 8089 -l ${LOGCONF}
 TimeoutStopSec=20
 Restart=on-failure
 

--- a/docs/man/trond.8
+++ b/docs/man/trond.8
@@ -63,8 +63,8 @@ Debug mode, extra error reporting, no daemonizing
 .B \fB\-\-nodaemon\fP
 (DEPRECATED in 0.9.4) Indicates we should not fork and daemonize the process (default False)
 .TP
-.B \fB\-\-pid\-file=PIDFILE\fP
-Where to store pid of the executing process (default /var/run/tron.pid)
+.B \fB\-\-lock\-file=LOCKFILE\fP
+Where to store the lock file of the executing process (default /var/run/tron.lock)
 .TP
 .B \fB\-P LISTEN_PORT, \-\-port=LISTEN_PORT\fP
 What port to listen on, defaults 8089
@@ -78,8 +78,8 @@ What host to listen on defaults to localhost
 .B Working directory
 The directory where state and saved output of processes are stored.
 .TP
-.B Pid file
-Contains the pid of the daemonized process.
+.B Lock file
+Ensures only one daemon runs at a time.
 .TP
 .B Log File
 trond error log, configured from logging.conf

--- a/docs/man_trond.rst
+++ b/docs/man_trond.rst
@@ -40,8 +40,8 @@ Options
 ``--nodaemon``
     [DEPRECATED in 0.9.4] Indicates we should not fork and daemonize the process (default False)
 
-``--pid-file=PIDFILE``
-    Where to store pid of the executing process (default /var/run/tron.pid)
+``--lock-file=LOCKFILE``
+    Where to store the lock file of the executing process (default /var/run/tron.lock)
 
 ``-P LISTEN_PORT, --port=LISTEN_PORT``
     What port to listen on, defaults 8089
@@ -55,8 +55,8 @@ Files
 Working directory
     The directory where state and saved output of processes are stored.
 
-Pid file
-    Contains the pid of the daemonized process.
+Lock file
+    Ensures only one daemon runs at a time.
 
 Log File
     trond error log, configured from logging.conf

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -38,7 +38,7 @@ On your management node, run::
     $ sudo -u <tron user> trond
 
 The chosen user will need SSH access to all your worker nodes, as well as
-permission to write to the working directory, log file, and pid file
+permission to write to the working directory, log file, and lock file
 (see ``trond --help`` for defaults).  You can change these directories using
 command line options. Also see :ref:`config_logging` on how to change the
 default logging settings.

--- a/example-cluster/start.sh
+++ b/example-cluster/start.sh
@@ -23,7 +23,6 @@ if ! pip3.6 list --format=columns | grep 'tron.*/work' > /dev/null; then
 fi
 
 echo Starting Tron
-rm -f /nail/tron/tron.lock
 FAKETIME_X=${FAKETIME_X:-10}
 exec faketime -f "+0.0y x$FAKETIME_X" \
   trond -l logging.conf -w /nail/tron -v --debug -H 0.0.0.0

--- a/example-cluster/start.sh
+++ b/example-cluster/start.sh
@@ -23,7 +23,7 @@ if ! pip3.6 list --format=columns | grep 'tron.*/work' > /dev/null; then
 fi
 
 echo Starting Tron
-rm -f /nail/tron/tron.pid
+rm -f /nail/tron/tron.lock
 FAKETIME_X=${FAKETIME_X:-10}
 exec faketime -f "+0.0y x$FAKETIME_X" \
   trond -l logging.conf -w /nail/tron -v --debug -H 0.0.0.0

--- a/example-cluster/sync-from-yelp-prod.sh
+++ b/example-cluster/sync-from-yelp-prod.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 rsync --exclude=.stderr --exclude=.stdout -aPv tron-prod:/nail/tron/config  example-cluster/
 rsync --exclude=.stderr --exclude=.stdout -aPv tron-prod:/nail/tron/tron_state_0.6.1.5.gdbm  example-cluster/
-rm example-cluser/tron.lock

--- a/example-cluster/sync-from-yelp-prod.sh
+++ b/example-cluster/sync-from-yelp-prod.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 rsync --exclude=.stderr --exclude=.stdout -aPv tron-prod:/nail/tron/config  example-cluster/
 rsync --exclude=.stderr --exclude=.stdout -aPv tron-prod:/nail/tron/tron_state_0.6.1.5.gdbm  example-cluster/
-rm example-cluser/tron.pid
+rm example-cluser/tron.lock

--- a/tests/utils/flockfile_test.py
+++ b/tests/utils/flockfile_test.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import os
+import tempfile
+
+import mock
+import pytest
+
+from tron.utils.flockfile import FlockFile
+
+
+@pytest.fixture
+def tmp_lockfile():
+    tmpdir = tempfile.TemporaryDirectory()
+    yield os.path.join(tmpdir.name, "test.lock")
+    tmpdir.cleanup()
+
+
+@pytest.fixture
+def mock_flockfile(tmp_lockfile):
+    return FlockFile(tmp_lockfile)
+
+
+@pytest.mark.parametrize('is_locked', [True, False])
+def test_is_locked(mock_flockfile, is_locked):
+    mock_flockfile._has_lock = is_locked
+
+    assert mock_flockfile.is_locked == is_locked
+
+
+@mock.patch('fcntl.flock', mock.Mock(side_effect=OSError), autospec=None)
+def test_is_locked_by_other(mock_flockfile):
+    mock_flockfile._has_lock = False
+
+    assert mock_flockfile.is_locked
+
+
+def test_acquire(mock_flockfile):
+    mock_flockfile.acquire()
+
+    assert mock_flockfile._has_lock
+
+
+@mock.patch('fcntl.flock', mock.Mock(side_effect=OSError), autospec=None)
+def test_acquire_other_process_locked(mock_flockfile):
+    with pytest.raises(OSError):
+        mock_flockfile.acquire()
+
+    assert not mock_flockfile._has_lock
+
+
+def test_release(mock_flockfile):
+    mock_flockfile.acquire()  # already tested
+
+    mock_flockfile.release()
+
+    assert not mock_flockfile._has_lock
+
+
+@mock.patch('fcntl.flock', mock.Mock(side_effect=BlockingIOError), autospec=None)
+def test_release_other_process_locked(mock_flockfile):
+    mock_flockfile._has_lock = True  # not possible, but allows us to test below
+
+    with pytest.raises(BlockingIOError):
+        mock_flockfile.release()
+
+    assert mock_flockfile._has_lock

--- a/tron/utils/flockfile.py
+++ b/tron/utils/flockfile.py
@@ -3,77 +3,54 @@ from __future__ import unicode_literals
 
 import fcntl
 import logging
-import os
-
-import lockfile
 
 log = logging.getLogger(__name__)
 
 
 class FlockFile(object):
-    """
-    A lockfile (matching the specification of the builtin lockfile class)
-    based off of flock. Single lockfile per process (no thread support)..
+    """ Provides a simple interface to locking and unlocking files, including
+    through context management.
     """
 
     def __init__(self, path):
         self.path = path
-        self.lock_file = None
-        try:
-            self.lock_file = open(self.path, 'a')
-        except (IOError, OSError) as e:
-            raise lockfile.LockFailed(e, self.path)
+        self.file = open(self.path, 'a')  # can raise OSError
         self._has_lock = False
 
-    @property
-    def file(self):
-        """Get a handle to the underlying lock file (to write out data to)"""
-        return self.lock_file
-
-    def acquire(self):
-        log.debug("Locking %s", self.path)
-        try:
-            fcntl.flock(self.lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            self._has_lock = True
-        except IOError as e:
-            raise lockfile.AlreadyLocked(e, self.path)
-        log.debug("Locked %s", self.path)
-
-    def break_lock(self):
-        """Can't break posix locks, sorry man"""
-        raise lockfile.LockError()
+    def __str__(self):
+        return self.path
 
     @property
-    def i_am_locking(self):
-        return self._has_lock
-
     def is_locked(self):
         if self._has_lock:
             return True
         try:
-            fcntl.flock(self.lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            fcntl.flock(self.lock_file.fileno(), fcntl.LOCK_UN)
+            fcntl.flock(self.file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(self.file.fileno(), fcntl.LOCK_UN)
             return False
-        except IOError:
+        except OSError:
+            log.debug(f"Locked by another process: {self.path}")
             return True
 
-    def release(self):
-        log.debug("Releasing lock on %s", self.path)
-        if self.i_am_locking:
-            fcntl.flock(self.lock_file.fileno(), fcntl.LOCK_UN)
-            self._has_lock = False
-        else:
-            raise lockfile.NotLocked(self.path)
-        log.debug("Unlocked %s", self.path)
-
-    def destroy(self):
+    def acquire(self):
+        log.debug(f"Attempting to lock: {self.path}")
         try:
-            if self.i_am_locking:
-                self.release()
-            self.lock_file.close()
-        finally:
-            if os.path.exists(self.path):
-                os.unlink(self.path)
+            fcntl.flock(self.file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            self._has_lock = True
+        except OSError as e:  # locked by someone else
+            log.debug(f"Locked by another process: {self.path}")
+            raise e
+        log.debug(f"Locked {self.path}")
+
+    def release(self):
+        log.debug(f"Attempting to unlock: {self.path}")
+        try:
+            fcntl.flock(self.file.fileno(), fcntl.LOCK_UN)
+            self._has_lock = False
+        except BlockingIOError as e:  # locked by someone else
+            log.debug(f"Locked by another process: {self.path}")
+            raise e
+        log.debug(f"Unlocked {self.path}")
 
     def __enter__(self):
         self.acquire()


### PR DESCRIPTION
### Description
- In the event of an unclean shutdown, Tron's pidfile and manhole socket could be left behind in the working directory, preventing another Tron daemon running, despite there being no existing daemon. However, these changes will allow us ignore those orphaned files and start Tron regardless.
- `tron.pid`:
    - If we find a pid file and verify no process is running with that pid, instead of exiting, we now simply clear it out and continue on.
    - We do not delete it, as we have already acquired a lock on it.
- `manhole.sock`:
    - If `manhole.sock.lock` was also left behind after an unclean shutdown, Tron is already able to reclaim the lock and start with no problems.
    - However, if the lock file was removed but the socket file remains, Tron would previously refuse to start. Now, the Tron daemon will simply delete the old manhole socket and continue on.

### Testing
- manual testing with `make dev`
- `make test`

### Notes to reviewers
- I also moved the call to `setup_logging` to the `TronDaemon` initialization because otherwise we wouldn't be able to properly log before actually running the daemon, like, say, during setup.