### PR TITLE
rename all job_name after migration

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,3 +1,3 @@
 mock>=0.8
-pre-commit
+pre-commit<1.12.0
 yapf

--- a/tron/core/job_scheduler.py
+++ b/tron/core/job_scheduler.py
@@ -197,6 +197,8 @@ class JobScheduler(Observer):
 
     def update_name(self, name):
         self.job.name = name
+        for run in self.get_job_runs():
+            run.job_name = name
         self.job.runs.remove_pending()
         self.create_and_schedule_runs(ignore_last_run_time=False)
 


### PR DESCRIPTION
Manually testing on my dev box. After "tronctl move test1.test test2.test", all runs for test1.test would be named as test2.test.[number]. https://fluffy.yelpcorp.com/i/t03slj07PwVkq49q7n9rnHM4jdWv60nQ.html

To resolve the page, we can do:
  1. make a release
  2. move the affected jobs to the old namespace through tronctl
  3. move them back to the new namespace through tronctl