### PR TITLE
Don't display actions/jobs in sorted order in tronview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ example-cluster/manhole.sock*
 example-cluster/_events/
 *.stdout
 *.stderr
+dev/manhole.sock.lock
+dev/tron.pid
 
 # Generated debian artifacts
 debian/tron

--- a/tron/commands/display.py
+++ b/tron/commands/display.py
@@ -384,6 +384,9 @@ class DisplayActionRuns(TableDisplay):
         self.data = data['runs']
         self.job_run = data
 
+    def rows(self):
+        return self.data
+
 
 def display_node(source, _=None):
     if not source:


### PR DESCRIPTION
This is the "easy" part, but I think we need to be careful what we wish for.
This also "unsorts" the big `tronview` list. I think I kinda want that sorted?

But the bigger issue is that "the order on disk" is not what users think it is. This is because tronfig re-serializes the content into yaml *again* before posting. 

This PR is only half of the puzzle, because what the user actually needs is this *plus* us not sorting the yaml when we post. To do that, we'll need a different yaml library or some workarounds:
https://stackoverflow.com/questions/16782112/can-pyyaml-dump-dict-items-in-non-alphabetical-order

I could be convinced in either direction about what we should do (including no-ship). 