### PR TITLE
Allow TASK_LOST updates to retry automatically

### DIFF
--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -1249,3 +1249,22 @@ class TestMesosActionRun:
         self.action_run.machine.state = ActionRun.RUNNING
         error_message = self.action_run.stop()
         assert error_message == "Error: Can't find task id for the action."
+
+    def test_handler_exiting_unknown_retry(self):
+        self.action_run.action_command = mock.create_autospec(
+            actioncommand.ActionCommand,
+            exit_status=None,
+        )
+        self.action_run.retries_remaining = 1
+        self.action_run.exit_statuses = []
+        self.action_run.start = mock.Mock()
+
+        self.action_run.machine.transition('start')
+        self.action_run.machine.transition('started')
+        assert self.action_run.handler(
+            self.action_run.action_command,
+            ActionCommand.EXITING,
+        )
+        assert self.action_run.retries_remaining == 0
+        assert not self.action_run.is_unknown
+        assert self.action_run.start.call_count == 1

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -1250,6 +1250,20 @@ class TestMesosActionRun:
         error_message = self.action_run.stop()
         assert error_message == "Error: Can't find task id for the action."
 
+    def test_handler_exiting_unknown(self):
+        self.action_run.action_command = mock.create_autospec(
+            actioncommand.ActionCommand,
+            exit_status=None,
+        )
+        self.action_run.machine.transition('start')
+        self.action_run.machine.transition('started')
+        assert self.action_run.handler(
+            self.action_run.action_command,
+            ActionCommand.EXITING,
+        )
+        assert self.action_run.is_unknown
+        assert self.action_run.exit_status is None
+
     def test_handler_exiting_unknown_retry(self):
         self.action_run.action_command = mock.create_autospec(
             actioncommand.ActionCommand,
@@ -1268,3 +1282,15 @@ class TestMesosActionRun:
         assert self.action_run.retries_remaining == 0
         assert not self.action_run.is_unknown
         assert self.action_run.start.call_count == 1
+
+    def test_handler_exiting_failstart_unknown(self):
+        self.action_run.action_command = mock.create_autospec(
+            actioncommand.ActionCommand,
+            exit_status=None,
+        )
+        self.action_run.machine.transition('start')
+        assert self.action_run.handler(
+            self.action_run.action_command,
+            ActionCommand.FAILSTART,
+        )
+        assert self.action_run.is_unknown

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -856,7 +856,6 @@ class MesosActionRun(ActionRun, Observer):
 
     def handle_action_command_state_change(self, action_command, event):
         """Observe ActionCommand state changes."""
-        # TODO: consolidate? Same as SSHActionRun for now
         log.debug(
             f"{self} action_command state change: {action_command.state}"
         )
@@ -869,7 +868,9 @@ class MesosActionRun(ActionRun, Observer):
 
         if event == ActionCommand.EXITING:
             if action_command.exit_status is None:
-                return self.fail_unknown()
+                # This is different from SSHActionRun
+                # Allows retries to happen, if configured
+                return self._exit_unsuccessful(None)
 
             if not action_command.exit_status:
                 return self.success()


### PR DESCRIPTION
Before, we had decided that we shouldn't retry if an action becomes unknown, because it means we've lost the connection and we don't know enough to retry. 

With Mesos, actions become unknown if we get a TASK_LOST update for them. In most cases, TASK_LOST means the agent running the task was terminated, and we should retry. It's possible that we get TASK_LOST for a task that is still running, in the case of a network partition, but I think if an action has automatic retries configured, they should be resilient to at-least-once execution anyway. 

This is kind of the same as losing an SSH connection, but... it didn't make sense to me to tell people that they would need to manually retry these cases, if it's going to be common with spot fleet. Thoughts?