### PR TITLE
Add cluster option to metrics script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ tron.iml
 __pycache__/
 .pytest_cache/
 tron_state
+tron.lock
 
 # Example cluster
 example-cluster/config


### PR DESCRIPTION
### Description
- Added a `cluster` option to the `get_tron_metrics` script
- In the script, we forward the `cluster` value as a dimension in all Tron metrics we send to meteorite

### Test
- dry-run for metrics script
- make test