### PR TITLE
Fix start bug

### DIFF
--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -755,6 +755,17 @@ class ActionRunStateRestoreTestCase(testingutils.MockTimeTestCase):
         assert action_run.exit_status == 0
         assert action_run.end_time == self.now
 
+    def test_from_state_starting(self):
+        self.state_data['state'] = 'starting'
+        action_run = ActionRun.from_state(
+            self.state_data,
+            self.parent_context,
+            self.output_path,
+            self.run_node,
+            lambda: None,
+        )
+        assert action_run.is_unknown
+
     def test_from_state_queued(self):
         self.state_data['state'] = 'queued'
         action_run = ActionRun.from_state(

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -339,10 +339,9 @@ class ActionRun(Observable):
         )
 
         # Transition running to fail unknown because exit status was missed
-        if run.is_running:
+        # Recovery will look for unknown runs
+        if run.is_active:
             run._done('fail_unknown')
-        if run.is_starting:
-            run.handle(ActionCommand.FAILSTART)
         return run
 
     def start(self):

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -722,7 +722,7 @@ class SSHActionRun(ActionRun, Observer):
             return self.transition_and_notify('started')
 
         if event == ActionCommand.FAILSTART:
-            return self._exit_unsuccessful(-2)
+            return self._exit_unsuccessful(self.EXIT_NODE_ERROR)
 
         if event == ActionCommand.EXITING:
             if action_command.exit_status is None:


### PR DESCRIPTION
`handle` doesn't even exist, the attribute is called `handler`... added a test for it.
I actually can't use the handler anyway because it wants an ActionCommand to be passed in.

We can make both starting and running actions unknown because recovery will be looking for unknown actions and transitioning them to failed if they didn't start, anyway.