### PR TITLE
Don't schedule jobs if they are disabled when renaming namespace

### DIFF
--- a/tron/core/job_scheduler.py
+++ b/tron/core/job_scheduler.py
@@ -200,8 +200,6 @@ class JobScheduler(Observer):
             for action_run in job_run._get_action_runs():
                 action_run.job_run_id = action_run.job_run_id.replace(job_run.job_name, name, 1)
             job_run.job_name = name
-        self.job.runs.remove_pending()
-        self.create_and_schedule_runs(ignore_last_run_time=False)
 
     def __str__(self):
         return f"{self.__class__.__name__}({self.job})"


### PR DESCRIPTION
I've reproduced the bug and tested the fix at tron-mesosstage