### PR TITLE
Log more information from terminal Mesos events

### DIFF
--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -244,6 +244,10 @@ class MesosTask(ActionCommand):
 
         if event.terminal:
             self.log.info('Event was terminal, closing task')
+            message = event.raw.get('message', '')
+            reason = event.raw.get('reason', '')
+            if message or reason:
+                self.log.info(f'More info: {reason}: {message}')
             self.report_resources(decrement=True)
 
             exit_code = int(not getattr(event, 'success', False))


### PR DESCRIPTION
First step to making LOST updates more informative. 
Considering making taskproc partition-aware so we get task dropped/unreachable/gone instead of lost, but this is an easy first step.

http://mesos.apache.org/documentation/latest/task-state-reasons/