### PR TITLE
Add signal queue with tests

### DIFF
--- a/tests/utils/signalqueue_test.py
+++ b/tests/utils/signalqueue_test.py
@@ -1,0 +1,42 @@
+import signal
+
+import mock
+import pytest
+
+from tron.utils.signalqueue import SignalQueue
+
+
+@pytest.fixture
+def mock_lock():
+    with mock.patch('threading.Lock', autospec=True) as mock_Lock:
+        yield mock_Lock
+
+
+@pytest.fixture
+def mock_sigqueue(mock_lock):
+    return SignalQueue()
+
+
+def test_init(mock_sigqueue, mock_lock):
+    # we don't want any locking in this module, since it'll cause deadlock
+    assert mock_lock.call_count == 0
+
+
+def test_wait_empty(mock_sigqueue):
+    signum = mock_sigqueue.wait()
+
+    assert signum is None
+
+
+def test_wait_pending(mock_sigqueue):
+    mock_sigqueue._q.put_nowait(signal.SIGINT)
+
+    signum = mock_sigqueue.wait()
+
+    assert signum == signal.SIGINT
+
+
+def test_handler(mock_sigqueue):
+    mock_sigqueue.handler(signal.SIGINT, None)
+
+    assert mock_sigqueue._q.get_nowait() == signal.SIGINT

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
 usedevelop = true
 passenv = USER
 commands =
-    py.test -s {posargs:tests}
+    py.test -s -v {posargs:tests}
     pre-commit install -f --install-hooks
     pre-commit run --all-files
 

--- a/tron/utils/signalqueue.py
+++ b/tron/utils/signalqueue.py
@@ -1,0 +1,54 @@
+import asyncio
+import logging
+import signal
+
+log = logging.getLogger(__name__)
+
+
+# We cannot use the queue module's Queue because the latter locks on queue
+# operations, which do not play well with signal handlers since handlers can
+# interrupt at any time. Consider the following main thread traceback:
+#
+# --- Normal Main Thread Operation ---
+# 1. q.wait()
+# 2. q.get_nowait()
+# 3. q._lock.acquire() (internal)
+# --- Signal Handler Interrupts (always on main thread)---
+# 4. q.handler()
+# 5. q.put_nowait()
+# 6. q._lock.acquire() (internal) <------- DEADLOCK (lock hasn't been released)
+#
+# Given that signal handlers work by interruption, it is impossible to enforce
+# locking on queue operations without encountering deadlock issues.
+#
+# Instead, we use asyncio's Queue, because its operations are not locked.
+# Given this module's simplicity, however, this is not an issue, even in a
+# multi-threaded program.
+
+class SignalQueue(object):
+    """ A queue for signals, which provides functionality for producing signals
+    from signal handlers, and consuming signals if there are anuy pending
+    """
+
+    def __init__(self):
+        self._q = asyncio.Queue()  # technically not thread-safe
+
+    def empty(self):
+        """ Returns whether or not the queue is empty """
+        return self._q.empty()
+
+    def wait(self):
+        """ Dequeues and returns a signal if one is available """
+        try:
+            signum = self._q.get_nowait()
+            log.info(f'Dequeued signal: {str(signal.Signals(signum))}')
+            return signum
+        except asyncio.QueueEmpty:
+            return None
+
+    def handler(self, signum, frame):
+        """ Signal handler that enqueues the received signal into the signal
+        queue.
+        """
+        self._q.put_nowait(signum)
+        log.info(f'Enqueued signal: {str(signal.Signals(signum))}')


### PR DESCRIPTION
### Description
- Add the SignalQueue class, which makes it so that signal handlers enqueue signals, so that we can dequeue them elsewhere to handle them serially.
- Modify the Tron daemon to use this class to handle signals

### Tests done
- make test
- pymesos interrupt tests (via docker): This change still allows us to detect when interrupts come from pymesos and continue on regardless.
- mesosstage: Manually started and stopped the tron service to ensure SIGTERM's are being properly caught and handled via the new SignalQueue.

### Notes to reviewers
- Solves the issue highlighted in PR #589
- What do I use a non-thread-safe queue?
    - tl;dr: Deadlock caused by enqueuing pending signals while waiting for them
    - I approached this problem by simulating `sigwait`'s behavior; that is, when a signal is received, assuming the signal handler doesn't terminate the program, the signal should be set to pending so that `sigwait` can return them.
    - I initially used Python's `queue.Queue` as my queue implementation. These queues are designed to be used in multithreaded applications and are therefore made thread-safe by way of locks.
    - What I found was that the act of calling a signal handler while the main thread is waiting for a signal can result in deadlock. Observe the following traceback:
        - --- Normal Main Thread Operation ---
        - q.wait()
        - q.get_nowait()
        - q._lock.acquire() (internal)
        - --- Signal Handler Interrupts (always on main thread)---
        - q.handler(signal, frame)
        - q.put_nowait(signal)
        - q._lock.acquire() (internal) <------- DEADLOCK (lock hasn't - been released)
    - As a result, a non-thread-safe queue implementation had to be used. However, given the simplicity of how we used this queue, locks are not needed.