### PR TITLE
Fix signal handling in tron daemon

### DIFF
--- a/tests/trondaemon_test.py
+++ b/tests/trondaemon_test.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 import os
 import tempfile
-from collections import defaultdict
 
 import mock
 
@@ -15,72 +14,33 @@ from tron.trondaemon import TronDaemon
 
 class TronDaemonTestCase(TestCase):
     @setup
+    @mock.patch('tron.trondaemon.setup_logging', mock.Mock(), autospec=None)
+    @mock.patch('signal.signal', mock.Mock(), autospec=None)
     def setup(self):
         self.tmpdir = tempfile.TemporaryDirectory()
         trond_opts = mock.Mock()
         trond_opts.working_dir = self.tmpdir.name
         trond_opts.lock_file = os.path.join(self.tmpdir.name, "lockfile")
-        with mock.patch('tron.trondaemon.setup_logging', autospec=True):
-            self.trond = TronDaemon(trond_opts)
+        self.trond = TronDaemon(trond_opts)
 
     @teardown
     def teardown(self):
         self.tmpdir.cleanup()
 
     @mock.patch('tron.trondaemon.setup_logging', mock.Mock(), autospec=None)
+    @mock.patch('signal.signal', mock.Mock(), autospec=None)
     def test_init(self):
         daemon = TronDaemon.__new__(TronDaemon)  # skip __init__
-        daemon._make_sigint_handler = mock.Mock()
         options = mock.Mock()
-        _sig_handlers = defaultdict(lambda: 'original_handler')
 
         with mock.patch(
-            'signal.getsignal',
-            mock.Mock(side_effect=_sig_handlers.__getitem__),
-            autospec=None
-        ), mock.patch(
-            'signal.signal',
-            mock.Mock(side_effect=_sig_handlers.__setitem__),
-            autospec=None
-        ), mock.patch(
             'tron.utils.flockfile.FlockFile',
             autospec=True,
         ) as mock_flockfile:
             daemon.__init__(options)
 
-            assert daemon._make_sigint_handler.call_count == 1
-            assert daemon._make_sigint_handler.call_args == mock.call(
-                'original_handler'
-            )
             assert mock_flockfile.call_count == 1
             assert daemon.context.lockfile == mock_flockfile.return_value
-
-    def test_make_sigint_handler_keyboardinterrupt(self):
-        daemon = TronDaemon.__new__(TronDaemon)  # skip __init__
-        daemon._handle_shutdown = mock.Mock()
-
-        def prev_handler(signum, frame):
-            raise KeyboardInterrupt
-
-        handler = daemon._make_sigint_handler(prev_handler)
-        handler('fake_signum', 'fake_frame')
-
-        daemon._handle_shutdown.call_args == mock.call(
-            'fake_signum',
-            'fake_frame',
-        )
-
-    def test_make_sigint_handler_exception(self):
-        daemon = TronDaemon.__new__(TronDaemon)  # skip __init__
-        daemon._handle_shutdown = mock.Mock()
-
-        def prev_handler(signum, frame):
-            raise Exception
-
-        handler = daemon._make_sigint_handler(prev_handler)
-        handler('fake_signum', 'fake_frame')
-
-        daemon._handle_shutdown.call_count == 0
 
     def test_run_manhole_new_manhole(self):
         with open(self.trond.manhole_sock, 'w+'):

--- a/tron/trondaemon.py
+++ b/tron/trondaemon.py
@@ -98,9 +98,6 @@ class TronDaemon(object):
         setup_logging(self.options)
 
         self.mcp = None
-        self._sigint_handler = self._make_sigint_handler(
-            signal.getsignal(signal.SIGINT)
-        )
         self.context = self._build_context(options)
         self.manhole_sock = f"{self.options.working_dir}/manhole.sock"
 
@@ -108,21 +105,30 @@ class TronDaemon(object):
         return NoDaemonContext(
             lockfile=flockfile.FlockFile(options.lock_file),
             working_directory=options.working_dir,
-            signal_map={
-                signal.SIGHUP: signal.SIG_DFL,
-                signal.SIGINT: signal.default_int_handler,
-                signal.SIGTERM: signal.SIG_DFL,
-                signal.SIGQUIT: signal.SIG_DFL,
-                signal.SIGUSR1: signal.SIG_DFL,
-            },
+            signal_map={signal.SIGINT: lambda sig, frame: sig},
         )
 
     def run(self):
         with self.context:
+            signal_map = {
+                signal.SIGHUP: self._handle_reconfigure,
+                signal.SIGINT: self._handle_shutdown,
+                signal.SIGTERM: self._handle_shutdown,
+                signal.SIGQUIT: self._handle_shutdown,
+                signal.SIGUSR1: self._handle_debug,
+            }
+            signal.pthread_sigmask(signal.SIG_BLOCK, signal_map.keys())
+
             self._run_mcp()
             self._run_www_api()
             self._run_manhole()
             self._run_reactor()
+
+            while True:
+                signum = signal.sigwait(list(signal_map.keys()))
+                if signum in signal_map:
+                    logging.info(f"Got signal {str(signum)}")
+                    signal_map[signum](signum, None)
 
     def _run_manhole(self):
         # This condition is made with the assumption that no existing daemon
@@ -159,65 +165,11 @@ class TronDaemon(object):
 
     def _run_reactor(self):
         """Run the twisted reactor."""
-        signal_map = {
-            signal.SIGHUP: self._handle_reconfigure,
-            signal.SIGINT: self._sigint_handler,
-            signal.SIGTERM: self._handle_shutdown,
-            signal.SIGQUIT: self._handle_shutdown,
-            signal.SIGUSR1: self._handle_debug,
-        }
-        signal.pthread_sigmask(signal.SIG_BLOCK, signal_map.keys())
-
         threading.Thread(
             target=reactor.run,
             daemon=True,
             kwargs=dict(installSignalHandlers=0)
         ).start()
-
-        while True:
-            try:
-                # We use a sigtimedwait instead of a sigwait here because in the
-                # event other threads try to interrupt the main thread, a
-                # KeyboardInterrupt will be thrown. A sigwait will not unblock,
-                # but a sigtimedwait will.
-                signum = signal.sigtimedwait(set(signal_map.keys()), 0)
-                if signum is not None:
-                    signum = signal.Signals(signum.si_signo)
-            except KeyboardInterrupt:
-                signum = signal.SIGINT
-
-            if signum in signal_map:
-                logging.info(f"Got signal {str(signum)}")
-                signal_map[signum](signum, None)
-
-    def _make_sigint_handler(self, prev_handler=None):
-        """ Creates a SIGINT handler that takes into account a previous
-        handler to differentiate between a user request to shutdown, versus
-        another source we want to prevent from interrupting the reactor.
-
-        :type prev_handler: function
-        :param prev_handler: The previous SIGINT handler, set by another source.
-                             We use it to verify whether or not a SIGINT we
-                             received is a genuine shutdown request.
-        """
-
-        def handler(signum, frame):
-            try:
-                if prev_handler is not None:
-                    prev_handler(signum, frame)
-            except KeyboardInterrupt:
-                # Previous signal handler didn't raise another exception,
-                # so must be user requesting shutdown.
-                pass
-            except Exception as e:
-                # We received a SIGINT, but was caused by another thread
-                # aborting due to its own error. In this case, we don't want to
-                # stop running.
-                log.error(f"Non-reactor thread raised: {e}")
-                return
-            self._handle_shutdown(signum, frame)
-
-        return handler
 
     def _handle_shutdown(self, sig_num, stack_frame):
         log.info(f"Shutdown requested via {str(sig_num)}")


### PR DESCRIPTION
### Description
- Overall, fixed Tron daemon to allow serial signal handling
- Call `pthread_sigmask` before any threads are spawned so that we don't have a situation where some threads block on signals and others do not
- Remove pymesos SIGINT handler wrapper (no longer needed given `pthread_sigmask` change)
- Set SIGINT handler to an 'ignore' handler (not `signal.SIG_IGN`, which is an int, since the handler must be callable, given `interrupt_main`'s unstoppable interrupt)

### Testing done
- make test
- Manual testing against pymesos errors to ensure main thread does not also die
- Manual testing on mesosstage to verify SIGTERMs are being handled properly (not via signal handler)

### Notes to reviewers
**WARNING: The notes are long and comprehensive to help everyone fully understand the issue, since it has caused headaches for all of us.**
#### The interplay between `sigwait` and signal handlers
To understand the interplay, we have to understand signal masks, which is essentially a list of signals. Each thread has its own signal mask, and will 'block' against all signals in the mask. Child threads inherit signal masks from their parents.

To block against a signal is to prevent it from being delivered to the current thread (whoever acquired the GIL); instead, the signal is considered 'pending'. If a signal has been delivered, then the appropriate signal handler is called, which is executed on the main thread (in Python). If a signal is instead pending, the handler is NOT called, but can be retrieved by `sigwait`, not just by the receiving thread, but ANY thread.

In other words, to prevent a signal handler from being called, one only needs to tell the thread to block on a signal. Then, another thread, say, one dedicated to signal handling, can retrieve it using `sigwait` and handle it. We tell threads to block on signals using `pthread_sigmask`.

#### Why did we have such an issue with signal handlers?
When @keymone made the change to have signals handled serially, he put the call to `pthread_sigmask` (setting the signal mask to block on all the signals we are interested in) right above the call to `sigwait` (key to our serial handling). The problem was that before `pthread_sigmask` was called, we had already spawned many other threads, including our pymesos thread (spawned when we create our MCP) and reactor thread. These child threads therefore inherited an EMPTY signal mask, and so would not block on any signal. As a result, if the current thread was not the main thread, and a signal was raised, it was dutifully delivered and its respective signal handler called, bypassing our serial handling code.

When I made my first attempt at this problem, I moved the `pthread_sigmask` call above where the daemon spawned the reactor thread, but still below the call to spawn the pymesos thread. In this PR, I have moved the `pthread_sigmask` call to the correct place, before any threads are spawned (having finally understood the issue enough :P).

#### One loose end: `interrupt_main`
Unfortunately, there is one exception to signal blocking: `interrupt_main`, a function I now consider to be the most evil and pernicious of threading-related functions.

[`interrupt_main`](https://github.com/python/cpython/blob/621cebe81b1e6c8de10425955bf532d31ee4df42/Modules/_threadmodule.c#L1103) is a Python function implemented in C advertised to raise a `KeyboardInterrupt` in the main thread and intended for use in non-main threads to shutdown the main thread. The way it does this is by setting an interrupt that, no matter what, even if all threads' signal masks blocked on SIGINTs, will deliver the signal and therefore call the SIGINT handler, which, by default raises a `KeyboardInterrupt`. The only way, therefore, to prevent this `KeyboardInterrupt` from shutting down the program is to override the SIGINT handler with one that does not raise the exception (or do anything else that results in death).

Of course, most programs don't have to care about this fact but because we use pymesos, we have to. In the event pymesos runs into an issue, it will [call `interrupt_main`](https://github.com/douban/pymesos/blob/master/pymesos/process.py#L383). Furthermore, although pymesos does [set its own signal handler](https://github.com/douban/pymesos/blob/master/pymesos/process.py#L31), it results in a `KeyboardInterrupt` anyway. Therefore, we do need to set the SIGINT handler to an 'ignore' handler. It also means we don't need to write a wrapper around pymesos's SIGINT handler anymore (which I wrote in a my first attempt at this problem, and have since removed), since signal handlers are no longer relevant.

#### Opinion: Is the `interrupt_main` implementation or pymesos calling `interrupt_main` wrong?
In light of this new information, I don't think its terrible that pymesos calls `interrupt_main`. It is a way of telling the main thread that the program can no longer communicate with Mesos and should therefore shutdown. Of course, signals should never be used as a way of communicating between threads (since which thread receives the signal is arbitrary), so there is some fault there. I can't deny it would be better if pymesos simply didn't call `interrupt_main`; it should simply expose exception information through some variable or function call, and let the application determine if pymesos has shutdown by checking whether or not the relevant thread is dead (via `threading.Thread.isAlive`).

What I have a much bigger problem with is that `interrupt_main` does not honor the idea of signal blocking. I would prefer if it instead sent a SIGINT (not set an interrupt) to the current PID; then, if the process (or its threads) blocked on the SIGINT, it can be handled with `sigwait`. So, if we are going to change or fork anything, I would be more in favor of patching Python itself.