### PR TITLE
Add consistency check on Tron startup

### DIFF
--- a/dev/config/MASTER.yaml
+++ b/dev/config/MASTER.yaml
@@ -14,28 +14,9 @@ mesos_options:
 jobs:
     - name: "test"
       node: localhost
-      schedule: "interval 10min"
+      schedule: "interval 1m"
       actions:
         - name: "first"
-          command: "/bin/sleep 5m"
-          executor: mesos
-          docker_image: docker-paasta.yelpcorp.com:443/services-robj-test-service:paasta-e9fc795ec881cfd1b9d4b68540504690deddd4ec
+          command: "echo 'hello world'"
           cpus: 1
           mem: 100
-          constraints:
-              - attribute: pool
-                operator: LIKE
-                value: default
-          env:
-              PAASTA_SERVICE: robj-test-service
-          docker_parameters:
-            - key: memory-swap
-              value: 1088m
-            - key: cpu-period
-              value: '100000'
-            - key: cpu-quota
-              value: '250000'
-            - key: label
-              value: paasta_service=robj-test-service
-            - key: label
-              value: paasta_instance=test.first

--- a/tron/serialize/runstate/statemanager.py
+++ b/tron/serialize/runstate/statemanager.py
@@ -152,10 +152,13 @@ class PersistentStateManager(object):
 
         jobs = self._restore_dicts(runstate.JOB_STATE, job_names)
         frameworks = self._restore_dicts(runstate.MESOS_STATE, ['frameworks'])
-        return {
+
+        state = {
             runstate.JOB_STATE: jobs,
             runstate.MESOS_STATE: frameworks,
         }
+        self._check_consistency(state)
+        return state
 
     def _restore_metadata(self):
         metadata = self._impl.restore([self.metadata_key])
@@ -200,6 +203,22 @@ class PersistentStateManager(object):
                 msg = "Failed to save state for %s: %s" % (keys, e)
                 log.warning(msg)
                 raise PersistenceStoreError(msg)
+
+    def _check_consistency(self, state):
+        """ Consistency checks on serialized state to ensure no corruption.
+
+        :param state: A dict of serialized state, like that returned by
+            self.restore
+        """
+        log.info("Running consistency checks")
+        try:
+            # We attempt to save all the state. A failure indicates corruption
+            for type_enum, items in state.items():
+                for name, state_data in items.items():
+                    self.save(type_enum, name, state_data)
+        except PersistenceStoreError as e:
+            log.error("Failed consistency check: Could not save serialized state")
+            raise e
 
     def cleanup(self):
         self._save_from_buffer()


### PR DESCRIPTION
### Description
- Add a consistency check after loading state during startup to save it immediately after
- Failing to save would indicate corruption

### Testing done
- manual testing
- make test

### Notes to reviewers
- I'm not sure how much this protects us, since I haven't been able to generate a Tron bdb state file that can load but not save.
- Additionally, this check doesn't really protect us while Tron is running, i.e. Tron's running state gets corrupted and doesn't save.