### PR TITLE
Mesos action run should fail if it gets an offer timeout event

### DIFF
--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -1294,14 +1294,14 @@ class TestMesosActionRun:
         assert not self.action_run.is_unknown
         assert self.action_run.start.call_count == 1
 
-    def test_handler_exiting_failstart_unknown(self):
+    def test_handler_exiting_failstart_failed(self):
         self.action_run.action_command = mock.create_autospec(
             actioncommand.ActionCommand,
-            exit_status=None,
+            exit_status=1,
         )
         self.action_run.machine.transition('start')
         assert self.action_run.handler(
             self.action_run.action_command,
             ActionCommand.FAILSTART,
         )
-        assert self.action_run.is_unknown
+        assert self.action_run.is_failed

--- a/tests/mesos_test.py
+++ b/tests/mesos_test.py
@@ -205,13 +205,15 @@ class TestMesosTask(TestCase):
         assert self.task.is_failed
         assert self.task.is_done
 
-    def test_handle_unknown_terminal_event(self):
+    def test_handle_terminal_event_offer_timeout(self):
         self.task.started()
         event = mock_task_event(
             task_id=self.task_id,
             platform_type=None,
             terminal=True,
             success=False,
+            raw='failed due to offer timeout',
+            message='stop',
         )
         self.task.handle_event(event)
         assert self.task.is_failed

--- a/tests/mesos_test.py
+++ b/tests/mesos_test.py
@@ -243,7 +243,13 @@ class TestMesosTask(TestCase):
         assert self.task.is_complete
 
     def test_log_event_error(self):
-        with mock.patch.object(self.task, 'log_event_info') as mock_log_event:
+        with mock.patch.object(
+            self.task,
+            'log_event_info',
+        ) as mock_log_event, mock.patch.object(
+            self.task.log,
+            'warning',
+        ) as mock_log:
             mock_log_event.side_effect = Exception
             self.task.handle_event(
                 mock_task_event(
@@ -252,6 +258,7 @@ class TestMesosTask(TestCase):
                 )
             )
             assert mock_log_event.called
+            assert mock_log.called
         assert self.task.state == MesosTask.RUNNING
 
     def test_get_event_logger_add_unique_handlers(self):

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -865,7 +865,7 @@ class MesosActionRun(ActionRun, Observer):
             return self.transition_and_notify('started')
 
         if event == ActionCommand.FAILSTART:
-            return self._exit_unsuccessful(None)
+            return self._exit_unsuccessful(action_command.exit_status)
 
         if event == ActionCommand.EXITING:
             if action_command.exit_status is None:

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -205,6 +205,13 @@ class MesosTask(ActionCommand):
         elif mesos_type is None:
             self.log.info(f'Non-Mesos event: {event.raw}')
 
+        # Mesos events may have task reasons
+        if mesos_type:
+            message = event.raw.get('message', '')
+            reason = event.raw.get('reason', '')
+            if message or reason:
+                self.log.info(f'More info: {reason}: {message}')
+
     def handle_event(self, event):
         event_id = getattr(event, 'task_id', None)
         if event_id != self.get_mesos_id():
@@ -244,10 +251,6 @@ class MesosTask(ActionCommand):
 
         if event.terminal:
             self.log.info('Event was terminal, closing task')
-            message = event.raw.get('message', '')
-            reason = event.raw.get('reason', '')
-            if message or reason:
-                self.log.info(f'More info: {reason}: {message}')
             self.report_resources(decrement=True)
 
             exit_code = int(not getattr(event, 'success', False))


### PR DESCRIPTION
There was a bug in logging terminal events that don't come from Mesos, so the task didn't exit. (Introduced in https://github.com/Yelp/Tron/pull/590.) I moved the logging code to `log_event_info` (which we wrap with a try-except to prevent logging from messing up state transitions) and check that the event is from Mesos before assuming event.raw will be a dict.

After the task exits with FAILSTART and a non-zero exit code, the action run handler should also fail. I changed exit_unsuccessful to transition to unknown if the exit status is None, instead of always failing, in https://github.com/Yelp/Tron/pull/581.

Manually verified this works for offer timeouts by running an action with an invalid pool, which will always lead to an offer timeout. The action fails.