### PR TITLE
Set an end time if and only if the action should not be recovered

### DIFF
--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -695,6 +695,7 @@ class TestSSHActionRun:
         )
         assert self.action_run.is_unknown
         assert self.action_run.exit_status is None
+        assert self.action_run.end_time is not None
 
     def test_handler_unhandled(self):
         self.action_run.build_action_command()
@@ -719,7 +720,7 @@ class ActionRunStateRestoreTestCase(testingutils.MockTimeTestCase):
             'node_name': 'anode',
             'command': 'do things',
             'start_time': 'start_time',
-            'end_time': 'end_time',
+            'end_time': None,
             'state': 'succeeded',
         }
         self.run_node = MagicMock()
@@ -752,8 +753,8 @@ class ActionRunStateRestoreTestCase(testingutils.MockTimeTestCase):
             lambda: None,
         )
         assert action_run.is_unknown
-        assert action_run.exit_status == 0
-        assert action_run.end_time == self.now
+        assert action_run.exit_status is None
+        assert action_run.end_time is None
 
     def test_from_state_starting(self):
         self.state_data['state'] = 'starting'
@@ -765,6 +766,8 @@ class ActionRunStateRestoreTestCase(testingutils.MockTimeTestCase):
             lambda: None,
         )
         assert action_run.is_unknown
+        assert action_run.exit_status is None
+        assert action_run.end_time is None
 
     def test_from_state_queued(self):
         self.state_data['state'] = 'queued'
@@ -1187,6 +1190,7 @@ class TestMesosActionRun:
             mock_watch.assert_called_once_with(task)
 
         assert self.action_run.is_running
+        assert self.action_run.end_time is None
         mock_filehandler.OutputStreamSerializer.assert_called_with(
             self.action_run.output_path,
         )
@@ -1212,6 +1216,7 @@ class TestMesosActionRun:
         self.action_run.recover()
         assert mock_cluster_repo.get_cluster.call_count == 0
         assert self.action_run.is_unknown
+        assert self.action_run.end_time is not None
 
     @mock.patch('tron.core.actionrun.filehandler', autospec=True)
     @mock.patch('tron.core.actionrun.MesosClusterRepository', autospec=True)
@@ -1226,6 +1231,7 @@ class TestMesosActionRun:
         mock_get_cluster.assert_called_once_with()
         assert self.action_run.is_unknown
         assert mock_get_cluster.return_value.recover.call_count == 0
+        assert self.action_run.end_time is not None
 
     @mock.patch('tron.core.actionrun.MesosClusterRepository', autospec=True)
     def test_kill_task(self, mock_cluster_repo):
@@ -1274,6 +1280,7 @@ class TestMesosActionRun:
         )
         assert self.action_run.is_unknown
         assert self.action_run.exit_status is None
+        assert self.action_run.end_time is not None
 
     def test_handler_exiting_unknown_retry(self):
         self.action_run.action_command = mock.create_autospec(

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -300,7 +300,7 @@ class MesosCluster:
         if is_enabled:
             self.connect()
         else:
-            self.stop()
+            self.stop(fail_tasks=True)
 
     def configure_tasks(
         self,
@@ -506,7 +506,7 @@ class MesosCluster:
         else:
             log.warning('Unknown type of event: {}'.format(event))
 
-    def stop(self):
+    def stop(self, fail_tasks=False):
         self.framework_id = None
         if self.runner:
             self.runner.stop()
@@ -516,9 +516,10 @@ class MesosCluster:
             self.deferred.cancel()
         self.queue = PyDeferredQueue()
 
-        for key, task in list(self.tasks.items()):
-            task.exited(None)
-            del self.tasks[key]
+        if fail_tasks:
+            for key, task in list(self.tasks.items()):
+                task.exited(None)
+                del self.tasks[key]
 
     def kill(self, task_id):
         return self.runner.kill(task_id)


### PR DESCRIPTION
Now `self.fail_unknown` uses _done, which adds an end time and does other cleanup. The only place we don't to add an end time is when we're restoring an ActionRun from state and we're getting it ready for recovery, so I do the transition to unknown directly there.

In tron/mesos.py, we don't want to exit the tasks (and therefore give them an end time) when we're shutting down normally. `fail_tasks=True` is for when we're toggling Mesos off in an emergency, without shutting all of Tron down.