### PR TITLE
Only recover unknown Mesos actions that have no end time

### DIFF
--- a/tests/core/recovery_test.py
+++ b/tests/core/recovery_test.py
@@ -14,7 +14,6 @@ from tron.core.actionrun import MesosActionRun
 from tron.core.actionrun import SSHActionRun
 from tron.core.recovery import build_recovery_command
 from tron.core.recovery import filter_action_runs_needing_recovery
-from tron.core.recovery import group_by_actionrun_type
 from tron.core.recovery import launch_recovery_actionruns_for_job_runs
 from tron.core.recovery import recover_action_run
 from tron.utils import timeutils
@@ -34,6 +33,7 @@ class TestRecovery(TestCase):
                 name="test.unknown",
                 node=Mock(),
                 machine=mock_unknown_machine,
+                end_time=timeutils.current_time(),
             ),
             SSHActionRun(
                 job_run_id="test.succeeded",
@@ -47,11 +47,26 @@ class TestRecovery(TestCase):
                 node=Mock(),
                 machine=mock_ok_machine,
             ),
+            MesosActionRun(
+                job_run_id="test.unknown-mesos",
+                name="test.unknown-mesos",
+                node=Mock(),
+                machine=mock_unknown_machine,
+            ),
+            MesosActionRun(
+                job_run_id="test.unknown-mesos-done",
+                name="test.unknown-mesos-done",
+                node=Mock(),
+                machine=mock_unknown_machine,
+                end_time=timeutils.current_time(),
+            ),
         ]
 
     def test_filter_action_runs_needing_recovery(self):
-        assert filter_action_runs_needing_recovery(self.action_runs) == \
-            [self.action_runs[0]]
+        assert filter_action_runs_needing_recovery(self.action_runs) == (
+            [self.action_runs[0]],
+            [self.action_runs[3]],
+        )
 
     def test_build_recovery_command(self):
         assert build_recovery_command(
@@ -90,28 +105,28 @@ class TestRecovery(TestCase):
         assert action_run.end_time is None
         assert action_run.exit_status is None
 
-    def test_group_by_actionrun_type(self):
-        assert group_by_actionrun_type(self.action_runs) == \
-            ([self.action_runs[0], self.action_runs[1]], [self.action_runs[2]])
-
     def test_launch_recovery_actionruns_for_job_runs(self):
         with mock.patch('tron.core.recovery.filter_action_runs_needing_recovery', autospec=True) as mock_filter, \
                 mock.patch('tron.core.recovery.recover_action_run', autospec=True) as mock_recover_action_run:
 
-            mock_actions = [
-                mock.Mock(
-                    action_runner=NoActionRunnerFactory(), spec=SSHActionRun
-                ),
-                mock.Mock(
-                    action_runner=SubprocessActionRunnerFactory(
-                        status_path='/tmp/foo', exec_path=('/tmp/foo')
+            mock_actions = (
+                [
+                    mock.Mock(
+                        action_runner=NoActionRunnerFactory(), spec=SSHActionRun
                     ),
-                    spec=SSHActionRun,
-                ),
-                mock.Mock(
-                    action_runner=NoActionRunnerFactory(), spec=MesosActionRun
-                ),
-            ]
+                    mock.Mock(
+                        action_runner=SubprocessActionRunnerFactory(
+                            status_path='/tmp/foo', exec_path=('/tmp/foo')
+                        ),
+                        spec=SSHActionRun,
+                    ),
+                ],
+                [
+                    mock.Mock(
+                        action_runner=NoActionRunnerFactory(), spec=MesosActionRun
+                    ),
+                ],
+            )
 
             mock_filter.return_value = mock_actions
             mock_action_runner = mock.Mock(autospec=True)
@@ -119,12 +134,12 @@ class TestRecovery(TestCase):
             mock_job_run = mock.Mock()
             launch_recovery_actionruns_for_job_runs([mock_job_run],
                                                     mock_action_runner)
-            ssh_runs = mock_actions[:2]
+            ssh_runs = mock_actions[0]
             calls = [
                 call(ssh_runs[0], mock_action_runner),
                 call(ssh_runs[1], ssh_runs[1].action_runner)
             ]
             mock_recover_action_run.assert_has_calls(calls, any_order=True)
 
-            mesos_run = mock_actions[2]
+            mesos_run = mock_actions[1][0]
             assert mesos_run.recover.call_count == 1

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -12,23 +12,15 @@ log = logging.getLogger(__name__)
 
 
 def filter_action_runs_needing_recovery(action_runs):
-    return [
-        action_run for action_run in action_runs
-        if action_run.state == ActionRun.UNKNOWN
-    ]
-
-
-def group_by_actionrun_type(action_runs):
-    """
-    Given a list of action_runs, group them by type.
-    """
     ssh_runs = []
     mesos_runs = []
     for action_run in action_runs:
         if isinstance(action_run, SSHActionRun):
-            ssh_runs.append(action_run)
+            if action_run.state == ActionRun.UNKNOWN:
+                ssh_runs.append(action_run)
         elif isinstance(action_run, MesosActionRun):
-            mesos_runs.append(action_run)
+            if action_run.state == ActionRun.UNKNOWN and action_run.end_time is None:
+                mesos_runs.append(action_run)
     return ssh_runs, mesos_runs
 
 
@@ -93,8 +85,7 @@ def recover_action_run(action_run, action_runner):
 
 def launch_recovery_actionruns_for_job_runs(job_runs, master_action_runner):
     for run in job_runs:
-        to_recover = filter_action_runs_needing_recovery(run._action_runs)
-        ssh_runs, mesos_runs = group_by_actionrun_type(to_recover)
+        ssh_runs, mesos_runs = filter_action_runs_needing_recovery(run._action_runs)
         for action_run in ssh_runs:
             if type(action_run.action_runner) == NoActionRunnerFactory and \
                type(master_action_runner) != NoActionRunnerFactory:


### PR DESCRIPTION
After recovery, SSH actions are never unknown - the recovery has either succeeded or failed. However, Mesos actions may still be unknown, if we get a LOST update for it. We don't want to try to recover it again next restart (which resets the end time, etc), so we check if there's an end_time already.

This needs to be released after https://github.com/Yelp/Tron/pull/597, which updates the end times for Mesos actions correctly.