### PR TITLE
Allow passing extra options to systemd-based distros.

### DIFF
--- a/debian/tron.default
+++ b/debian/tron.default
@@ -7,7 +7,10 @@
 #
 
 # Additional options that are passed to the Daemon.
-DAEMON_OPTS="-l /var/lib/tron/logging.conf"
+DAEMON_OPTS="--log-conf /var/lib/tron/logging.conf"
+
+LISTEN_HOST="0.0.0.0"
+LISTEN_PORT="8089"
 
 # User the daemon will run as. Needs to have appropriate credentials to SSH into your working nodes.
 # You should take care in setting permissions appropriately for log and working directories on /var

--- a/debian/tron.service
+++ b/debian/tron.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=tron
 EnvironmentFile=/etc/default/tron
-ExecStart=/usr/bin/trond --lock-file=${LOCKFILE:-$PIDFILE} --working-dir=${WORKINGDIR} -H 0.0.0.0 -P 8089 -l ${LOGCONF}
+ExecStart=/usr/bin/trond --lock-file=${LOCKFILE:-$PIDFILE} --working-dir=${WORKINGDIR} --host ${LISTEN_HOST} --port ${LISTEN_PORT} ${DAEMON_OPTS}
 TimeoutStopSec=20
 Restart=on-failure
 


### PR DESCRIPTION
We need the option to pass arbitrary options to tron on systemd-based distros.

Specifically I need to set the listen port.
This also adds the generic "OPTS" var so that users can add new cli options that are not baked into the defaults file (without editing the .service file)