### PR TITLE
Don't try to use an ssh-agent for the default config

### DIFF
--- a/tron/default_config.yaml
+++ b/tron/default_config.yaml
@@ -4,7 +4,7 @@ ssh_options:
     ## SSH agent or list
     # identities:
     #     - /home/tron/.ssh/id_dsa
-    agent: true
+    agent: false
 
 ## Directory used to store stdout/stderr from jobs. Defaults
 ## to the working directory


### PR DESCRIPTION
These defaults don't allow tron to start automatically on freshly bootstrapped clusters.
This means they won't even get the API running enough for us to "post" the *actual* config.

This should make it so new tron servers can launch for the first time, without manual intervention, and let the cron jobs take over.