### PR TITLE
Fixes for inactive framework

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ PyYAML==3.13
 requests==2.20.0
 six==1.11.0
 SQLAlchemy==1.2.12
-task_processing[mesos_executor]==0.1.2
+task_processing[mesos_executor]==0.1.3
 Twisted==18.7.0

--- a/tests/mesos_test.py
+++ b/tests/mesos_test.py
@@ -640,8 +640,8 @@ class TestMesosCluster(TestCase):
         )
         cluster = MesosCluster('mesos-cluster-a.me')
         cluster._process_event(event)
-        assert_equal(cluster.runner.stop.call_count, 1)
-        assert_equal(cluster.deferred.cancel.call_count, 1)
+        assert cluster.runner.stop.call_count == 1
+        assert cluster.deferred is None
 
     def test_stop_default(self):
         # When stopping, tasks should not exit. They will be recovered
@@ -650,7 +650,7 @@ class TestMesosCluster(TestCase):
         cluster.tasks = {'task_id': mock_task}
         cluster.stop()
         assert cluster.runner.stop.call_count == 1
-        assert cluster.deferred.cancel.call_count == 1
+        assert cluster.deferred is None
         assert mock_task.exited.call_count == 0
         assert len(cluster.tasks) == 1
 

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -517,6 +517,7 @@ class MesosCluster:
         # Clear message queue
         if self.deferred:
             self.deferred.cancel()
+            self.deferred = None
         self.queue = PyDeferredQueue()
 
         if fail_tasks:


### PR DESCRIPTION
Found several frameworks that had become inactive in prod. From nova-prod:
```
  File "/opt/venvs/tron/lib/python3.6/site-packages/task_processing/plugins/mesos/execution_framework.py", line 345, in launch_tasks_for_offer
    md = self.task_metadata[task.task_id]
  File "/opt/venvs/tron/lib/python3.6/site-packages/pyrsistent/_pmap.py", line 71, in __getitem__
    return PMap._getitem(self._buckets, key)
  File "/opt/venvs/tron/lib/python3.6/site-packages/pyrsistent/_pmap.py", line 68, in _getitem
    raise KeyError(key)
KeyError: 'paasta-contract-monitor.nova-prod-mesos.709.sleep.112a8604-e348-471c-9b7c-8afcb4019a07'
```
which looks like the task_metadata bugs (see TASKPROC-217).

I attempted to restart the framework by disabling and renabling Mesos, but that didn't work without L521 (in L323, a cancelled deferred doesn't count as 'called', so no new event handlers get added).