### PR TITLE
Skip job runs with no action runs during recovery

### DIFF
--- a/tests/core/recovery_test.py
+++ b/tests/core/recovery_test.py
@@ -105,41 +105,54 @@ class TestRecovery(TestCase):
         assert action_run.end_time is None
         assert action_run.exit_status is None
 
-    def test_launch_recovery_actionruns_for_job_runs(self):
-        with mock.patch('tron.core.recovery.filter_action_runs_needing_recovery', autospec=True) as mock_filter, \
-                mock.patch('tron.core.recovery.recover_action_run', autospec=True) as mock_recover_action_run:
-
-            mock_actions = (
-                [
-                    mock.Mock(
-                        action_runner=NoActionRunnerFactory(), spec=SSHActionRun
+    @mock.patch('tron.core.recovery.recover_action_run', autospec=True)
+    @mock.patch('tron.core.recovery.filter_action_runs_needing_recovery', autospec=True)
+    def test_launch_recovery_actionruns_for_job_runs(self, mock_filter, mock_recover_action_run):
+        mock_actions = (
+            [
+                mock.Mock(
+                    action_runner=NoActionRunnerFactory(), spec=SSHActionRun
+                ),
+                mock.Mock(
+                    action_runner=SubprocessActionRunnerFactory(
+                        status_path='/tmp/foo', exec_path=('/tmp/foo')
                     ),
-                    mock.Mock(
-                        action_runner=SubprocessActionRunnerFactory(
-                            status_path='/tmp/foo', exec_path=('/tmp/foo')
-                        ),
-                        spec=SSHActionRun,
-                    ),
-                ],
-                [
-                    mock.Mock(
-                        action_runner=NoActionRunnerFactory(), spec=MesosActionRun
-                    ),
-                ],
-            )
+                    spec=SSHActionRun,
+                ),
+            ],
+            [
+                mock.Mock(
+                    action_runner=NoActionRunnerFactory(), spec=MesosActionRun
+                ),
+            ],
+        )
 
-            mock_filter.return_value = mock_actions
-            mock_action_runner = mock.Mock(autospec=True)
+        mock_filter.return_value = mock_actions
+        mock_action_runner = mock.Mock(autospec=True)
 
-            mock_job_run = mock.Mock()
-            launch_recovery_actionruns_for_job_runs([mock_job_run],
-                                                    mock_action_runner)
-            ssh_runs = mock_actions[0]
-            calls = [
-                call(ssh_runs[0], mock_action_runner),
-                call(ssh_runs[1], ssh_runs[1].action_runner)
-            ]
-            mock_recover_action_run.assert_has_calls(calls, any_order=True)
+        mock_job_run = mock.Mock()
+        launch_recovery_actionruns_for_job_runs([mock_job_run],
+                                                mock_action_runner)
+        ssh_runs = mock_actions[0]
+        calls = [
+            call(ssh_runs[0], mock_action_runner),
+            call(ssh_runs[1], ssh_runs[1].action_runner)
+        ]
+        mock_recover_action_run.assert_has_calls(calls, any_order=True)
 
-            mesos_run = mock_actions[1][0]
-            assert mesos_run.recover.call_count == 1
+        mesos_run = mock_actions[1][0]
+        assert mesos_run.recover.call_count == 1
+
+    @mock.patch('tron.core.recovery.filter_action_runs_needing_recovery', autospec=True)
+    def test_launch_recovery_actionruns_empty_job_run(self, mock_filter):
+        """_action_runs=None shouldn't prevent other job runs from being recovered"""
+        empty_job_run = mock.Mock(_action_runs=None)
+        other_job_run = mock.Mock(_action_runs=[mock.Mock()])
+        mock_action_runner = mock.Mock()
+        mock_filter.return_value = ([], [])
+
+        launch_recovery_actionruns_for_job_runs(
+            [empty_job_run, other_job_run],
+            mock_action_runner,
+        )
+        mock_filter.assert_called_with(other_job_run._action_runs)

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -85,6 +85,10 @@ def recover_action_run(action_run, action_runner):
 
 def launch_recovery_actionruns_for_job_runs(job_runs, master_action_runner):
     for run in job_runs:
+        if not run._action_runs:
+            log.info(f'Skipping recovery of {run} with no action runs (may have been cleaned up)')
+            continue
+
         ssh_runs, mesos_runs = filter_action_runs_needing_recovery(run._action_runs)
         for action_run in ssh_runs:
             if type(action_run.action_runner) == NoActionRunnerFactory and \


### PR DESCRIPTION
Ticket TRON-584.
Error during startup:
```
tron.trondaemon _run_mcp:163 Error in configuration /nail/tron/config/: 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/trondaemon.py", line 160, in _run_mcp
    self.mcp.initial_setup()
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/mcp.py", line 63, in initial_setup
    self.config.load().get_master().action_runner
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/mcp.py", line 148, in restore_state
    self.jobs.restore_state(states.get('job_state', {}), action_runner)
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/core/job_collection.py", line 69, in restore_state
    self.jobs[name].restore_state(state, config_action_runner)
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/core/job_scheduler.py", line 35, in restore_state
    job_runs=job_runs, master_action_runner=config_action_runner
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/core/recovery.py", line 88, in launch_recovery_actionruns_for_job_runs
    ssh_runs, mesos_runs = filter_action_runs_needing_recovery(run._action_runs)
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/core/recovery.py", line 17, in filter_action_runs_needing_recovery
    for action_run in action_runs:
TypeError: 'NoneType' object is not iterable
```

After I added a similar patch to recover in prod, I got these logs:
```
Dec 18 12:04:38 tron1-uswest1bprod tron: INFO pid=11818 tid=140627408762624 tron.core.jobrun finalize:275 JobRun:mobile_metrics.load_daily_device_events.643 succeeded
Dec 18 12:04:38 tron1-uswest1bprod tron: INFO pid=11818 tid=140627408762624 tron.core.jobrun build_new_run:354 JobRun:mobile_metrics.load_daily_device_events.644 created on paasta at 2018-12-19 02:30:00
Dec 18 12:04:38 tron1-uswest1bprod tron: INFO pid=11818 tid=140627408762624 tron.core.jobrun cleanup:282 JobRun:mobile_metrics.load_daily_device_events.594 removed
Dec 18 12:04:38 tron1-uswest1bprod tron: INFO pid=11818 tid=140627408762624 tron.core.recovery launch_recovery_actionruns_for_job_runs:89 unable to recover JobRun:mobile_metrics.load_daily_device_events.594, no action runs
```
which suggests that it's fine (the run just got cleaned up after one succeeded during recovery) so we can skip it.