### PR TITLE
Don't pass in task id when submitting retries of mesos actions

### DIFF
--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -1128,6 +1128,8 @@ class TestMesosActionRun:
     @mock.patch('tron.core.actionrun.MesosClusterRepository', autospec=True)
     def test_submit_command(self, mock_cluster_repo, mock_filehandler):
         serializer = mock_filehandler.OutputStreamSerializer.return_value
+        # submit_command should reset the task_id
+        self.action_run.mesos_task_id = 'last_attempt'
         with mock.patch.object(
             self.action_run,
             'watch',
@@ -1151,6 +1153,7 @@ class TestMesosActionRun:
             task = mock_get_cluster.return_value.create_task.return_value
             mock_get_cluster.return_value.submit.assert_called_once_with(task)
             mock_watch.assert_called_once_with(task)
+            assert self.action_run.mesos_task_id == task.get_mesos_id.return_value
 
         mock_filehandler.OutputStreamSerializer.assert_called_with(
             self.action_run.output_path,

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -738,7 +738,7 @@ class SSHActionRun(ActionRun, Observer):
 class MesosActionRun(ActionRun, Observer):
     """An ActionRun that executes the command on a Mesos cluster.
     """
-    def _create_mesos_task(self, mesos_cluster, serializer):
+    def _create_mesos_task(self, mesos_cluster, serializer, task_id=None):
         return mesos_cluster.create_task(
             action_run_id=self.id,
             command=self.command,
@@ -751,7 +751,7 @@ class MesosActionRun(ActionRun, Observer):
             env=self.env,
             extra_volumes=[e._asdict() for e in self.extra_volumes],
             serializer=serializer,
-            task_id=self.mesos_task_id,
+            task_id=task_id,
         )
 
     def submit_command(self):
@@ -786,7 +786,11 @@ class MesosActionRun(ActionRun, Observer):
 
         serializer = filehandler.OutputStreamSerializer(self.output_path)
         mesos_cluster = MesosClusterRepository.get_cluster()
-        task = self._create_mesos_task(mesos_cluster, serializer)
+        task = self._create_mesos_task(
+            mesos_cluster,
+            serializer,
+            self.mesos_task_id,
+        )
         if not task:
             log.warning(
                 f'{self} cannot recover, Mesos is disabled or '


### PR DESCRIPTION
Before, if we were submitting a retry of a MesosActionRun, that action run already had a self.mesos_task_id corresponding to the previous attempt, so the new attempt would re-use that ID.

This makes None the default task ID for _create_mesos_task, and only passes in self.mesos_task_id when we are recovering.