### PR TITLE
Add ym format

### DIFF
--- a/docs/command_context.rst
+++ b/docs/command_context.rst
@@ -13,7 +13,7 @@ command configuration.
     form ``{shortdate+6}`` which returns a date 6 days in the future,
     ``{shortdate-2}`` which returns a date 2 days before the run date.
 
-**ymd, ymdh, ymdhm**
+**ym, ymd, ymdh, ymdhm**
     Same as ``shortdate`` but better granularity. Arithmetic works with most
     granular unit: ``ymdh+1`` is  +1 hours, ``ymdhm+1`` is +1 minute.
 

--- a/tests/utils/timeutils_test.py
+++ b/tests/utils/timeutils_test.py
@@ -286,6 +286,20 @@ class DateArithmeticTestCase(testingutils.MockTimeTestCase):
 
 
 class DateArithmeticYMDHTest(TestCase):
+    def test_ym_plus(self):
+        def parse(*ym):
+            return DateArithmetic.parse('ym+1', datetime.datetime(*ym))
+
+        assert_equal(parse(2018, 1, 1), '2018-02')
+        assert_equal(parse(2017, 12, 1), '2018-01')
+
+    def test_ym_minus(self):
+        def parse(*ym):
+            return DateArithmetic.parse('ym-1', datetime.datetime(*ym))
+
+        assert_equal(parse(2018, 1, 1), '2017-12')
+        assert_equal(parse(2017, 12, 1), '2018-01')
+
     def test_ymd_plus(self):
         def parse(*ymd):
             return DateArithmetic.parse('ymd+1', datetime.datetime(*ymd))

--- a/tests/utils/timeutils_test.py
+++ b/tests/utils/timeutils_test.py
@@ -298,7 +298,7 @@ class DateArithmeticYMDHTest(TestCase):
             return DateArithmetic.parse('ym-1', datetime.datetime(*ym))
 
         assert_equal(parse(2018, 1, 1), '2017-12')
-        assert_equal(parse(2017, 12, 1), '2018-01')
+        assert_equal(parse(2018, 2, 1), '2018-01')
 
     def test_ymd_plus(self):
         def parse(*ymd):

--- a/tron/utils/timeutils.py
+++ b/tron/utils/timeutils.py
@@ -77,6 +77,7 @@ class DateArithmetic(object):
         'day': '%d',
         'hour': '%H',
         'shortdate': '%Y-%m-%d',
+        'ym': '%Y-%m',
         'ymd': '%Y-%m-%d',
         'ymdh': '%Y-%m-%dT%H',
         'ymdhm': '%Y-%m-%dT%H:%M',
@@ -103,7 +104,7 @@ class DateArithmetic(object):
                 dt += macro_timedelta(dt, **kwargs)
             return dt.strftime(cls.DATE_FORMATS[attr])
 
-        if attr in ('ymd', 'ymdh', 'ymdhm'):
+        if attr in ('ym', 'ymd', 'ymdh', 'ymdhm'):
             args = [0] * len(attr)
             args[-1] = delta
             dt += macro_timedelta(dt, *args)


### PR DESCRIPTION
new date format to  correctly declare monthly dependencies with arithmetic

`{ym}` -> `2019-01`
`{ym+1}` -> `2019-02`
`{ym-1}` -> `2018-12`