### PR TITLE
Fix inconsistency between JobRun state attribute and is_<state> checks

### DIFF
--- a/tests/core/jobrun_test.py
+++ b/tests/core/jobrun_test.py
@@ -318,7 +318,7 @@ class TestJobRun(TestCase):
 
     def test__getattr__(self):
         assert self.job_run.cancel
-        assert self.job_run.is_queued
+        assert self.job_run.state == 'succeeded'
         assert self.job_run.is_succeeded
 
     def test__getattr__miss(self):

--- a/tests/mcp_reconfigure_test.py
+++ b/tests/mcp_reconfigure_test.py
@@ -320,8 +320,9 @@ class TestMCPReconfigure(TestCase):
         run = job_sched.job.runs.runs[0]
         assert run.is_scheduled
 
+        action_runs = run.action_runs
         self.reconfigure()
-        assert run.is_cancelled
+        assert action_runs.is_cancelled
 
         assert_equal(len(job_sched.job.runs.runs), 1)
         new_run = job_sched.job.runs.runs[0]

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -146,7 +146,7 @@ class ActionRun(Observable):
 
     default_transitions = dict(fail=FAILED, success=SUCCEEDED)
     STATE_MACHINE = Machine(
-        'scheduled',
+        SCHEDULED,
         **{
             CANCELLED:
                 dict(skip=SKIPPED),


### PR DESCRIPTION
`is_<state>` checks on jobruns are proxied directly  to actionrun collection and are not always consistent with value of jobrun.state. This PR replaces proxying of `is_<state>` checks with a more direct  comparison to `state` property value.