### PR TITLE
Add cross-job dependency visualization to Tronweb

### DIFF
--- a/dev/config/MASTER.yaml
+++ b/dev/config/MASTER.yaml
@@ -1,5 +1,6 @@
+eventbus_enabled: True
 ssh_options:
-   agent: False
+   agent: True
 
 nodes:
   - hostname: localhost
@@ -12,11 +13,42 @@ mesos_options:
   dockercfg_location: file:///root/.dockercfg
 
 jobs:
-    - name: "test"
+    - name: testjob0
+      node: localhost
+      schedule: "interval 1m"
+      actions:
+        - name: zeroth
+          command: "sleep 5"
+          trigger_downstreams:
+            minutely: "{ymdhm}"
+          cpus: 1
+          mem: 100
+
+    - name: "testjob1"
       node: localhost
       schedule: "interval 1m"
       actions:
         - name: "first"
-          command: "echo 'hello world'"
+          command: "sleep 5"
           cpus: 1
           mem: 100
+        - name: "second"
+          command: "echo 'hello world'"
+          requires: [first]
+          triggered_by:
+            - "MASTER.testjob0.zeroth.minutely.{ymdhm}"
+          trigger_downstreams:
+            minutely: "{ymdhm}"
+          cpus: 1
+          mem: 100
+
+    - name: "testjob2"
+      node: localhost
+      schedule: "interval 1m"
+      actions:
+        - name: "first"
+          command: "echo 'goodbye, world'"
+          cpus: 1
+          mem: 100
+          triggered_by:
+            - "MASTER.testjob1.second.minutely.{ymdhm}"

--- a/tests/api/adapter_test.py
+++ b/tests/api/adapter_test.py
@@ -132,23 +132,31 @@ class TestActionRunAdapter(TestCase):
 class TestActionRunGraphAdapter(TestCase):
     @setup
     def setup_adapter(self):
-        self.a1 = mock.MagicMock(action_name="a1", dependent_actions=['a2'])
-        self.a2 = mock.MagicMock(action_name="a2")
+        self.ar1 = mock.MagicMock(action_name="a1")
+        self.ar2 = mock.MagicMock(action_name="a2")
+        self.a1 = mock.MagicMock()
+        self.a2 = mock.MagicMock()
+        self.a1.name = 'a1'
+        self.a2.name = 'a2'
         self.action_runs = mock.create_autospec(
             actionrun.ActionRunCollection,
-            action_graph=actiongraph.ActionGraph([self.a1], {
-                'a1': self.a1,
-                'a2': self.a2
-            }),
+            action_graph=actiongraph.ActionGraph(
+                {
+                    'a1': self.a1,
+                    'a2': self.a2
+                },
+                {'a1': set(), 'a2': {'a1'}},
+                {'a1': set(), 'a2': set()},
+            ),
         )
         self.adapter = adapter.ActionRunGraphAdapter(self.action_runs)
-        self.action_runs.__iter__.return_value = [self.a1, self.a2]
+        self.action_runs.__iter__.return_value = [self.ar1, self.ar2]
 
     def test_get_repr(self):
         result = self.adapter.get_repr()
         assert len(result) == 2
-        assert self.a1.id == result[0]['id']
-        assert ['a2'] == result[0]['dependent']
+        assert self.ar1.id == result[0]['id']
+        assert ['a1'] == result[1]['dependencies']
 
 
 class TestJobRunAdapter(TestCase):

--- a/tests/api/resource_test.py
+++ b/tests/api/resource_test.py
@@ -263,7 +263,7 @@ class TestJobResource(WWWTestCase):
         )
         action_name = 'action_name'
         action_runs = [mock.Mock(), mock.Mock()]
-        self.job.action_graph.names = [action_name]
+        self.job.action_graph.names.return_value = [action_name]
         self.job.runs.get_action_runs.return_value = action_runs
         resource = self.resource.getChild(action_name, None)
         assert resource.__class__ == www.ActionRunHistoryResource

--- a/tests/core/action_test.py
+++ b/tests/core/action_test.py
@@ -50,7 +50,6 @@ class TestAction:
         assert new_action.name == config.name
         assert new_action.command == config.command
         assert new_action.node_pool is None
-        assert new_action.required_actions == set()
         assert new_action.executor == config.executor
         assert new_action.cpus == config.cpus
         assert new_action.mem == config.mem
@@ -73,7 +72,6 @@ class TestAction:
         new_action = Action.from_config(config)
         assert new_action.name == config.name
         assert new_action.command == config.command
-        assert new_action.required_actions == set()
         assert new_action.executor == config.executor
         assert new_action.constraints == set()
         assert new_action.docker_image is None

--- a/tests/core/actiongraph_test.py
+++ b/tests/core/actiongraph_test.py
@@ -21,53 +21,19 @@ class TestActionGraph(TestCase):
             'dep_one_one',
             'dep_multi',
         ]
-        am = self.action_map = {}
+        self.action_map = {}
         for name in self.action_names:
-            am[name] = mock.MagicMock()
-            am[name].name = name
+            self.action_map[name] = mock.MagicMock()
+            self.action_map[name].name = name
 
-        am['dep_multi'].required_actions = [am['dep_one_one'], am['base_two']]
-        am['dep_one_one'].required_actions = [am['dep_one']]
-        am['dep_one'].required_actions = [am['base_one']]
+        self.required_actions = {
+            'dep_multi': {self.action_map['dep_one_one'], self.action_map['base_two']},
+            'dep_one_one': {self.action_map['dep_one']},
+            'dep_one': {self.action_map['base_one']},
+        }
+        self.required_triggers = {}
 
-        self.graph = [am['base_one'], am['base_two']]
-        self.action_graph = actiongraph.ActionGraph(self.graph, am)
-
-    def test_from_config(self):
-        config = {}
-        for name in self.action_names:
-            config[name] = mock.MagicMock(name=name, node='first', requires=[])
-            config[name].name = name
-            config[name].node = 'first'
-            config[name].requires = []
-        config['dep_multi'].requires = ['dep_one_one', 'base_two']
-        config['dep_one_one'].requires = ['dep_one']
-        config['dep_one'].requires = ['base_one']
-
-        built_graph = actiongraph.ActionGraph.from_config(config)
-        am = built_graph.action_map
-
-        graph_base_names = {a.name for a in built_graph.graph}
-        assert_equal(graph_base_names, {a.name for a in self.graph})
-        assert_equal(graph_base_names, {'base_one', 'base_two'})
-        assert_equal(
-            set(am['dep_multi'].required_actions),
-            {'dep_one_one', 'base_two'},
-        )
-
-        assert_equal(set(am.keys()), set(self.action_names))
-        assert_equal(am['base_one'].dependent_actions, {'dep_one'})
-        assert_equal(am['dep_one'].dependent_actions, {'dep_one_one'})
-
-    def test_actions_for_names(self):
-        actions = list(
-            self.action_graph.actions_for_names(['base_one', 'dep_multi']),
-        )
-        expected_actions = [
-            self.action_map['base_one'],
-            self.action_map['dep_multi'],
-        ]
-        assert_equal(actions, expected_actions)
+        self.action_graph = actiongraph.ActionGraph(self.action_map, self.required_actions, self.required_triggers)
 
     def test__getitem__(self):
         assert_equal(
@@ -80,17 +46,18 @@ class TestActionGraph(TestCase):
 
     def test__eq__(self):
         other_graph = mock.MagicMock(
-            graph=self.graph,
             action_map=self.action_map,
+            required_actions=self.required_actions,
+            required_triggers=self.required_triggers,
         )
         assert_equal(self.action_graph, other_graph)
 
-        other_graph.graph = None
+        other_graph.required_actions = None
         assert not self.action_graph == other_graph
 
     def test__ne__(self):
         other_graph = mock.MagicMock()
-        assert self.graph != other_graph
+        assert self.action_graph != other_graph
 
 
 if __name__ == "__main__":

--- a/tests/core/actiongraph_test.py
+++ b/tests/core/actiongraph_test.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from unittest import mock
 
 from testifycompat import assert_equal
@@ -27,13 +24,35 @@ class TestActionGraph(TestCase):
             self.action_map[name].name = name
 
         self.required_actions = {
-            'dep_multi': {self.action_map['dep_one_one'], self.action_map['base_two']},
-            'dep_one_one': {self.action_map['dep_one']},
-            'dep_one': {self.action_map['base_one']},
+            'base_one': set(),
+            'base_two': set(),
+            'dep_multi': {'dep_one_one', 'base_two'},
+            'dep_one_one': {'dep_one'},
+            'dep_one': {'base_one'},
         }
-        self.required_triggers = {}
+        self.required_triggers = {
+            'base_one': {'MASTER.otherjob.first'},
+            'base_two': set(),
+            'dep_multi': set(),
+            'dep_one_one': set(),
+            'dep_one': set(),
+        }
 
         self.action_graph = actiongraph.ActionGraph(self.action_map, self.required_actions, self.required_triggers)
+
+    def test_get_dependencies(self):
+        assert self.action_graph.get_dependencies('not_in_job') == []
+        assert self.action_graph.get_dependencies('base_one') == []
+        assert self.action_graph.get_dependencies('base_one', include_triggers=True)[0].name == 'MASTER.otherjob.first'
+        assert sorted([d.name for d in self.action_graph.get_dependencies('dep_multi')]) == sorted([
+            'dep_one_one', 'base_two',
+        ])
+
+    def test_names(self):
+        assert sorted(self.action_graph.names()) == sorted(self.action_names)
+        assert sorted(self.action_graph.names(include_triggers=True)) == sorted(
+            self.action_names + ['MASTER.otherjob.first']
+        )
 
     def test__getitem__(self):
         assert_equal(

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -58,9 +58,9 @@ class TestActionRunFactory:
         a2.name = 'act2'
         actions = [a1, a2]
         self.action_graph = actiongraph.ActionGraph(
-            actions,
-            {a.name: a
-             for a in actions},
+            {a.name: a for a in actions},
+            {'act1': set(), 'act2': set()},
+            {'act1': set(), 'act2': set()},
         )
 
         mock_node = mock.create_autospec(node.Node)
@@ -894,9 +894,9 @@ class TestActionRunCollection:
             action_graph.append(m)
 
         self.action_graph = actiongraph.ActionGraph(
-            action_graph,
-            {a.name: a
-             for a in action_graph},
+            {a.name: a for a in action_graph},
+            {'action_name': set(), 'second_name': set(), 'cleanup': set()},
+            {'action_name': set(), 'second_name': set(), 'cleanup': set()},
         )
         self.output_path = filehandler.OutputPath(tempfile.mkdtemp())
         self.command = "do command"
@@ -1056,17 +1056,19 @@ class TestActionRunCollectionIsRunBlocked:
     def setup_collection(self):
         action_names = ['action_name', 'second_name', 'cleanup']
 
-        action_graph = []
+        actions = []
         for name in action_names:
-            m = MagicMock(name=name, required_actions=[])
+            m = MagicMock()
             m.name = name
-            action_graph.append(m)
+            actions.append(m)
 
-        self.second_act = second_act = action_graph.pop(1)
-        second_act.required_actions.append(action_graph[0].name)
-        action_map = {a.name: a for a in action_graph}
-        action_map['second_name'] = second_act
-        self.action_graph = actiongraph.ActionGraph(action_graph, action_map)
+        self.second_act = actions[1]
+        action_map = {a.name: a for a in actions}
+        self.action_graph = actiongraph.ActionGraph(
+            action_map,
+            {'action_name': set(), 'second_name': {'action_name'}, 'cleanup': set()},
+            {'action_name': set(), 'second_name': set(), 'cleanup': set()},
+        )
 
         self.output_path = filehandler.OutputPath(tempfile.mkdtemp())
         self.command = "do command"
@@ -1092,9 +1094,10 @@ class TestActionRunCollectionIsRunBlocked:
         assert not self.collection._is_run_blocked(self.run_map['second_name'])
 
     def test_is_run_blocked_required_actions_blocked(self):
-        third_act = MagicMock(required_actions=[self.second_act.name], )
+        third_act = MagicMock()
         third_act.name = 'third_act'
         self.action_graph.action_map['third_act'] = third_act
+        self.action_graph.required_actions['third_act'] = {self.second_act.name}
         self.run_map['third_act'] = self._build_run('third_act')
 
         self.run_map['action_name'].machine.state = ActionRun.FAILED

--- a/tests/core/job_scheduler_test.py
+++ b/tests/core/job_scheduler_test.py
@@ -330,6 +330,7 @@ class TestJobSchedulerFactory(TestCase):
             self.output_stream_dir,
             self.time_zone,
             self.action_runner,
+            mock.Mock(),
         )
 
     def test_build(self):

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -81,6 +81,7 @@ class TestJob(TestCase):
             parent_context=parent_context,
             output_path=output_path,
             action_runner=self.action_runner,
+            action_graph=mock.Mock()
         )
 
         assert_equal(new_job.scheduler, scheduler)

--- a/tests/core/jobgraph_test.py
+++ b/tests/core/jobgraph_test.py
@@ -1,0 +1,139 @@
+from unittest import mock
+
+from testifycompat import setup
+from testifycompat import TestCase
+from tron.config.schema import ConfigAction
+from tron.config.schema import ConfigJob
+from tron.core.jobgraph import AdjListEntry
+from tron.core.jobgraph import JobGraph
+
+
+class TestJobGraph(TestCase):
+    @setup
+    def setup_graph(self):
+        action1 = ConfigAction(
+            name='action1',
+            command='do something',
+        )
+        action2 = ConfigAction(
+            name='action1',
+            command='do something',
+            requires=['action1'],
+        )
+        job1_config = ConfigJob(
+            name='job1',
+            node='default',
+            schedule=mock.Mock(),
+            actions={'action1': action1, 'action2': action2},
+            namespace='MASTER',
+        )
+
+        action3 = ConfigAction(
+            name='action3',
+            command='do something',
+            triggered_by=['MASTER.job1.action2'],
+        )
+        job2_config = ConfigJob(
+            name='job1',
+            node='default',
+            schedule=mock.Mock(),
+            actions={'action3': action3},
+            namespace='other',
+        )
+
+        action4 = ConfigAction(
+            name='action4',
+            command='do something',
+        )
+        action5 = ConfigAction(
+            name='action5',
+            command='do something',
+            requires=['action4'],
+            triggered_by=['other.job2.action3'],
+        )
+        job3_config = ConfigJob(
+            name='job1',
+            node='default',
+            schedule=mock.Mock(),
+            actions={'action4': action4, 'action5': action5},
+            namespace='MASTER',
+        )
+        config_container = mock.Mock()
+        config_container.get_jobs.return_value = {
+            'MASTER.job1': job1_config,
+            'other.job2': job2_config,
+            'MASTER.job3': job3_config,
+        }
+
+        self.job_graph = JobGraph(config_container)
+
+    def test_job_graph(self):
+        assert sorted(list(self.job_graph.action_map.keys())) == [
+            'MASTER.job1.action1',
+            'MASTER.job1.action2',
+            'MASTER.job3.action4',
+            'MASTER.job3.action5',
+            'other.job2.action3',
+        ]
+        assert self.job_graph._actions_for_job == {
+            'MASTER.job1': ['MASTER.job1.action1', 'MASTER.job1.action2'],
+            'other.job2': ['other.job2.action3'],
+            'MASTER.job3': ['MASTER.job3.action4', 'MASTER.job3.action5'],
+        }
+        assert self.job_graph._adj_list == {
+            'MASTER.job1.action1': [AdjListEntry('MASTER.job1.action2', False)],
+            'MASTER.job1.action2': [AdjListEntry('other.job2.action3', True)],
+            'other.job2.action3': [AdjListEntry('MASTER.job3.action5', True)],
+            'MASTER.job3.action4': [AdjListEntry('MASTER.job3.action5', False)],
+        }
+        assert self.job_graph._rev_adj_list == {
+            'MASTER.job1.action1': [],
+            'MASTER.job1.action2': [AdjListEntry('MASTER.job1.action1', False)],
+            'other.job2.action3': [AdjListEntry('MASTER.job1.action2', True)],
+            'MASTER.job3.action4': [],
+            'MASTER.job3.action5': [
+                AdjListEntry('MASTER.job3.action4', False),
+                AdjListEntry('other.job2.action3', True),
+            ],
+        }
+
+    def test_get_action_graph_for_job(self):
+        action_graph_1 = self.job_graph.get_action_graph_for_job('MASTER.job1')
+        assert sorted((action_graph_1.action_map.keys())) == [
+            'action1',
+            'action2',
+        ]
+        assert action_graph_1.required_actions == {
+            'action1': set(),
+            'action2': {'action1'}
+        }
+        assert action_graph_1.required_triggers == {
+            'other.job2.action3': {'action2'},
+            'MASTER.job3.action5': {'other.job2.action3'},
+        }
+
+        action_graph_2 = self.job_graph.get_action_graph_for_job('other.job2')
+        assert sorted((action_graph_2.action_map.keys())) == [
+            'action3',
+        ]
+        assert action_graph_2.required_actions == {
+            'action3': set(),
+        }
+        assert action_graph_2.required_triggers == {
+            'action3': {'MASTER.job1.action2'},
+            'MASTER.job3.action5': {'action3'},
+        }
+
+        action_graph_3 = self.job_graph.get_action_graph_for_job('MASTER.job3')
+        assert sorted((action_graph_3.action_map.keys())) == [
+            'action4',
+            'action5',
+        ]
+        assert action_graph_3.required_actions == {
+            'action4': set(),
+            'action5': {'action4'},
+        }
+        assert action_graph_3.required_triggers == {
+            'action5': {'other.job2.action3'},
+            'other.job2.action3': {'MASTER.job1.action2'},
+        }

--- a/tests/mcp_test.py
+++ b/tests/mcp_test.py
@@ -77,7 +77,7 @@ class TestMasterControlProgram(TestCase):
         mock_cluster_repo.configure.assert_called_with(
             master_config.mesos_options,
         )
-        self.mcp.build_job_scheduler_factory(master_config)
+        self.mcp.build_job_scheduler_factory(master_config, mock.Mock())
 
     def test_update_state_watcher_config_changed(self):
         self.mcp.state_watcher.update_from_config.return_value = True

--- a/tron/api/adapter.py
+++ b/tron/api/adapter.py
@@ -207,7 +207,8 @@ class ActionRunGraphAdapter(object):
 
     def get_repr(self):
         def build(action_run):
-            action = self.action_runs.action_graph[action_run.action_name]
+            graph = self.action_runs.action_graph
+            dependencies = graph.get_dependencies(action_run.action_name, include_triggers=True)
             return {
                 'id': action_run.id,
                 'name': action_run.action_name,
@@ -216,7 +217,7 @@ class ActionRunGraphAdapter(object):
                 'state': action_run.state,
                 'start_time': action_run.start_time,
                 'end_time': action_run.end_time,
-                'dependencies': [dep for dep in action.dependent_actions],
+                'dependencies': [d.name for d in dependencies]
             }
 
         return [build(action_run) for action_run in self.action_runs]

--- a/tron/api/adapter.py
+++ b/tron/api/adapter.py
@@ -220,7 +220,21 @@ class ActionRunGraphAdapter(object):
                 'dependencies': [d.name for d in dependencies]
             }
 
-        return [build(action_run) for action_run in self.action_runs]
+        def build_trigger(trigger_name):
+            graph = self.action_runs.action_graph
+            trigger = graph[trigger_name]
+            dependencies = graph.get_dependencies(trigger_name, include_triggers=True)
+            return {
+                'name': trigger.name,
+                'command': trigger.command,
+                'dependencies': [d.name for d in dependencies],
+                'state': 'unknown',
+            }
+
+        return [build(action_run) for action_run in self.action_runs] + [
+            build_trigger(trigger_name)
+            for trigger_name in self.action_runs.action_graph.all_triggers
+        ]
 
 
 class JobRunAdapter(RunAdapter):

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -206,7 +206,7 @@ class JobResource(resource.Resource):
             return JobRunResource(run, self.job_scheduler)
 
         job = self.job_scheduler.get_job()
-        if run_id in job.action_graph.names:
+        if run_id in job.action_graph.names():
             action_runs = job.runs.get_action_runs(run_id)
             return ActionRunHistoryResource(action_runs)
 

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -32,8 +32,6 @@ class Action:
     triggered_by: set = None
     on_upstream_rerun: str = None
     trigger_timeout: datetime.timedelta = None
-    required_actions: set = field(default_factory=set)
-    dependent_actions: set = field(default_factory=set)
 
     @property
     def is_cleanup(self):

--- a/tron/core/actiongraph.py
+++ b/tron/core/actiongraph.py
@@ -22,8 +22,8 @@ class ActionGraph(object):
             self.all_triggers |= action_triggers
 
     def get_dependencies(self, action_name, include_triggers=False):
-        """Given an Action's name return the Actions required to run
-        before that Action.
+        """Given an Action's name return the Actions (and optionally, Triggers)
+        required to run before that Action.
         """
         if action_name not in set(self.action_map) | self.all_triggers:
             return []
@@ -56,6 +56,8 @@ class ActionGraph(object):
         if name in self.action_map:
             return self.action_map[name]
         elif name in self.all_triggers:
+            # we don't have the Trigger config to know what the real command is,
+            # so we just fill in the command with 'TRIGGER'
             return Trigger(name, 'TRIGGER')
         else:
             raise KeyError(f'{name} is not a valid action')

--- a/tron/core/actiongraph.py
+++ b/tron/core/actiongraph.py
@@ -57,9 +57,15 @@ class ActionGraph(object):
             return self.action_map[name]
         elif name in self.all_triggers:
             return Trigger(name, 'TRIGGER')
+        else:
+            raise KeyError(f'{name} is not a valid action')
 
     def __eq__(self, other):
-        return self.graph == other.graph and self.action_map == other.action_map
+        return (
+            self.action_map == other.action_map and
+            self.required_actions == other.required_actions and
+            self.required_triggers == other.required_triggers
+        )
 
     def __ne__(self, other):
         return not self == other

--- a/tron/core/actiongraph.py
+++ b/tron/core/actiongraph.py
@@ -20,6 +20,7 @@ class ActionGraph(object):
         self.all_triggers = set(self.required_triggers)
         for action_triggers in self.required_triggers.values():
             self.all_triggers |= action_triggers
+        self.all_triggers -= set(self.action_map)
 
     def get_dependencies(self, action_name, include_triggers=False):
         """Given an Action's name return the Actions (and optionally, Triggers)

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -35,7 +35,7 @@ class ActionRunFactory(object):
 
     @classmethod
     def build_action_run_collection(cls, job_run, action_runner):
-        """Create an ActionRunGraph from an ActionGraph and JobRun."""
+        """Create an ActionRunCollection from an ActionGraph and JobRun."""
         action_run_map = {
             maybe_decode(name): cls.build_run_for_action(
                 job_run,

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -979,7 +979,7 @@ class ActionRunCollection(object):
         if action_run.is_done or action_run.is_active:
             return False
 
-        required_actions = self.action_graph.get_required_actions(
+        required_actions = self.action_graph.get_dependencies(
             action_run.action_name,
         )
 

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -2,7 +2,6 @@ import logging
 
 from tron import command_context
 from tron import node
-from tron.core import actiongraph
 from tron.core import jobrun
 from tron.core.actionrun import ActionRun
 from tron.serialize import filehandler
@@ -109,12 +108,9 @@ class Job(Observable, Observer):
         parent_context,
         output_path,
         action_runner,
+        action_graph,
     ):
         """Factory method to create a new Job instance from configuration."""
-        action_graph = actiongraph.ActionGraph.from_config(
-            job_config.actions,
-            job_config.cleanup_action,
-        )
         runs = jobrun.JobRunCollection.from_config(job_config)
         node_repo = node.NodePoolRepository.get_instance()
 

--- a/tron/core/job_scheduler.py
+++ b/tron/core/job_scheduler.py
@@ -224,22 +224,25 @@ class JobScheduler(Observer):
 class JobSchedulerFactory(object):
     """Construct JobScheduler instances from configuration."""
 
-    def __init__(self, context, output_stream_dir, time_zone, action_runner):
+    def __init__(self, context, output_stream_dir, time_zone, action_runner, job_graph):
         self.context = context
         self.output_stream_dir = output_stream_dir
         self.time_zone = time_zone
         self.action_runner = action_runner
+        self.job_graph = job_graph
 
     def build(self, job_config):
         log.debug(f"Building new job {job_config.name}")
         output_path = filehandler.OutputPath(self.output_stream_dir)
         time_zone = job_config.time_zone or self.time_zone
         scheduler = scheduler_from_config(job_config.schedule, time_zone)
+        action_graph = self.job_graph.get_action_graph_for_job(job_config.name)
         job = Job.from_config(
             job_config=job_config,
             scheduler=scheduler,
             parent_context=self.context,
             output_path=output_path,
             action_runner=self.action_runner,
+            action_graph=action_graph,
         )
         return JobScheduler(job)

--- a/tron/core/jobgraph.py
+++ b/tron/core/jobgraph.py
@@ -9,7 +9,14 @@ AdjListEntry = namedtuple('AdjListEntry', ['action_name', 'is_trigger'])
 
 
 class JobGraph(object):
+    """ A JobGraph stores the entire DAG of jobs and actions, including
+    cross-job dependencies (aka triggers)
+    """
+
     def __init__(self, config_container):
+        """ Build an adjacency list and a reverse adjacency list for the graph,
+        and store all the actions as well as which actions belong to which job
+        """
         self.action_map = {}
         self._actions_for_job = defaultdict(list)
         self._adj_list = defaultdict(list)
@@ -17,15 +24,13 @@ class JobGraph(object):
 
         for job_name, job_config in config_container.get_jobs().items():
             for action_name, action_config in job_config.actions.items():
-                action_name = maybe_decode(action_name)
-                full_name = f'{job_name}.{action_name}'
-                self.action_map[full_name] = Action.from_config(action_config)
-                self._actions_for_job[job_name].append(full_name)
+                full_name = self._save_action(action_name, job_name, action_config)
 
-                self._rev_adj_list[full_name] += [
-                    AdjListEntry(f'{job_name}.{required_action}', False)
-                    for required_action in action_config.requires
-                ]
+                if action_config.requires:
+                    self._rev_adj_list[full_name] += [
+                        AdjListEntry(f'{job_name}.{required_action}', False)
+                        for required_action in action_config.requires
+                    ]
                 if action_config.triggered_by:
                     self._rev_adj_list[full_name] += [
                         AdjListEntry('.'.join(trigger.split('.')[:3]), True)
@@ -37,16 +42,15 @@ class JobGraph(object):
 
             cleanup_action_config = job_config.cleanup_action
             if cleanup_action_config:
-                cleanup_action = Action.from_config(cleanup_action_config)
-                full_name = f'{job_name}.{cleanup_action.name}'
-                self._actions_for_job[job_name].append(full_name)
-                self.action_map[full_name] = cleanup_action
+                self._save_action(cleanup_action_config.name, job_name, cleanup_action_config)
 
     def get_action_graph_for_job(self, job_name):
+        """ Traverse the JobGraph for a specific job to construct an ActionGraph for it """
         job_action_map = {}
         required_actions, required_triggers = defaultdict(set), defaultdict(set)
 
         for action_name in self._actions_for_job[job_name]:
+            # Any actions that belong to _this job_ are not prefixed by the job name
             short_action_name = action_name.split('.')[-1]
             job_action_map[short_action_name] = self.action_map[action_name]
             required_actions[short_action_name] = {
@@ -54,13 +58,27 @@ class JobGraph(object):
                 for entry in self._rev_adj_list[action_name]
                 if not entry.is_trigger
             }
+
+            # We call this twice to build the complete DAG for the job; the first time
+            # we search the forward adjacency list and the second time we search the
+            # reverse adjancency list.  This ensures we don't miss any triggers
             self._get_required_triggers(action_name, required_triggers)
             self._get_required_triggers(action_name, required_triggers, search_up=False)
         return ActionGraph(job_action_map, required_actions, required_triggers)
 
+    def _save_action(self, action_name, job_name, config):
+        action_name = maybe_decode(action_name)
+        full_name = f'{job_name}.{action_name}'
+        self.action_map[full_name] = Action.from_config(config)
+        self._actions_for_job[job_name].append(full_name)
+        return full_name
+
     def _get_required_triggers(self, action_name, triggers, search_up=True):
         stack = [action_name]
         visited = set()
+
+        # Do DFS to search the adjacency list and find all of the required triggers
+        # for a particular action
         while stack:
             current_action = stack.pop()
             visited.add(current_action)

--- a/tron/core/jobgraph.py
+++ b/tron/core/jobgraph.py
@@ -1,0 +1,79 @@
+from collections import defaultdict
+from collections import namedtuple
+
+from tron.core.action import Action
+from tron.core.actiongraph import ActionGraph
+from tron.utils import maybe_decode
+
+AdjListEntry = namedtuple('AdjListEntry', ['action_name', 'is_trigger'])
+
+
+class JobGraph(object):
+    def __init__(self, config_container):
+        self.action_map = {}
+        self._actions_for_job = defaultdict(list)
+        self._adj_list = defaultdict(list)
+        self._rev_adj_list = defaultdict(list)
+
+        for job_name, job_config in config_container.get_jobs().items():
+            for action_name, action_config in job_config.actions.items():
+                action_name = maybe_decode(action_name)
+                full_name = f'{job_name}.{action_name}'
+                self.action_map[full_name] = Action.from_config(action_config)
+                self._actions_for_job[job_name].append(full_name)
+
+                self._rev_adj_list[full_name] += [
+                    AdjListEntry(f'{job_name}.{required_action}', False)
+                    for required_action in action_config.requires
+                ]
+                if action_config.triggered_by:
+                    self._rev_adj_list[full_name] += [
+                        AdjListEntry('.'.join(trigger.split('.')[:3]), True)
+                        for trigger in action_config.triggered_by
+                    ]
+
+                for parent_action, is_trigger in self._rev_adj_list[full_name]:
+                    self._adj_list[parent_action].append(AdjListEntry(full_name, is_trigger))
+
+            cleanup_action_config = job_config.cleanup_action
+            if cleanup_action_config:
+                cleanup_action = Action.from_config(cleanup_action_config)
+                self.action_map[maybe_decode(cleanup_action.name)] = cleanup_action
+
+    def get_action_graph_for_job(self, job_name):
+        job_action_map = {}
+        required_actions, required_triggers = defaultdict(set), defaultdict(set)
+
+        for action_name in self._actions_for_job[job_name]:
+            short_action_name = action_name.split('.')[-1]
+            job_action_map[short_action_name] = self.action_map[action_name]
+            required_actions[short_action_name] = {
+                entry.action_name.split('.')[-1]
+                for entry in self._rev_adj_list[action_name]
+                if not entry.is_trigger
+            }
+            self._get_required_triggers(action_name, required_triggers)
+            self._get_required_triggers(action_name, required_triggers, search_up=False)
+        return ActionGraph(job_action_map, required_actions, required_triggers)
+
+    def _get_required_triggers(self, action_name, triggers, search_up=True):
+        stack = [action_name]
+        visited = set()
+        while stack:
+            current_action = stack.pop()
+            visited.add(current_action)
+            adj_list = self._rev_adj_list if search_up else self._adj_list
+            for next_action, is_trigger in adj_list[current_action]:
+                if not is_trigger:
+                    continue
+
+                if next_action not in visited:
+                    stack.append(next_action)
+
+                if current_action == action_name:
+                    current_action = current_action.split('.')[-1]
+
+                if search_up:
+                    triggers[current_action].add(next_action)
+                else:
+                    triggers[next_action].add(current_action)

--- a/tron/core/jobgraph.py
+++ b/tron/core/jobgraph.py
@@ -38,7 +38,9 @@ class JobGraph(object):
             cleanup_action_config = job_config.cleanup_action
             if cleanup_action_config:
                 cleanup_action = Action.from_config(cleanup_action_config)
-                self.action_map[maybe_decode(cleanup_action.name)] = cleanup_action
+                full_name = f'{job_name}.{cleanup_action.name}'
+                self._actions_for_job[job_name].append(full_name)
+                self.action_map[full_name] = cleanup_action
 
     def get_action_graph_for_job(self, job_name):
         job_action_map = {}

--- a/tronweb/coffee/graph.coffee
+++ b/tronweb/coffee/graph.coffee
@@ -23,7 +23,7 @@ class window.GraphView extends Backbone.View
     getLinks: (data) =>
         nodes = @buildNodeMap(data)
         nested = for node in data
-            ({source: node, target: nodes[target]} for target in node.dependent)
+            ({source: nodes[dep], target: node} for dep in node.dependencies)
         _.flatten(nested)
 
     buildSvgLinks: (links) =>


### PR DESCRIPTION
### Description of change

1) When Tron initializes, we compute the _entire_ DAG so that we can quickly reference upstream and downstream triggers.  This is stored in the JobGraph class.
2) The JobGraph provides a way to construct an ActionGraph for a particular job: instead of reading the ActionGraph from the config, we look at the jobgraph and get all the actions for that job, along with all of the upstream and downstream triggers.
    - The ActionGraph class has largely been rewritten; there was a bunch of code in there that wasn't being used anywhere, which I stripped out
    - The ActionGraph interface has also changed slightly
3) The ActionGraphAdapter and the ActionRunGraphAdapter are responsible for getting all of the upstream dependencies for each action in the job into the right format.

### Testing done

* So far all the testing I've done has just been on my local devbox.  You can see what tronweb looks like [here](http://dev54-uswest1adevc:8089/web/#home) (requires VPN).