### PR TITLE
Waiting state if an action is waiting for normal or cross-job dependencies

### DIFF
--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -269,6 +269,10 @@ class TestActionRun:
     def test_init_state(self):
         assert self.action_run.state == ActionRun.SCHEDULED
 
+    def test_ready_state(self):
+        self.action_run.ready()
+        assert self.action_run.state == ActionRun.WAITING
+
     def test_start(self):
         self.action_run.machine.transition('ready')
         assert self.action_run.start()

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -109,17 +109,16 @@ class TestJob(TestCase):
         assert_equal(self.job.status, self.job.STATUS_DISABLED)
 
     def test_status_enabled(self):
-        def state_in(state):
-            return state in [ActionRun.SCHEDULED, ActionRun.QUEUED]
-
-        self.job.runs.get_run_by_state = state_in
+        self.job.runs.get_run_by_state = lambda state: MagicMock() if state == ActionRun.SCHEDULED else None
+        self.job.runs.get_active.return_value = []
         assert_equal(self.job.status, self.job.STATUS_ENABLED)
 
     def test_status_running(self):
-        self.job.runs.get_run_by_state = lambda s: MagicMock()
+        self.job.runs.get_active.return_value = [MagicMock()]
         assert_equal(self.job.status, self.job.STATUS_RUNNING)
 
     def test_status_unknown(self):
+        self.job.runs.get_active.return_value = []
         self.job.runs.get_run_by_state = lambda s: None
         assert_equal(self.job.status, self.job.STATUS_UNKNOWN)
 

--- a/tests/core/jobrun_test.py
+++ b/tests/core/jobrun_test.py
@@ -163,11 +163,6 @@ class TestJobRun(TestCase):
         autospec_method(self.job_run._do_start, return_value=False)
         assert not self.job_run.start()
 
-    def test_start_no_startable_action_runs(self):
-        autospec_method(self.job_run._do_start)
-        self.job_run.action_runs.has_startable_action_runs = False
-        assert not self.job_run.start()
-
     def test_do_start(self):
         startable_runs = [
             mock.create_autospec(actionrun.ActionRun) for _ in range(3)
@@ -408,6 +403,10 @@ class MockJobRun(MagicMock):
     def is_starting(self):
         return self.state == actionrun.ActionRun.STARTING
 
+    @property
+    def is_waiting(self):
+        return self.state == actionrun.ActionRun.WAITING
+
     def __repr__(self):
         return str(self.__dict__)
 
@@ -418,9 +417,10 @@ class TestJobRunCollection(TestCase):
 
     @setup
     def setup_runs(self):
-        self.run_collection = jobrun.JobRunCollection(5)
+        self.run_collection = jobrun.JobRunCollection(6)
         self.job_runs = [
-            self._mock_run(state=actionrun.ActionRun.QUEUED, run_num=4),
+            self._mock_run(state=actionrun.ActionRun.QUEUED, run_num=5),
+            self._mock_run(state=actionrun.ActionRun.WAITING, run_num=4),
             self._mock_run(state=actionrun.ActionRun.RUNNING, run_num=3),
         ] + [
             self._mock_run(
@@ -432,7 +432,7 @@ class TestJobRunCollection(TestCase):
         self.mock_node = mock.create_autospec(node.Node)
 
     def test__init__(self):
-        assert_equal(self.run_collection.run_limit, 5)
+        assert_equal(self.run_collection.run_limit, 6)
 
     def test_from_config(self):
         job_config = mock.Mock(run_limit=20)
@@ -476,7 +476,7 @@ class TestJobRunCollection(TestCase):
         )
         assert_in(job_run, self.run_collection.runs)
         self.run_collection.remove_old_runs.assert_called_with()
-        assert job_run.run_num == 5
+        assert job_run.run_num == 6
         assert job_run.job_name == mock_job.get_name.return_value
 
     def test_build_new_run_manual(self):
@@ -491,7 +491,7 @@ class TestJobRunCollection(TestCase):
         )
         assert_in(job_run, self.run_collection.runs)
         self.run_collection.remove_old_runs.assert_called_with()
-        assert job_run.run_num == 5
+        assert job_run.run_num == 6
         assert job_run.manual
 
     def test_cancel_pending(self):
@@ -510,14 +510,14 @@ class TestJobRunCollection(TestCase):
 
     def test_remove_pending(self):
         self.run_collection.remove_pending()
-        assert_length(self.run_collection.runs, 3)
+        assert_length(self.run_collection.runs, 4)
         assert_equal(self.run_collection.runs[0], self.job_runs[1])
         assert_call(self.job_runs[0].cleanup, 0)
 
     def test_get_run_by_state(self):
         state = actionrun.ActionRun.SUCCEEDED
         run = self.run_collection.get_run_by_state(state)
-        assert_equal(run, self.job_runs[2])
+        assert_equal(run, self.job_runs[3])
 
     def test_get_run_by_state_no_match(self):
         state = actionrun.ActionRun.UNKNOWN
@@ -543,9 +543,9 @@ class TestJobRunCollection(TestCase):
         assert_equal(run, self.job_runs[-2])
 
     def test_get_run_by_index_invalid_index(self):
-        run = self.run_collection.get_run_by_index(-5)
+        run = self.run_collection.get_run_by_index(-6)
         assert_equal(run, None)
-        run = self.run_collection.get_run_by_index(4)
+        run = self.run_collection.get_run_by_index(5)
         assert_equal(run, None)
 
     def test_get_newest(self):
@@ -584,8 +584,8 @@ class TestJobRunCollection(TestCase):
         )
         self.run_collection.runs.appendleft(starting_run)
         active = list(self.run_collection.get_active())
-        assert_length(active, 2)
-        assert_equal(active, [starting_run, self.job_runs[1]])
+        assert_length(active, 3)
+        assert_equal(active, [starting_run, self.job_runs[1], self.job_runs[2]])
 
     def test_get_active_with_node(self):
         starting_run = self._mock_run(
@@ -595,8 +595,8 @@ class TestJobRunCollection(TestCase):
         starting_run.node = 'differentnode'
         self.run_collection.runs.appendleft(starting_run)
         active = list(self.run_collection.get_active('anode'))
-        assert_length(active, 1)
-        assert_equal(active, [self.job_runs[1]])
+        assert_length(active, 2)
+        assert_equal(active, [self.job_runs[1], self.job_runs[2]])
 
     def test_get_active_none(self):
         active = list(self.run_collection.get_active('bogus'))
@@ -618,32 +618,8 @@ class TestJobRunCollection(TestCase):
         first_queued = self.run_collection.get_first_queued()
         assert not first_queued
 
-    def test_get_next_to_finish(self):
-        next_run = self.run_collection.get_next_to_finish()
-        assert_equal(next_run, self.job_runs[1])
-
-    def test_get_next_to_finish_by_node(self):
-        self.job_runs[1].node = "seven"
-        scheduled_run = self._mock_run(
-            run_num=self.run_collection.next_run_num(),
-            state=actionrun.ActionRun.SCHEDULED,
-            node="nine",
-        )
-        self.run_collection.runs.appendleft(scheduled_run)
-
-        next_run = self.run_collection.get_next_to_finish(node="seven")
-        assert_equal(next_run, self.job_runs[1])
-
-    def test_get_next_to_finish_none(self):
-        next_run = self.run_collection.get_next_to_finish(node="seven")
-        assert_equal(next_run, None)
-
-        self.job_runs[1].state = None
-        next_run = self.run_collection.get_next_to_finish()
-        assert_equal(next_run, None)
-
     def test_get_next_run_num(self):
-        assert_equal(self.run_collection.next_run_num(), 5)
+        assert_equal(self.run_collection.next_run_num(), 6)
 
     def test_get_next_run_num_first(self):
         run_collection = jobrun.JobRunCollection(5)
@@ -671,10 +647,10 @@ class TestJobRunCollection(TestCase):
         assert_length(self.run_collection.state_data, len(self.job_runs))
 
     def test_last_success(self):
-        assert_equal(self.run_collection.last_success, self.job_runs[2])
+        assert_equal(self.run_collection.last_success, self.job_runs[3])
 
     def test__str__(self):
-        expected = "JobRunCollection[4(queued), 3(running), 2(succeeded), 1(succeeded)]"
+        expected = "JobRunCollection[5(queued), 4(waiting), 3(running), 2(succeeded), 1(succeeded)]"
         assert_equal(str(self.run_collection), expected)
 
     def test_get_action_runs(self):

--- a/tests/core/jobrun_test.py
+++ b/tests/core/jobrun_test.py
@@ -216,6 +216,19 @@ class TestJobRun(TestCase):
         started_runs = self.job_run._start_action_runs()
         assert_equal(started_runs, [])
 
+    def test_handler_trigger_ready_still_scheduled(self):
+        autospec_method(self.job_run._start_action_runs)
+        self.job_run.is_scheduled = True
+        self.job_run.handler(self.action_run, actionrun.ActionRun.NOTIFY_TRIGGER_READY)
+        assert not self.job_run._start_action_runs.mock_calls
+
+    def test_handler_trigger_ready_started(self):
+        autospec_method(self.job_run._start_action_runs)
+        self.job_run.is_scheduled = False
+        self.job_run.is_queued = False
+        self.job_run.handler(self.action_run, actionrun.ActionRun.NOTIFY_TRIGGER_READY)
+        assert self.job_run._start_action_runs.call_count == 1
+
     def test_handler_not_end_state_event(self):
         autospec_method(self.job_run.finalize)
         autospec_method(self.job_run._start_action_runs)
@@ -238,8 +251,8 @@ class TestJobRun(TestCase):
         startable_run.start.assert_called_with()
         assert not self.job_run.finalize.mock_calls
 
-    def test_handler_is_active(self):
-        self.job_run.action_runs.is_active = True
+    def test_handler_runs_not_done(self):
+        self.job_run.action_runs.is_done = False
         autospec_method(self.job_run._start_action_runs, return_value=[])
         autospec_method(self.job_run.finalize)
         self.job_run.handler(self.action_run, mock.Mock())

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -142,6 +142,7 @@ class ActionRun(Observable):
     SKIPPED = 'skipped'
     STARTING = 'starting'
     SUCCEEDED = 'succeeded'
+    WAITING = 'waiting'
     UNKNOWN = 'unknown'
 
     default_transitions = dict(fail=FAILED, success=SUCCEEDED)
@@ -165,9 +166,15 @@ class ActionRun(Observable):
                     schedule=SCHEDULED,
                     **default_transitions,
                 ),
+            WAITING:
+                dict(
+                    cancel=CANCELLED,
+                    start=STARTING,
+                    **default_transitions,
+                ),
             SCHEDULED:
                 dict(
-                    ready=QUEUED,
+                    ready=WAITING,
                     queue=QUEUED,
                     cancel=CANCELLED,
                     start=STARTING,
@@ -918,6 +925,7 @@ class ActionRunCollection(object):
                 proxy.attr_proxy('is_scheduled', any),
                 proxy.attr_proxy('is_cancelled', any),
                 proxy.attr_proxy('is_active', any),
+                proxy.attr_proxy('is_waiting', all),
                 proxy.attr_proxy('is_queued', all),
                 proxy.attr_proxy('is_complete', all),
                 proxy.func_proxy('queue', eager_all),

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -161,6 +161,7 @@ class ActionRun(Observable):
                 dict(running=RUNNING, fail_unknown=UNKNOWN, **default_transitions),
             QUEUED:
                 dict(
+                    ready=WAITING,
                     cancel=CANCELLED,
                     start=STARTING,
                     schedule=SCHEDULED,

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -925,7 +925,7 @@ class ActionRunCollection(object):
                 proxy.attr_proxy('is_scheduled', any),
                 proxy.attr_proxy('is_cancelled', any),
                 proxy.attr_proxy('is_active', any),
-                proxy.attr_proxy('is_waiting', all),
+                proxy.attr_proxy('is_waiting', any),
                 proxy.attr_proxy('is_queued', all),
                 proxy.attr_proxy('is_complete', all),
                 proxy.func_proxy('queue', eager_all),
@@ -980,9 +980,12 @@ class ActionRunCollection(object):
     def has_startable_action_runs(self):
         return any(self.get_startable_action_runs())
 
-    def _is_run_blocked(self, action_run):
+    def _is_run_blocked(self, action_run, in_job_only=False):
         """Returns True if the ActionRun is waiting on a required run to
         finish before it can run.
+
+        If in_job_only is True, only considers required actions in this job,
+        not triggers.
         """
         if action_run.is_done or action_run.is_active:
             return False
@@ -996,7 +999,7 @@ class ActionRunCollection(object):
             if any(not run.is_complete for run in required_runs):
                 return True
 
-        if action_run.is_blocked_on_trigger:
+        if action_run.is_blocked_on_trigger and not in_job_only:
             return True
 
         return False
@@ -1014,7 +1017,9 @@ class ActionRunCollection(object):
             return False
 
         def done_or_blocked(action_run):
-            return action_run.is_done or self._is_run_blocked(action_run)
+            # Can't make progress if blocked by actions in the job, and other actions are done.
+            # On the other hand, not necessarily done if still waiting for cross-job dependencies.
+            return action_run.is_done or self._is_run_blocked(action_run, in_job_only=True)
 
         return all(done_or_blocked(run) for run in self.action_runs)
 

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -151,7 +151,7 @@ class Job(Observable, Observer):
         """Current status."""
         if not self.enabled:
             return self.STATUS_DISABLED
-        if self.runs.get_run_by_state(ActionRun.RUNNING):
+        if self.runs.get_active():
             return self.STATUS_RUNNING
 
         if self.runs.get_run_by_state(ActionRun.SCHEDULED):

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -217,8 +217,8 @@ class JobRun(Observable, Observer):
         metrics.meter(f'tron.actionrun.{event}')
 
         if event == ActionRun.NOTIFY_TRIGGER_READY:
-            if timeutils.current_timestamp() < self.run_time.timestamp():
-                log.info(f"{self} triggers are satisfied but not run_time yet")
+            if self.is_scheduled or self.is_queued:
+                log.info(f"{self} triggers are satisfied but run not started yet")
                 return
 
             started = self._start_action_runs()
@@ -247,8 +247,8 @@ class JobRun(Observable, Observer):
                 )
                 return
 
-        if self.action_runs.is_active or self.action_runs.is_scheduled:
-            log.info(f"{self} still has running or scheduled actions")
+        if not self.action_runs.is_done:
+            log.info(f"{self} still has running or waiting actions")
             return
 
         # If we can't make any progress, we're done

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -179,7 +179,7 @@ class JobRun(Observable, Observer):
 
     def start(self):
         """Start this JobRun as a scheduled run (not a manual run)."""
-        if self.action_runs.has_startable_action_runs and self._do_start():
+        if self._do_start():
             return True
 
     def _do_start(self):
@@ -306,8 +306,8 @@ class JobRun(Observable, Observer):
             return ActionRun.STARTING
         if self.action_runs.is_failed:
             return ActionRun.FAILED
-        if self.seconds_until_run_time() == 0 and self.action_runs.is_blocked_on_trigger:
-            return ActionRun.RUNNING
+        if self.action_runs.is_waiting:
+            return ActionRun.WAITING
         if self.action_runs.is_scheduled:
             return ActionRun.SCHEDULED
         if self.action_runs.is_queued:
@@ -405,7 +405,7 @@ class JobRunCollection(object):
 
     def get_active(self, node=None):
         return [
-            r for r in self.runs if (r.is_running or r.is_starting) and
+            r for r in self.runs if (r.is_running or r.is_starting or r.is_waiting) and
             (not node or r.node == node)
         ]
 

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -418,15 +418,6 @@ class JobRunCollection(object):
     def get_scheduled(self):
         return [r for r in self.runs if r.state == ActionRun.SCHEDULED]
 
-    def get_next_to_finish(self, node=None):
-        """Return the most recent run which is either running or scheduled. If
-        node is not None, then only looks for runs on that node.
-        """
-        return next_or_none(
-            r for r in self.runs if (not node or r.node == node) and
-            (r.is_running or r.is_scheduled)
-        )
-
     def next_run_num(self):
         """Return the next run number to use."""
         if not self.runs:


### PR DESCRIPTION
We need to differentiate between "waiting for dependencies" and "waiting for the previous job run to finish". QUEUED was being used for both, but now I'm proposing WAITING for the first state and QUEUED for the second. The key change is in L177 of tron/core/actionrun.py.

https://github.com/Yelp/Tron/pull/611 attempted to make "waiting for dependencies" into the RUNNING state, but that makes it seem like it's running as soon as its scheduled time has passed. That causes these issues:
* In the run_job callback that gets called when the scheduled time comes, it won't start the run if it's not "SCHEDULED". With #611, it already appeared running, so job_run.start() never got called. https://github.com/Yelp/Tron/blob/f115e9502153de09dc36f93d2bbbf303a35bb606/tron/core/job_scheduler.py#L130 
* Jobs don't get queued correctly if the next scheduled time comes and the previous run is waiting for dependencies, because no action runs are active if it's waiting: https://github.com/Yelp/Tron/blob/f115e9502153de09dc36f93d2bbbf303a35bb606/tron/core/job_scheduler.py#L139