### PR TITLE
use mesos 1.7.1 in itests

### DIFF
--- a/yelp_package/itest_dockerfiles/mesos/Dockerfile
+++ b/yelp_package/itest_dockerfiles/mesos/Dockerfile
@@ -29,7 +29,7 @@ RUN echo "deb http://repos.mesosphere.com/ubuntu xenial main" > /etc/apt/sources
         docker.io=18.06.1-0ubuntu1.2~16.04.1 \
         libsasl2-modules \
         libstdc++6 \
-        mesos=1.5.0-2.0.1 > /dev/null && \
+        mesos=1.7.1-2.0.1 > /dev/null && \
     rm -rf /var/lib/apt/lists/*
 
 COPY mesos-secrets mesos-slave-secret /etc/


### PR DESCRIPTION
as with https://github.com/Yelp/paasta/pull/2146, there isn't a mesos 1.7.2 package yet in the mesosphere apt repo.  I'll check back for that next week.