### PR TITLE
Add waiting state first for rollback safety

### DIFF
--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -142,6 +142,7 @@ class ActionRun(Observable):
     SKIPPED = 'skipped'
     STARTING = 'starting'
     SUCCEEDED = 'succeeded'
+    WAITING = 'waiting'
     UNKNOWN = 'unknown'
 
     default_transitions = dict(fail=FAILED, success=SUCCEEDED)
@@ -158,6 +159,12 @@ class ActionRun(Observable):
                 dict(started=RUNNING, fail=FAILED, fail_unknown=UNKNOWN),
             UNKNOWN:
                 dict(running=RUNNING, fail_unknown=UNKNOWN, **default_transitions),
+            WAITING:
+                dict(
+                    cancel=CANCELLED,
+                    start=STARTING,
+                    **default_transitions,
+                ),
             QUEUED:
                 dict(
                     cancel=CANCELLED,


### PR DESCRIPTION
Realized my previous change was not rollback safe. If things end up in the waiting state, and then we need to roll back, it's impossible to transition the "waiting" actions to anything, since the state is unknown. 

With this, nothing can go to the waiting state, but it's safe to roll back to.