### PR TITLE
Just get run state once to reduce iterating on deque

### DIFF
--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -404,8 +404,9 @@ class JobRunCollection(object):
         return any(self.get_pending())
 
     def get_active(self, node=None):
+        active_states = {ActionRun.RUNNING, ActionRun.STARTING, ActionRun.WAITING}
         return [
-            r for r in self.runs if (r.is_running or r.is_starting or r.is_waiting) and
+            r for r in self.runs if (r.state in active_states) and
             (not node or r.node == node)
         ]
 


### PR DESCRIPTION
found this error a couple times in the logs with the latest version:
```
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/api/async_resource.py", line 34, in process
    result = fn(resource, request)
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/api/resource.py", line 323, in render_GET
    include_node_pool,
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/api/resource.py", line 286, in get_data
    num_runs=5,
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/api/adapter.py", line 53, in adapt_many
    adapter_class(item, *args, **kwargs).get_repr() for item in seq
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/api/adapter.py", line 54, in <listcomp>
    if item is not None
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/api/adapter.py", line 42, in get_repr
    repr_data = {field: getattr(self._obj, field) for field in self.fields}
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/api/adapter.py", line 42, in <dictcomp>
    repr_data = {field: getattr(self._obj, field) for field in self.fields}
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/core/job.py", line 154, in status
    if self.runs.get_active():
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/core/jobrun.py", line 408, in get_active
    r for r in self.runs if (r.is_running or r.is_starting or r.is_waiting) and
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/core/jobrun.py", line 408, in <listcomp>
    r for r in self.runs if (r.is_running or r.is_starting or r.is_waiting) and
RuntimeError: deque mutated during iteration
```
While we're getting the state of a job via the Tron API, runs are changing state, which causes this error. I don't think this is critical, but I realized what I was doing before was slightly inefficient, so hopefully this will reduce the frequency that happens.