### PR TITLE
Handle starting state from Mesos

### DIFF
--- a/tests/mesos_test.py
+++ b/tests/mesos_test.py
@@ -130,6 +130,14 @@ class TestMesosTask(TestCase):
         self.task.handle_event(event)
         assert self.task.state == MesosTask.PENDING
 
+    def test_handle_starting(self):
+        event = mock_task_event(
+            task_id=self.task_id,
+            platform_type='starting',
+        )
+        self.task.handle_event(event)
+        assert self.task.state == MesosTask.PENDING
+
     def test_handle_running(self):
         event = mock_task_event(
             task_id=self.task_id,

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -233,6 +233,8 @@ class MesosTask(ActionCommand):
 
         if mesos_type == 'staging':
             pass
+        elif mesos_type == 'starting':
+            pass
         elif mesos_type == 'running':
             self.started()
         elif mesos_type == 'finished':


### PR DESCRIPTION
The CommandExecutor sends a TASK_STARTING state as of Mesos 1.5. http://mesos.apache.org/documentation/latest/upgrades/#1-5-x-task-starting

Wasn't an error before, but fills up the logs with this:

```
2019-03-21 15:58:27,696 tron.mesos.MASTER.testjob0.8.zeroth INFO Did not handle unknown 
type of event: Event(timestamp=1553209107.5581896, success=None, kind='task', 
terminal=False, message=None, platform_type='starting', extensions=pmap({}), 
task_id='MASTER.testjob0.8.zeroth.679f1ab0-425e-46a0-8c17-b514d55717a2', raw={'task_id': 
{'value': 'MASTER.testjob0.8.zeroth.679f1ab0-425e-46a0-8c17-b514d55717a2'}, 'state': 
'TASK_STARTING', 'source': 'SOURCE_EXECUTOR', 'agent_id': {'value': '6a8accd7-85ed-4c2b-
a09b-b92e8f3a48c2-S3'}, 'executor_id': {'value': 'MASTER.testjob0.8.zeroth.679f1ab0-425e-
46a0-8c17-b514d55717a2'}, 'timestamp': 1553209107.520053, 'uuid': 
'GhA03NuVRiaeUUPuaeXHpQ==', 'container_status': {'container_id': {'value': 'a41254f4-553f-
444e-bb72-63ca5161b20b'}, 'network_infos': [{'ip_addresses': [{'protocol': 'IPv4', 'ip_address': 
'10.40.16.104'}]}]}}, task_config=MesosTaskConfig(containerizer='DOCKER', 
docker_parameters=pvector([]), image='docker-paasta.yelpcorp.com:443/services-compute-
infra-test-service:paasta-baaf4d7b2ddff5ee9bc0561b1095add5360195a3', 
constraints=pvector([]), cap_add=pvector([]), volumes=pvector([]), offer_timeout=300.0, 
disk=1024.0, mem=100.0, gpus=0, uris=pvector(['file:///root/.dockercfg']), 
name='MASTER.testjob0.8.zeroth', ports=pvector([]), cpus=1.0, uuid=UUID('679f1ab0-425e-
46a0-8c17-b514d55717a2'), cmd='sleep 30', environment=pmap({}), use_cached_image=True, 
ulimit=pvector([])))
```
