### PR TITLE
extend tron restart timeout to 60 seconds so that it could have enoug…

### DIFF
--- a/debian/tron.service
+++ b/debian/tron.service
@@ -6,7 +6,7 @@ After=network.target
 User=tron
 EnvironmentFile=/etc/default/tron
 ExecStart=/usr/bin/trond --lock-file=${LOCKFILE:-$PIDFILE} --working-dir=${WORKINGDIR} --host ${LISTEN_HOST} --port ${LISTEN_PORT} ${DAEMON_OPTS}
-TimeoutStopSec=20
+TimeoutStopSec=60
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Extend Tron restart timeout to 60 seconds so that it could have enough time to retrieve data from DynamoDB. 
DynamoDB on-demand billing mode could not handle sudden changes in workload. It needs a long time(around 30 mins according to someone online) to scale up. We either have to extend timeout to make sure DynamoDB has enough time to read/write or provision more instances.
I need to test more to figure out how long is enough to handle a large enough workload. I tested more. It seems a long enough timeout and enough provisioned instances should be enough.
