### PR TITLE
Make macro_timedelta round days if day > a month's days

### DIFF
--- a/tests/utils/timeutils_test.py
+++ b/tests/utils/timeutils_test.py
@@ -284,6 +284,11 @@ class DateArithmeticTestCase(testingutils.MockTimeTestCase):
     def test_bad_date_format(self):
         assert DateArithmetic.parse('~~') is None
 
+    def test_round_day(self):
+        start = datetime.datetime(2019, 3, 30)
+        delta = timeutils.macro_timedelta(start, months=-1)
+        assert (start + delta).day == 28
+
 
 class DateArithmeticYMDHTest(TestCase):
     def test_ym_plus(self):
@@ -341,6 +346,11 @@ class DateArithmeticYMDHTest(TestCase):
 
         assert_equal(parse(2018, 1, 1, 1, 2), '2018-01-01T01:01')
         assert_equal(parse(2018, 1, 1, 0, 0), '2017-12-31T23:59')
+
+    def test_ym_minus_round(self):
+        dt = datetime.datetime(2019, 3, 30)
+        s = timeutils.DateArithmetic.parse('ym-1', dt=dt)
+        assert s == '2019-02'
 
 
 class TestDateArithmeticWithTimezone(DateArithmeticTestCase):

--- a/tron/utils/timeutils.py
+++ b/tron/utils/timeutils.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
+import calendar
 import datetime
 import re
 
@@ -37,11 +38,17 @@ def macro_timedelta(start_date, years=0, months=0, days=0, hours=0, minutes=0):
     while new_month < 1:
         new_month += 12
         years -= 1
+    new_year = start_date.year + years
+
+    # TRON-1045: round day to the max days in a given month if the day doesn't
+    # exist for that month. (e.g. Feb 30 rounds to Feb 28 in a non-leap year)
+    _, days_in_month = calendar.monthrange(new_year, new_month)
+    new_day = min(start_date.day, days_in_month)
 
     end_date = datetime.datetime(
-        start_date.year + years,
+        new_year,
         new_month,
-        start_date.day,
+        new_day,
         start_date.hour,
         start_date.minute,
     )


### PR DESCRIPTION
### Description
- If `macro_timedelta` is given 03/30 and told to subtract a month from it, it will give 02/30, which is an invalid day. 
- I've made a change that rounds the day to the number of days in a given month if that day doesn't exist. So now, 03/30 becomes 02/28 (for non-leap years like 2019).

### Tests
make test