### PR TITLE
Bump taskproc to 0.1.5 to include fix that restarts driver on error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,7 @@ s3transfer==0.1.13
 setuptools==40.8.0
 six==1.12.0
 SQLAlchemy==1.2.18
-task-processing==0.1.4
+task-processing==0.1.5
 traitlets==4.3.2
 Twisted==18.9.0
 urllib3==1.24.1


### PR DESCRIPTION
@kawaiwanyelp someone needs to review this, and you also have some changes in this bump: https://github.com/Yelp/task_processing/commits/master

Look reasonable?
