### PR TITLE
Improve dynamodb read/write speed

### DIFF
--- a/tests/serialize/runstate/dynamodb_state_store_test.py
+++ b/tests/serialize/runstate/dynamodb_state_store_test.py
@@ -114,3 +114,14 @@ class TestDynamoDBStateStore:
         vals = store.restore(keys)
         for key in keys:
             assert_equal(pickle.dumps(vals[key]), small_object)
+
+    def test_delete(self, store, small_object, large_object):
+        pairs = [(store.build_key("thing", i), large_object) for i in range(3)]
+
+        store.save(pairs)
+
+        for key in pairs:
+            store._delete_item(key)
+
+        for key in pairs:
+            assert_equal(store._get_num_of_partitions(key), 0)

--- a/tests/serialize/runstate/dynamodb_state_store_test.py
+++ b/tests/serialize/runstate/dynamodb_state_store_test.py
@@ -81,9 +81,6 @@ class TestDynamoDBStateStore:
         for key, value in key_value_pairs:
             assert_equal(vals[key], value)
 
-        # for key, value in key_value_pairs:
-        #     store._delete_item(key)
-
     def test_save_more_than_4KB(self, store, small_object, large_object):
         key_value_pairs = [
             (
@@ -98,9 +95,6 @@ class TestDynamoDBStateStore:
         for key, value in key_value_pairs:
             assert_equal(vals[key], value)
 
-        # for key, value in key_value_pairs:
-        #     store._delete_item(key)
-
     def test_restore_more_than_4KB(self, store, small_object, large_object):
         keys = [store.build_key("thing", i) for i in range(3)]
         value = pickle.loads(large_object)
@@ -111,9 +105,6 @@ class TestDynamoDBStateStore:
         for key in keys:
             assert_equal(pickle.dumps(vals[key]), large_object)
 
-        # for key in keys:
-        #     store._delete_item(key)
-
     def test_restore(self, store, small_object, large_object):
         keys = [store.build_key("thing", i) for i in range(3)]
         value = pickle.loads(small_object)
@@ -123,18 +114,3 @@ class TestDynamoDBStateStore:
         vals = store.restore(keys)
         for key in keys:
             assert_equal(pickle.dumps(vals[key]), small_object)
-
-        # for key in keys:
-        #     store._delete_item(key)
-
-    # def test_delete(self, store, small_object, large_object):
-    #     keys = [store.build_key("thing", i) for i in range(3)]
-    #     value = large_object
-    #     for key in keys:
-    #         store[key] = value
-
-    #     for key in keys:
-    #         store._delete_item(key)
-
-    #     for key in keys:
-    #         assert_equal(store._get_num_of_partitions(key), 0)

--- a/tests/serialize/runstate/dynamodb_state_store_test.py
+++ b/tests/serialize/runstate/dynamodb_state_store_test.py
@@ -76,11 +76,13 @@ class TestDynamoDBStateStore:
         ]
         store.save(key_value_pairs)
 
+        keys = [store.build_key("DynamoDBTest", "two"), store.build_key("DynamoDBTest2", "four")]
+        vals = store.restore(keys)
         for key, value in key_value_pairs:
-            assert_equal(store[key], value)
+            assert_equal(vals[key], value)
 
-        for key, value in key_value_pairs:
-            store._delete_item(key)
+        # for key, value in key_value_pairs:
+        #     store._delete_item(key)
 
     def test_save_more_than_4KB(self, store, small_object, large_object):
         key_value_pairs = [
@@ -91,11 +93,13 @@ class TestDynamoDBStateStore:
         ]
         store.save(key_value_pairs)
 
+        keys = [store.build_key("DynamoDBTest", "two")]
+        vals = store.restore(keys)
         for key, value in key_value_pairs:
-            assert_equal(store[key], value)
+            assert_equal(vals[key], value)
 
-        for key, value in key_value_pairs:
-            store._delete_item(key)
+        # for key, value in key_value_pairs:
+        #     store._delete_item(key)
 
     def test_restore_more_than_4KB(self, store, small_object, large_object):
         keys = [store.build_key("thing", i) for i in range(3)]
@@ -107,8 +111,8 @@ class TestDynamoDBStateStore:
         for key in keys:
             assert_equal(pickle.dumps(vals[key]), large_object)
 
-        for key in keys:
-            store._delete_item(key)
+        # for key in keys:
+        #     store._delete_item(key)
 
     def test_restore(self, store, small_object, large_object):
         keys = [store.build_key("thing", i) for i in range(3)]
@@ -120,17 +124,17 @@ class TestDynamoDBStateStore:
         for key in keys:
             assert_equal(pickle.dumps(vals[key]), small_object)
 
-        for key in keys:
-            store._delete_item(key)
+        # for key in keys:
+        #     store._delete_item(key)
 
-    def test_delete(self, store, small_object, large_object):
-        keys = [store.build_key("thing", i) for i in range(3)]
-        value = large_object
-        for key in keys:
-            store[key] = value
+    # def test_delete(self, store, small_object, large_object):
+    #     keys = [store.build_key("thing", i) for i in range(3)]
+    #     value = large_object
+    #     for key in keys:
+    #         store[key] = value
 
-        for key in keys:
-            store._delete_item(key)
+    #     for key in keys:
+    #         store._delete_item(key)
 
-        for key in keys:
-            assert_equal(store._get_num_of_partitions(key), 0)
+    #     for key in keys:
+    #         assert_equal(store._get_num_of_partitions(key), 0)

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -35,6 +35,7 @@ class DynamoDBStateStore(object):
             first_items = self._get_first_items(keys)
             remaining_items = self._get_remaining_items(first_items)
             items = self._merge_items(first_items, remaining_items)
+            #TODO: remove this after berkleyDB is removed.
             for key in keys:
                 if str(key) in items:
                     tranlated_items[key] = items[str(key)]

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -31,15 +31,15 @@ class DynamoDBStateStore(object):
         ret: <dict of key to states>
         """
         tranlated_items = {}
-        # try:
-        first_items = self._get_first_items(keys)
-        remaining_items = self._get_remaining_items(first_items)
-        items = self._merge_items(first_items, remaining_items)
-        for key in keys:
-            if str(key) in items:
-                tranlated_items[key] = items[str(key)]
-        # except Exception as e:
-        #     self.alert(str(e))
+        try:
+            first_items = self._get_first_items(keys)
+            remaining_items = self._get_remaining_items(first_items)
+            items = self._merge_items(first_items, remaining_items)
+            for key in keys:
+                if str(key) in items:
+                    tranlated_items[key] = items[str(key)]
+        except Exception as e:
+            self.alert(str(e))
         return tranlated_items
 
     def alert(self, msg: str):

--- a/tron/serialize/runstate/mirror_state_store.py
+++ b/tron/serialize/runstate/mirror_state_store.py
@@ -68,9 +68,9 @@ class MirrorStateStore():
 
         diffs = []
         if not self.is_valid(shelve_kv_pairs, dynamo_kv_pairs, diffs):
-            msg = 'Data in dynamoDB is not synced to BerkleyDB. This is not critical \
-                                          since only BerkleyDB is used to restore states right now'
-            msg.append('\n\n'.join(diffs))
+            msg = 'Data in dynamoDB is not synced to BerkleyDB. This is not critical' \
+                  + 'since only BerkleyDB is used to restore states right now'
+            msg += '\n\n'.join(diffs)
             self.dynamodb_store.alert(msg)
 
         return shelve_kv_pairs

--- a/tron/serialize/runstate/mirror_state_store.py
+++ b/tron/serialize/runstate/mirror_state_store.py
@@ -68,9 +68,9 @@ class MirrorStateStore():
 
         diffs = []
         if not self.is_valid(shelve_kv_pairs, dynamo_kv_pairs, diffs):
-            msg = 'Data in dynamoDB is not synced to BerkleyDB. This is not critical' \
-                  + 'since only BerkleyDB is used to restore states right now'
-            msg += '\n\n'.join(diffs)
+            msg = 'Data in dynamoDB is not synced to BerkleyDB. This is not critical \
+                                          since only BerkleyDB is used to restore states right now'
+            msg.append('\n\n'.join(diffs))
             self.dynamodb_store.alert(msg)
 
         return shelve_kv_pairs


### PR DESCRIPTION
1. Instead of reading num_partitions and then read contents one by one, it just fetch all partitions and read 100 at a time (limit of batch_get_item method).
Test done:
  Tested on mesosstage.