### PR TITLE
Workaround for trond segfaults

### DIFF
--- a/tests/serialize/filehandler_test.py
+++ b/tests/serialize/filehandler_test.py
@@ -80,7 +80,7 @@ class TestFileHandleWrapper(TestCase):
     def test_context_manager(self):
         with self.fh_wrapper as fh:
             fh.write("123")
-        assert fh._fh.closed
+        assert fh._fh is None
         with open(self.file.name) as fh:
             assert_equal(fh.read(), "123")
 


### PR DESCRIPTION
`trond` is rarely segfaulting at random moments when running under heavy
load with Python 3.6.0.  It seems that the crash is caused by
`task_processing.plugins.mesos.logging_executor` writes into a closed
filehandler inside `FileHandleWrapper`, triggering
https://bugs.python.org/issue31976.

The bug is fixed in Python 3.7.x, but since we cannot migrate from 3.6.x
at the moment, let's add a workaround by protesting all filehandler
operations by a lock, avoiding the bug as the result.