### PR TITLE
Log state changes

### DIFF
--- a/dev/config/MASTER.yaml
+++ b/dev/config/MASTER.yaml
@@ -1,5 +1,5 @@
 state_persistence:
-  name: "/tmp/tron_state"
+  name: "tron_state"
   table_name: "-tmp-tron_state"
   store_type: "dynamodb"
   buffer_size: 10

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -293,6 +293,10 @@ class ActionRun(Observable):
     def id(self):
         return f"{self.job_run_id}.{self.action_name}"
 
+    @property
+    def name(self):
+        return self.action_name
+
     @classmethod
     def from_state(
         cls,

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -23,11 +23,11 @@ log = logging.getLogger(__name__)
 state_logger = logging.getLogger(f'{__name__}.state_changes')
 
 
-def log_run_state(obj):
+def log_run_state(obj, state=None):
     data = {
         'id': str(obj.id),
         'type': str(obj.__class__.__name__),
-        'state': str(obj.state),
+        'state': state or str(obj.state),
         'timestamp': time.time(),
     }
     state_logger.info(json.dumps(data))
@@ -192,6 +192,7 @@ class JobRun(Observable, Observer):
 
     def start(self):
         """Start this JobRun as a scheduled run (not a manual run)."""
+        log_run_state(self, 'start')
         if self._do_start():
             return True
 

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -299,11 +299,13 @@ class JobRun(Observable, Observer):
     def log_state_update(self, state, action_name=None):
         if action_name is None:
             state = f'job_{state}'
+        else:
+            action_name = str(action_name)
 
         data = {
             'job_name': str(self.job_name),
             'run_num': str(self.run_num),
-            'action_name': str(action_name),
+            'action_name': action_name,
             'state': str(state),
             'timestamp': time.time(),
         }


### PR DESCRIPTION
Once we have this, we can set up a log handler to pull these into a separate log and ingest them wherever we want.

Some example lines:
```
{"id": "MASTER.testjob1.8.first", "type": "SSHActionRun", "state": "running", "timestamp": 1555533995.7740123}
{"id": "MASTER.testjob0.8.zeroth", "type": "SSHActionRun", "state": "unknown", "timestamp": 1555533996.7385292}
{"id": "MASTER.testjob0.8", "type": "JobRun", "state": "unknown", "timestamp": 1555533996.7392828}
```