### PR TITLE
"Remove" interval scheduler from documentation

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -31,7 +31,7 @@ Basic Example
     jobs:
       - name: "getting_node_info"
         node: local
-        schedule: "interval 10 mins"
+        schedule: "cron */10 * * * *"
         actions:
           - name: "uname"
             command: "uname -a"

--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -254,6 +254,7 @@ random time delta.
 Interval
 ^^^^^^^^
 .. deprecated:: 0.9.12.6
+   Use cron instead. This is deprecated because a job does not run as expected occasionaly.
 
 Run the job every X seconds, minutes, hours, or days. The time expression
 is ``<interval> days|hours|minutes|seconds``, where the units can be

--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -253,8 +253,8 @@ random time delta.
 
 Interval
 ^^^^^^^^
-.. deprecated:: 0.9.12.6
-   Use cron instead. This is deprecated because a job does not run as expected occasionaly.
+**removed since 0.9.12.6**
+    Use cron instead. This is removed because it does not schedule jobs as expected occasionaly.
 
 Run the job every X seconds, minutes, hours, or days. The time expression
 is ``<interval> days|hours|minutes|seconds``, where the units can be

--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -253,7 +253,7 @@ random time delta.
 
 Interval
 ^^^^^^^^
-.. deprecated:: 0.12.9.6
+.. deprecated:: 0.9.12.6
 
 Run the job every X seconds, minutes, hours, or days. The time expression
 is ``<interval> days|hours|minutes|seconds``, where the units can be

--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -251,32 +251,6 @@ support a jitter parameter that allows them to vary their runtime by a
 random time delta.
 
 
-Interval
-^^^^^^^^
-**removed since 0.9.12.6**
-    Use cron instead. This is removed because it does not schedule jobs as expected occasionaly.
-
-Run the job every X seconds, minutes, hours, or days. The time expression
-is ``<interval> days|hours|minutes|seconds``, where the units can be
-abbreviated.
-
-Short form::
-
-    schedule: "interval 20s"
-
-Long form::
-
-    schedule:
-        type:   "interval"
-        value:  "5 mins"
-        jitter: "10 seconds"        # Optional
-
-With alias::
-
-    schedule:
-        type:   "interval"
-        value:  "hourly"
-
 Daily
 ^^^^^
 

--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -253,6 +253,7 @@ random time delta.
 
 Interval
 ^^^^^^^^
+.. deprecated:: 0.12.9.6
 
 Run the job every X seconds, minutes, hours, or days. The time expression
 is ``<interval> days|hours|minutes|seconds``, where the units can be

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -45,13 +45,13 @@ each of which is responsible for a single job::
     jobs:
       - name: "job0"
         node: node1
-        schedule: "interval 20s"
+        schedule: "cron * * * * *"
         actions:
           - name: "batch1action"
             command: "sleep 3; echo asdfasdf"
       - name: "job1"
         node: node2
-        schedule: "interval 20s"
+        schedule: "cron * * * * *"
         actions:
           - name: "batch2action"
             command: "cat big.txt; sleep 10"
@@ -81,7 +81,7 @@ Nodes can be grouped into *pools*. To continue the previous example::
         # ...
         - name: "job2"
           node: pool
-          schedule: "interval 5s"
+          schedule: "cron * * * * *"
           actions:
             - name: "pool_action"
               command: "ls /; sleep 1"

--- a/docs/tron.yaml
+++ b/docs/tron.yaml
@@ -9,7 +9,7 @@ jobs:
     -
        name: "uptime_job"
        node: node0
-       schedule: "interval 10m"
+       schedule: "cron */10 * * * *"
        actions:
          - name: "uptimer"
            command: "uptime"

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -74,7 +74,7 @@ file. Edit your file to be something like this::
     jobs:
       - name: "getting_node_info"
         node: local
-        schedule: "interval 10 mins"
+        schedule: "cron */10 * * * *"
         actions:
           - name: "uname"
             command: "uname -a"


### PR DESCRIPTION
I marked interval scheduler as removed and change all examples using interval scheduler to use cron. I used version 0.9.12.6 which would be the version of the next release. 