### PR TITLE
reload old config if new config fails

### DIFF
--- a/tron/api/controller.py
+++ b/tron/api/controller.py
@@ -2,7 +2,6 @@
 Web Controllers for the API.
 """
 import logging
-from copy import copy
 
 from tron import yaml
 from tron.eventbus import EventBus
@@ -175,7 +174,7 @@ class ConfigController(object):
         if self.config_manager.get_hash(name) != config_hash:
             return "Configuration has changed. Please try again."
 
-        old_config = copy(self.read_config(name)['config'])
+        old_config = self.read_config(name)['config']
         try:
             self.config_manager.write_config(name, content)
             self.mcp.reconfigure()


### PR DESCRIPTION
tested on my devbox and on mesosstage

One thing I noticed is that if the config file in /nail/tron/config/whatever.yaml has a bad value, tron can't restart.  That's probably a different issue, but maybe something worth fixing?