### PR TITLE
Fixed guess_realert_every

### DIFF
--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1337,11 +1337,15 @@ class TestCheckJobs(TestCase):
                         'MASTER.test.2',
                     'state':
                         'failed',
-                    'start_time': None,
-                    'run_time':
+                    'start_time':
                         time.strftime(
                             '%Y-%m-%d %H:%M:%S',
                             time.localtime(time.time() - 600),
+                        ),
+                    'run_time':
+                        time.strftime(
+                            '%Y-%m-%d %H:%M:%S',
+                            time.localtime(time.time() - 200),
                         ),
                 },
                 {

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1328,7 +1328,7 @@ class TestCheckJobs(TestCase):
                 ),
             'runs': [
                 {
-                    'id': 'MASTER.test.3',
+                    'id': 'MASTER.test.1',
                     'state': 'scheduled',
                     'start_time': None,
                 },
@@ -1337,6 +1337,18 @@ class TestCheckJobs(TestCase):
                         'MASTER.test.2',
                     'state':
                         'failed',
+                    'start_time': None,
+                    'run_time':
+                        time.strftime(
+                            '%Y-%m-%d %H:%M:%S',
+                            time.localtime(time.time() - 200),
+                        ),
+                },
+                {
+                    'id':
+                        'MASTER.test.3',
+                    'state':
+                        'succeeded',
                     'start_time':
                         time.strftime(
                             '%Y-%m-%d %H:%M:%S',
@@ -1345,19 +1357,7 @@ class TestCheckJobs(TestCase):
                     'run_time':
                         time.strftime(
                             '%Y-%m-%d %H:%M:%S',
-                            time.localtime(time.time() - 100),
-                        ),
-                },
-                {
-                    'id':
-                        'MASTER.test.1',
-                    'state':
-                        'succeeded',
-                    'start_time': None,
-                    'run_time':
-                        time.strftime(
-                            '%Y-%m-%d %H:%M:%S',
-                            time.localtime(time.time() - 200),
+                            time.localtime(time.time() - 600),
                         ),
                 },
             ],  # noqa: E122

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1345,7 +1345,7 @@ class TestCheckJobs(TestCase):
                     'run_time':
                         time.strftime(
                             '%Y-%m-%d %H:%M:%S',
-                            time.localtime(time.time() - 200),
+                            time.localtime(time.time() - 100),
                         ),
                 },
                 {
@@ -1357,13 +1357,13 @@ class TestCheckJobs(TestCase):
                     'run_time':
                         time.strftime(
                             '%Y-%m-%d %H:%M:%S',
-                            time.localtime(time.time() - 1800),
+                            time.localtime(time.time() - 200),
                         ),
                 },
             ],  # noqa: E122
         }
         realert_every = check_tron_jobs.guess_realert_every(job_runs)
-        assert_equal(realert_every, 4)
+        assert_equal(realert_every, 2)
 
     def test_guess_realert_every_queue_job(self):
         job_runs = {

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1328,7 +1328,7 @@ class TestCheckJobs(TestCase):
                 ),
             'runs': [
                 {
-                    'id': 'MASTER.test.1',
+                    'id': 'MASTER.test.3',
                     'state': 'scheduled',
                     'start_time': None,
                 },
@@ -1346,7 +1346,7 @@ class TestCheckJobs(TestCase):
                 },
                 {
                     'id':
-                        'MASTER.test.3',
+                        'MASTER.test.1',
                     'state':
                         'succeeded',
                     'start_time':

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1326,41 +1326,15 @@ class TestCheckJobs(TestCase):
                     '%Y-%m-%d %H:%M:%S',
                     time.localtime(time.time() + 600),
                 ),
-            'runs': [
-                {
-                    'id': 'MASTER.test.3',
-                    'state': 'scheduled',
-                    'run_time': None,
-                    'start_time': None,
-                },
-                {
-                    'id':
-                        'MASTER.test.2',
-                    'state':
-                        'failed',
-                    'start_time': None,
-                    'run_time':
-                        time.strftime(
-                            '%Y-%m-%d %H:%M:%S',
-                            time.localtime(time.time() - 600),
-                        ),
-                },
-                {
-                    'id':
-                        'MASTER.test.1',
-                    'state':
-                        'succeeded',
-                    'start_time': None,
-                    'run_time':
-                        time.strftime(
-                            '%Y-%m-%d %H:%M:%S',
-                            time.localtime(time.time() - 1800),
-                        ),
-                },
-            ],  # noqa: E122
+            'run_time':
+                time.strftime(
+                    '%Y-%m-%d %H:%M:%S',
+                    time.localtime(time.time() + 600),
+                ),
+            'runs': [],  # noqa: E122
         }
         realert_every = check_tron_jobs.guess_realert_every(job_runs)
-        assert_equal(realert_every, 4)
+        assert_equal(realert_every, 1)
 
     def test_guess_realert_every_queue_job(self):
         job_runs = {

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1326,15 +1326,40 @@ class TestCheckJobs(TestCase):
                     '%Y-%m-%d %H:%M:%S',
                     time.localtime(time.time() + 600),
                 ),
-            'run_time':
-                time.strftime(
-                    '%Y-%m-%d %H:%M:%S',
-                    time.localtime(time.time() + 600),
-                ),
-            'runs': [],  # noqa: E122
+            'runs': [
+                {
+                    'id': 'MASTER.test.3',
+                    'state': 'scheduled',
+                    'start_time': None,
+                },
+                {
+                    'id':
+                        'MASTER.test.2',
+                    'state':
+                        'failed',
+                    'start_time': None,
+                    'run_time':
+                        time.strftime(
+                            '%Y-%m-%d %H:%M:%S',
+                            time.localtime(time.time() - 600),
+                        ),
+                },
+                {
+                    'id':
+                        'MASTER.test.1',
+                    'state':
+                        'succeeded',
+                    'start_time': None,
+                    'run_time':
+                        time.strftime(
+                            '%Y-%m-%d %H:%M:%S',
+                            time.localtime(time.time() - 1800),
+                        ),
+                },
+            ],  # noqa: E122
         }
         realert_every = check_tron_jobs.guess_realert_every(job_runs)
-        assert_equal(realert_every, 1)
+        assert_equal(realert_every, 4)
 
     def test_guess_realert_every_queue_job(self):
         job_runs = {

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1317,6 +1317,51 @@ class TestCheckJobs(TestCase):
         realert_every = check_tron_jobs.guess_realert_every(job_runs)
         assert_equal(realert_every, 4)
 
+    def test_guess_realert_every_no_action_run_starts(self):
+        job_runs = {
+            'status':
+                'running',
+            'next_run':
+                time.strftime(
+                    '%Y-%m-%d %H:%M:%S',
+                    time.localtime(time.time() + 600),
+                ),
+            'runs': [
+                {
+                    'id': 'MASTER.test.3',
+                    'state': 'scheduled',
+                    'run_time': None,
+                    'start_time': None,
+                },
+                {
+                    'id':
+                        'MASTER.test.2',
+                    'state':
+                        'failed',
+                    'start_time': None,
+                    'run_time':
+                        time.strftime(
+                            '%Y-%m-%d %H:%M:%S',
+                            time.localtime(time.time() - 600),
+                        ),
+                },
+                {
+                    'id':
+                        'MASTER.test.1',
+                    'state':
+                        'succeeded',
+                    'start_time': None,
+                    'run_time':
+                        time.strftime(
+                            '%Y-%m-%d %H:%M:%S',
+                            time.localtime(time.time() - 1800),
+                        ),
+                },
+            ],  # noqa: E122
+        }
+        realert_every = check_tron_jobs.guess_realert_every(job_runs)
+        assert_equal(realert_every, 4)
+
     def test_guess_realert_every_queue_job(self):
         job_runs = {
             'status':

--- a/tron/bin/check_tron_jobs.py
+++ b/tron/bin/check_tron_jobs.py
@@ -286,12 +286,8 @@ def guess_realert_every(job):
             return -1
         job_runs = job.get('runs', [])
         job_runs_started = [
-            run['start_time'] for run in job_runs if run['start_time'] is not None
+            run.get('start_time') or run.get('run_time') for run in job_runs if run.get('start_time') or run.get('run_time')
         ]
-        if len(job_runs_started) == 0:
-            job_runs_started = [
-                run.get('run_time', None) for run in job_runs if run.get('run_time', None) is not None
-            ]
         if len(job_runs_started) == 0:
             return -1
         job_previous_run = max(

--- a/tron/bin/check_tron_jobs.py
+++ b/tron/bin/check_tron_jobs.py
@@ -288,9 +288,9 @@ def guess_realert_every(job):
         job_runs_started = [
             run['start_time'] for run in job_runs if run['start_time'] is not None
         ]
-        if len(job_runs_started) == 0:
+        if len(job_runs_started) == 0 and job.get('run_time', None):
             job_runs_started = [
-                run['run_time'] for run in job_runs if run.get('run_time', None) is not None
+                job['run_time']
             ]
         if len(job_runs_started) == 0:
             return -1

--- a/tron/bin/check_tron_jobs.py
+++ b/tron/bin/check_tron_jobs.py
@@ -286,14 +286,17 @@ def guess_realert_every(job):
             return -1
         job_runs = job.get('runs', [])
         job_runs_started = [
-            run for run in job_runs if run['start_time'] is not None
+            run['start_time'] for run in job_runs if run['start_time'] is not None
         ]
+        if len(job_runs_started) == 0:
+            job_runs_started = [
+                run['run_time'] for run in job_runs if run.get('run_time', None) is not None
+            ]
         if len(job_runs_started) == 0:
             return -1
         job_previous_run = max(
-            job_runs_started,
-            key=lambda k: k['start_time'],
-        ).get('start_time')
+            job_runs_started
+        )
         time_diff = (
             time.mktime(_timestamp_to_timeobj(job_next_run)) -
             time.mktime(_timestamp_to_timeobj(job_previous_run))

--- a/tron/bin/check_tron_jobs.py
+++ b/tron/bin/check_tron_jobs.py
@@ -288,9 +288,9 @@ def guess_realert_every(job):
         job_runs_started = [
             run['start_time'] for run in job_runs if run['start_time'] is not None
         ]
-        if len(job_runs_started) == 0 and job.get('run_time', None):
+        if len(job_runs_started) == 0:
             job_runs_started = [
-                job['run_time']
+                run.get('run_time', None) for run in job_runs if run.get('run_time', None) is not None
             ]
         if len(job_runs_started) == 0:
             return -1


### PR DESCRIPTION
Tron does not realert as expected after Tron jobs fail when no run ever starts. Check TRON-1104 for detail.
I updated tron such that it checks run_time when no start_time exists. No start_time exists when the job never runs. run_time is the scheduled time of the job.