### PR TITLE
Return 200 if no code is passed and the response is not a dict

### DIFF
--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -44,8 +44,11 @@ class JSONEncoder(json.JSONEncoder):
 
 def respond(request, response, code=None, headers=None):
     """Helper to generate a json response"""
-    if code is None and type(response) is dict:
-        code = http.INTERNAL_SERVER_ERROR if response.get('error') else http.OK
+    if code is None:
+        if type(response) is dict and response.get('error'):
+            code = http.INTERNAL_SERVER_ERROR
+        else:
+            code = http.OK
     request.setResponseCode(code)
     request.setHeader(b'content-type', b'application/json; charset=utf-8')
     request.setHeader(b'Access-Control-Allow-Origin', b'*')


### PR DESCRIPTION
We were setting the code to `None` if the response was not a dict, causing this:
```
Apr 25 17:19:16 tron1-uswest1bprod tron: CRITICAL pid=20629 tid=140564817245952 twisted publishToNewObserver:154 
Traceback (most recent call last):
  File "/opt/venvs/tron/lib/python3.6/site-packages/twisted/python/threadpool.py", line 250, in inContext
    result = inContext.theWork()
  File "/opt/venvs/tron/lib/python3.6/site-packages/twisted/python/threadpool.py", line 266, in <lambda>
    inContext.theWork = lambda: context.call(ctx, func, *args, **kw)
  File "/opt/venvs/tron/lib/python3.6/site-packages/twisted/python/context.py", line 122, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/opt/venvs/tron/lib/python3.6/site-packages/twisted/python/context.py", line 85, in callWithContext
    return func(*args,**kw)
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/api/async_resource.py", line 34, in process
    result = fn(resource, request)
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/api/resource.py", line 255, in render_GET
    response=adapter.adapt_many(adapter.ActionRunAdapter, self.action_runs),
  File "/opt/venvs/tron/lib/python3.6/site-packages/tron/api/resource.py", line 49, in respond
    request.setResponseCode(code)
  File "/opt/venvs/tron/lib/python3.6/site-packages/twisted/web/http.py", line 1244, in setResponseCode
    raise TypeError("HTTP response code must be int or long")
TypeError: HTTP response code must be int or long
```