### PR TITLE
Prevent a connection error in the recovery action from failing the action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ example-cluster/_events/
 *.stderr
 dev/manhole.sock.lock
 dev/tron.pid
+dev/_events/
 
 # Generated debian artifacts
 debian/tron

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ cluster_itests:
 	tox -e cluster_itests
 
 dev:
-	.tox/py36/bin/trond --debug --working-dir=dev -l logging.conf --host=$(shell hostname -f)
+	SSH_AUTH_SOCK=$(SSH_AUTH_SOCK) .tox/py36/bin/trond --debug --working-dir=dev -l logging.conf --host=$(shell hostname -f)
 
 example_cluster:
 	tox -e example-cluster

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -54,6 +54,9 @@ def recover_action_run(action_run, action_runner):
     recovery_action_command.write_stdout(
         "recovering action run %s" % action_run.id,
     )
+    # Put action command in "running" state so if it fails to connect
+    # and exits with no exit code, the real action run will not retry.
+    recovery_action_command.started()
 
     # this line is where the magic happens.
     # the action run watches another actioncommand,

--- a/tron/node.py
+++ b/tron/node.py
@@ -607,9 +607,6 @@ class Node(object):
         if not self._is_run_id_tracked(run):
             log.warning("Run %s no longer tracked (_run_started)", run.id)
             return
-        assert self.run_states[run.id].state == RUN_STATE_STARTING
-        self.run_states[run.id].state = RUN_STATE_RUNNING
-
         run.started()
 
     def _run_start_error(self, result, run):


### PR DESCRIPTION
If the recovery action fails, then the state of the action should be unknown, not failed, because we don't know what happened to the real action command.

Internal ticket TRON-1116. 

This just affects the logic in the handler: https://github.com/Yelp/Tron/blob/a068fe84474cf2a51b72ad31b98c1df419ea6d98/tron/core/actionrun.py#L742
Before this change, if the recovery command failed to connect, the ActionCommand would emit the FAILSTART event, which Tron thinks is safe to retry because nothing has happened yet. After this change, if it fails to connect, it emits a EXITING event with `exit_status=None`, which triggers `fail_unknown` as desired.

I tested this manually:
1. let a run start
2. shut down Tron
3. edit the node config for localhost with a different user (e.g. `user: batch`) so SSH authentication would fail
4. restart Tron and let it start recovery

Before this change, the affected action would get failed and retry. After, it stays unknown.