### PR TITLE
Changed dynamodb partition index to int so it is sorted correctly

### DIFF
--- a/tests/serialize/runstate/dynamodb_state_store_test.py
+++ b/tests/serialize/runstate/dynamodb_state_store_test.py
@@ -58,7 +58,7 @@ def small_object():
 
 @pytest.fixture
 def large_object():
-    yield pickle.dumps([i for i in range(100000)])
+    yield pickle.dumps([i for i in range(1000000)])
 
 
 @pytest.mark.usefixtures("store", "small_object", "large_object")

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -100,7 +100,7 @@ class DynamoDBStateStore(object):
             key = item['key']['S']
             items[key].append(item)
         for key, item in items.items():
-            item.sort(key=lambda x: x['index']['N'])
+            item.sort(key=lambda x: int(x['index']['N']))
             for val in item:
                 raw_items[key] += bytes(val['val']['B'])
         deserialized_items = {k: pickle.loads(v) for k, v in raw_items.items()}


### PR DESCRIPTION
The index is sorted as str rather than int. So when there are more than 10 partitions, the data is merged in wrong order. 
I also updated test to cover this case.