### PR TITLE
fix guess_realert when next_run is the same as previous_run

### DIFF
--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1289,6 +1289,11 @@ class TestCheckJobs(TestCase):
                     'id': 'MASTER.test.3',
                     'state': 'scheduled',
                     'start_time': None,
+                    'run_time':
+                        time.strftime(
+                            '%Y-%m-%d %H:%M:%S',
+                            time.localtime(time.time() + 600),
+                        ),
                 },
                 {
                     'id':
@@ -1310,44 +1315,6 @@ class TestCheckJobs(TestCase):
                         time.strftime(
                             '%Y-%m-%d %H:%M:%S',
                             time.localtime(time.time() - 1800),
-                        ),
-                },
-            ],  # noqa: E122
-        }
-        realert_every = check_tron_jobs.guess_realert_every(job_runs)
-        assert_equal(realert_every, 4)
-
-    def test_guess_realert_every_same_next_run_and_prev_run_time(self):
-        job_runs = {
-            'status':
-                'running',
-            'next_run':
-                time.strftime(
-                    '%Y-%m-%d %H:%M:%S',
-                    time.localtime(time.time() + 600),
-                ),
-            'runs': [
-                {
-                    'id':
-                        'MASTER.test.2',
-                    'state':
-                        'failed',
-                    'start_time': None,
-                    'run_time':
-                        time.strftime(
-                            '%Y-%m-%d %H:%M:%S',
-                            time.localtime(time.time() + 600),
-                        ),
-                },
-                {
-                    'id':
-                        'MASTER.test.1',
-                    'state':
-                        'succeeded',
-                    'start_time':
-                        time.strftime(
-                            '%Y-%m-%d %H:%M:%S',
-                            time.localtime(time.time() - 600),
                         ),
                 },
             ],  # noqa: E122

--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1317,6 +1317,44 @@ class TestCheckJobs(TestCase):
         realert_every = check_tron_jobs.guess_realert_every(job_runs)
         assert_equal(realert_every, 4)
 
+    def test_guess_realert_every_same_next_run_and_prev_run_time(self):
+        job_runs = {
+            'status':
+                'running',
+            'next_run':
+                time.strftime(
+                    '%Y-%m-%d %H:%M:%S',
+                    time.localtime(time.time() + 600),
+                ),
+            'runs': [
+                {
+                    'id':
+                        'MASTER.test.2',
+                    'state':
+                        'failed',
+                    'start_time': None,
+                    'run_time':
+                        time.strftime(
+                            '%Y-%m-%d %H:%M:%S',
+                            time.localtime(time.time() + 600),
+                        ),
+                },
+                {
+                    'id':
+                        'MASTER.test.1',
+                    'state':
+                        'succeeded',
+                    'start_time':
+                        time.strftime(
+                            '%Y-%m-%d %H:%M:%S',
+                            time.localtime(time.time() - 600),
+                        ),
+                },
+            ],  # noqa: E122
+        }
+        realert_every = check_tron_jobs.guess_realert_every(job_runs)
+        assert_equal(realert_every, 4)
+
     def test_guess_realert_every_no_action_run_starts(self):
         job_runs = {
             'status':

--- a/tron/bin/check_tron_jobs.py
+++ b/tron/bin/check_tron_jobs.py
@@ -286,9 +286,8 @@ def guess_realert_every(job):
             return -1
         job_runs = job.get('runs', [])
         job_runs_started = [
-            run.get('start_time') or run.get('run_time') for run in job_runs if run.get('start_time') 
-            or run.get('run_time') 
-            and run.get('run_time') != job_next_run
+            run.get('start_time') or run.get('run_time') for run in job_runs
+            if run.get('start_time') or run.get('run_time') and run.get('run_time') != job_next_run
         ]
         if len(job_runs_started) == 0:
             return -1

--- a/tron/bin/check_tron_jobs.py
+++ b/tron/bin/check_tron_jobs.py
@@ -286,7 +286,7 @@ def guess_realert_every(job):
             return -1
         job_runs = job.get('runs', [])
         job_runs_started = [
-            run.get('start_time') or run.get('run_time') for run in job_runs if run.get('start_time') or run.get('run_time')
+            run.get('start_time') or run.get('run_time') for run in job_runs if run.get('start_time') or run.get('run_time') and run.get('run_time') != job_next_run
         ]
         if len(job_runs_started) == 0:
             return -1

--- a/tron/bin/check_tron_jobs.py
+++ b/tron/bin/check_tron_jobs.py
@@ -286,7 +286,9 @@ def guess_realert_every(job):
             return -1
         job_runs = job.get('runs', [])
         job_runs_started = [
-            run.get('start_time') or run.get('run_time') for run in job_runs if run.get('start_time') or run.get('run_time') and run.get('run_time') != job_next_run
+            run.get('start_time') or run.get('run_time') for run in job_runs if run.get('start_time') 
+            or run.get('run_time') 
+            and run.get('run_time') != job_next_run
         ]
         if len(job_runs_started) == 0:
             return -1


### PR DESCRIPTION
I tested with real data as well but didn't use it here since that is too long. 
The bug happens when run_time is the same as next_run, 1 is returned. 