### PR TITLE
Place the bash completion script in the completion dir

### DIFF
--- a/debian/tron.links
+++ b/debian/tron.links
@@ -4,4 +4,4 @@ opt/venvs/tron/bin/trond usr/bin/trond
 opt/venvs/tron/bin/tronfig usr/bin/tronfig
 opt/venvs/tron/bin/tronview usr/bin/tronview
 opt/venvs/tron/bin/generate_tron_tab_completion_cache usr/bin/generate_tron_tab_completion_cache
-opt/venvs/tron/bin/tron_tabcomplete.sh usr/share/bash-completion/completions/tron.bash
+opt/venvs/tron/bin/tron_tabcomplete.sh usr/share/bash-completion/completions/tron

--- a/debian/tron.links
+++ b/debian/tron.links
@@ -4,4 +4,4 @@ opt/venvs/tron/bin/trond usr/bin/trond
 opt/venvs/tron/bin/tronfig usr/bin/tronfig
 opt/venvs/tron/bin/tronview usr/bin/tronview
 opt/venvs/tron/bin/generate_tron_tab_completion_cache usr/bin/generate_tron_tab_completion_cache
-opt/venvs/tron/bin/tron_tabcomplete.sh etc/bash_completion.d/tron.bash
+opt/venvs/tron/bin/tron_tabcomplete.sh usr/share/bash-completion/completions/tron.bash


### PR DESCRIPTION
Stop using the compatibility dir and use the standard completion dir, introduced in bash-completion 2.x. Completion scripts in there are lazily loaded, which defers the ~180ms cost of invoking the completion registration.