### PR TITLE
Split the tab completion file

### DIFF
--- a/bin/tronctl_tabcomplete.sh
+++ b/bin/tronctl_tabcomplete.sh
@@ -4,5 +4,4 @@ fi
 
 # This magic eval enables tab-completion for tron commands
 # http://argcomplete.readthedocs.io/en/latest/index.html#synopsis
-eval "$(/opt/venvs/tron/bin/register-python-argcomplete tronview)"
 eval "$(/opt/venvs/tron/bin/register-python-argcomplete tronctl)"

--- a/bin/tronview_tabcomplete.sh
+++ b/bin/tronview_tabcomplete.sh
@@ -1,0 +1,7 @@
+if [[ -n ${ZSH_VERSION-} ]]; then
+	autoload -U +X bashcompinit && bashcompinit
+fi
+
+# This magic eval enables tab-completion for tron commands
+# http://argcomplete.readthedocs.io/en/latest/index.html#synopsis
+eval "$(/opt/venvs/tron/bin/register-python-argcomplete tronview)"

--- a/debian/tron.links
+++ b/debian/tron.links
@@ -4,4 +4,5 @@ opt/venvs/tron/bin/trond usr/bin/trond
 opt/venvs/tron/bin/tronfig usr/bin/tronfig
 opt/venvs/tron/bin/tronview usr/bin/tronview
 opt/venvs/tron/bin/generate_tron_tab_completion_cache usr/bin/generate_tron_tab_completion_cache
-opt/venvs/tron/bin/tron_tabcomplete.sh usr/share/bash-completion/completions/tron
+opt/venvs/tron/bin/tronctl_tabcomplete.sh usr/share/bash-completion/completions/tronctl
+opt/venvs/tron/bin/tronview_tabcomplete.sh usr/share/bash-completion/completions/tronview


### PR DESCRIPTION
bash-completion lazy loading loads the completion based on the executable name, so the name of the completion file needs to match. https://github.com/scop/bash-completion/blob/master/README.md