### PR TITLE
Build for bionic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,12 +39,13 @@ dev/tron.pid
 dev/_events/
 
 # Generated debian artifacts
-debian/tron
-debian/tron.preinst.debhelper
+debian/.debhelper/
+debian/debhelper-build-stamp
 debian/files
-debian/tron.substvars
+debian/tron
 debian/tron.debhelper.log
 debian/tron.postinst.debhelper
 debian/tron.postrm.debhelper
+debian/tron.preinst.debhelper
 debian/tron.prerm.debhelper
-debian/debhelper-build-stamp
+debian/tron.substvars

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@
 language: python
 env:
   - TARGET=tox_py36
-  - TARGET=debitest_xenial
   - TARGET=debitest_trusty
+  - TARGET=debitest_xenial
+  - TARGET=debitest_bionic
   - TARGET=cluster_itests
 python:
   - 3.6

--- a/yelp_package/bionic/Dockerfile
+++ b/yelp_package/bionic/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:bionic
+
+RUN apt-get -q update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -q install -y --no-install-recommends \
+        coffeescript \
+        debhelper \
+        devscripts \
+        dpkg-dev \
+        gcc \
+        gdebi-core \
+        git \
+        help2man \
+        libffi-dev \
+        libgpgme11 \
+        libssl-dev \
+        libdb5.3-dev \
+        libyaml-dev \
+        libssl-dev \
+        libffi-dev \
+        python3.6-dev \
+        python-pip \
+        python-tox \
+        wget \
+    && apt-get -q clean
+
+RUN cd /tmp && \
+    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
+    gdebi -n dh-virtualenv*.deb && \
+    rm dh-virtualenv_*.deb
+
+WORKDIR /work

--- a/yelp_package/bionic/Dockerfile
+++ b/yelp_package/bionic/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get -q update && \
         coffeescript \
         debhelper \
         devscripts \
+        dh-virtualenv \
         dpkg-dev \
         gcc \
         gdebi-core \
@@ -22,10 +23,5 @@ RUN apt-get -q update && \
         python-tox \
         wget \
     && apt-get -q clean
-
-RUN cd /tmp && \
-    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
-    gdebi -n dh-virtualenv*.deb && \
-    rm dh-virtualenv_*.deb
 
 WORKDIR /work


### PR DESCRIPTION
- Added `debian/.debhelper/` to `.gitignore` (and sorted the things under `debian/` for good measure)
- Start building for bionic (same `Dockerfile` as for xenial, but I removed the deadsnakes stuff since [bionic ships with python 3.6](https://packages.ubuntu.com/bionic/python3.6) and also removed the dh-virtualenv wget installation since [bionic ships with the same version, 1.0-1](https://packages.ubuntu.com/bionic/dh-virtualenv))

Testing:
- Ran `make itest_bionic` and it passed successfully

Is there anything else I should update? I didn't touch some of the stuff like [this](https://github.com/Yelp/Tron/blob/ba6eee0094101e0a8b26dd6e66f5ca6ccb0ca3f7/Makefile#L67-L78) since it doesn't really affect building an actual tron bionic package.