### PR TITLE
Prevent job runs from incorrectly getting stuck in WAITING

### DIFF
--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -329,7 +329,7 @@ class JobRun(Observable, Observer):
             return ActionRun.STARTING
         if self.action_runs.is_failed:
             return ActionRun.FAILED
-        if self.action_runs.is_waiting:
+        if self.action_runs.is_blocked_on_trigger:
             return ActionRun.WAITING
         if self.action_runs.is_scheduled:
             return ActionRun.SCHEDULED


### PR DESCRIPTION
If any run in a job is WAITING, the next job run will get queued (if allow_overlap is False, the default) because a WAITING run still counts as active. If there are actions waiting for a trigger, that's legitimate - the run really isn't done yet, and we shouldn't start the next one. But there have been two cases recently where the next run **doesn't** start as expected because a previous run is unexpectedly waiting, which I'm trying to fix in this PR. 

My solution is to say the overall run is WAITING only if an action is blocked on a trigger. It shouldn't have waiting actions that aren't blocked on triggers unless something has gone wrong, because we try to start unblocked actions as soon as they become unblocked.

1) One action A, required by B, goes unknown. No other actions in the job have failed. The job run should be in a terminal state (UNKNOWN) instead of WAITING. `TestJobRunStateTransitions. test_required_action_unknown` covers this. People expect the behavior to basically be the same as `test_required_action_fails`.

2) action A used to depend on B. B fails, and the run is failed because A is blocked. Later the config changes so that A doesn't depend on B. That only reconfigures new runs, so the old run is failed as expected until Tron restarts... When Tron restarts, it re-constructs the action_graph for every action run from the latest config, so it appears that A is *not* blocked. The old run no longer satisfies https://github.com/Yelp/Tron/blob/56d94c17eb1e8289015e70e5725d038aba9a9e60/tron/core/actionrun.py#L1017-L1019 so it becomes WAITING instead of FAILED. Now it will be UNKNOWN because it doesn't fit the criteria for the WAITING state anymore. That's the last part of `test_required_action_fails`.

This solution isn't ideal for case #2 - it should really stay FAILED instead of changing to UNKNOWN after restart. But it's the same behavior as *before* I added the WAITING state, so calling this good enough for now. I thought about this for a while and I think the only real way to achieve the ideal solution is to save the action graph for every action... which we can do in a separate PR if we want to.

The interaction between job run / action run / action command state transitions is complicated enough that I decided to add a bunch of tests asserting what state we expect the job run to be in other situations, too.