### PR TITLE
Runs with triggers should start in scheduled state

### DIFF
--- a/tests/core/jobrun_test.py
+++ b/tests/core/jobrun_test.py
@@ -786,6 +786,8 @@ class TestJobRunStateTransitions:
         after_foo = job_run.get_action_run('after_foo')
         bar = job_run.get_action_run('bar')
 
+        assert job_run.state == actionrun.ActionRun.SCHEDULED
+
         # bar action becomes unknown, job is RUNNING because foo is still running
         job_run.start()
         foo.action_command.started()
@@ -830,6 +832,8 @@ class TestJobRunStateTransitions:
         foo = job_run.get_action_run('foo')
         after_foo = job_run.get_action_run('after_foo')
         bar = job_run.get_action_run('bar')
+
+        assert job_run.state == actionrun.ActionRun.SCHEDULED
 
         # An action (foo) required by another action fails
         # Run is RUNNING while the other action, bar, is running
@@ -883,8 +887,11 @@ class TestJobRunStateTransitions:
         bar = job_run.get_action_run('bar')
 
         # Start without trigger for bar
-        # Only foo is able to start
         mock_event_bus.has_event.return_value = False
+        # Job should still start in scheduled state
+        assert job_run.state == actionrun.ActionRun.SCHEDULED
+
+        # Only foo is able to start
         job_run.start()
         assert foo.is_starting
         assert bar.is_waiting
@@ -920,6 +927,7 @@ class TestJobRunStateTransitions:
         assert job_run.state == actionrun.ActionRun.STARTING
 
     def test_cancel_one(self, job_run):
+        assert job_run.state == actionrun.ActionRun.SCHEDULED
         job_run.start()
         assert job_run.state == actionrun.ActionRun.STARTING
         job_run.get_action_run('after_foo').cancel()

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -329,7 +329,7 @@ class JobRun(Observable, Observer):
             return ActionRun.STARTING
         if self.action_runs.is_failed:
             return ActionRun.FAILED
-        if self.action_runs.is_blocked_on_trigger:
+        if self.action_runs.is_waiting and self.action_runs.is_blocked_on_trigger:
             return ActionRun.WAITING
         if self.action_runs.is_scheduled:
             return ActionRun.SCHEDULED


### PR DESCRIPTION
If a job isn't in a scheduled state when Tron tries to start it in the the job scheduler, it won't start: https://github.com/Yelp/Tron/blob/master/tron/core/job_scheduler.py#L130

Added some assertions about the scheduled state. test_with_trigger fails before the fix, passes after.

