### PR TITLE
Improve logging for deferred errors and apply timeout config to trans…

### DIFF
--- a/tron/node.py
+++ b/tron/node.py
@@ -409,9 +409,10 @@ class Node(object):
 
         def connect_fail(result):
             log.warning(
-                "Cannot run %s, Failed to connect to %s",
+                "Cannot run %s, Failed to connect to %s: %s",
                 run,
                 self.hostname,
+                repr(result)
             )
             self.connection_defer = None
             self._fail_run(
@@ -491,6 +492,7 @@ class Node(object):
         create_defer = client_creator.connectTCP(
             self.hostname,
             self.config.port,
+            timeout=self.node_settings.connect_timeout,
         )
 
         # We're going to create a deferred, returned to the caller, that will
@@ -597,7 +599,7 @@ class Node(object):
 
         We don't actually know if the run succeeded
         """
-        log.error("Failure waiting on channel completion: %s", str(result))
+        log.error("Failure waiting on channel completion: %s", repr(result))
         self._fail_run(run, failure.Failure(exc_value=ResultError()))
 
     def _run_started(self, channel, run):
@@ -618,7 +620,7 @@ class Node(object):
             "Error running %s, disconnecting from %s: %s",
             run.id,
             self.hostname,
-            str(result),
+            repr(result),
         )
 
         # We clear out the deferred that likely called us because there are


### PR DESCRIPTION
…port creation

Once you add the logging for `connect_fail`, the logs show the ConnectErrors are caused by a CancelledError: `connect_fail:417 <twisted.python.failure.Failure twisted.internet.defer.CancelledError: >` That means we're running into this timeout: https://github.com/Yelp/Tron/blob/c574401c741fa26dfae2bdd34701eafa2bd31ace/tron/node.py#L502-L505

After I increased the timeout in tronfig, I got ConnectErrors again, but with `<twisted.python.failure.Failure twisted.internet.error.TimeoutError: User timeout caused connection failure.>` Turns out connectTCP has its own timeout, default 30 seconds. 

Finally, after applying the longer timeout to connectTCP, the ssh connections were successfully created after about 3 minutes.