### PR TITLE
Use last run time to get next run time before scheduling

### DIFF
--- a/tron/core/job_scheduler.py
+++ b/tron/core/job_scheduler.py
@@ -93,7 +93,8 @@ class JobScheduler(Observer):
             return
         last_run = self.job.runs.get_newest(include_manual=False)
         last_run_time = last_run.run_time if last_run else None
-        self.create_and_schedule_runs(next_run_time=last_run_time)
+        next_run_time = self.job.scheduler.next_run_time(last_run_time)
+        self.create_and_schedule_runs(next_run_time=next_run_time)
 
     def update_from_job_scheduler(self, job_scheduler):
         """ Update a job scheduler by copying another. """


### PR DESCRIPTION
Regression introduced here: https://github.com/Yelp/Tron/pull/674/commits/dedb5a93ded5fd232f9bf216be2e37ff6d076968#diff-c5160fb364ea48a71d54f9eec62ff1a0L195

There were some noop "assertions" in the tests, fixed them to be real assertions.

