### PR TITLE
Determine that runner is not running anymore if pid is none for recover_batch

### DIFF
--- a/tests/bin/recover_batch_test.py
+++ b/tests/bin/recover_batch_test.py
@@ -56,7 +56,7 @@ def test_run_not_running():
     assert exc_info.value.code == 1
 
 
-@mock.patch.object(recover_batch, 'get_key_from_last_line', mock.Mock(side_effect=[None, None]))
+@mock.patch.object(recover_batch, 'get_key_from_last_line', mock.Mock(side_effect=[None, 0]))
 @mock.patch('psutil.pid_exists', mock.Mock(return_value=True), autospec=None)
 @mock.patch.object(recover_batch, 'Queue', autospec=True)
 @mock.patch.object(recover_batch, 'StatusFileWatcher', mock.Mock())

--- a/tron/bin/recover_batch.py
+++ b/tron/bin/recover_batch.py
@@ -56,7 +56,7 @@ def notify(notify_queue, ignored, filepath, mask):
             else:
                 exit_code = return_code
 
-        elif not psutil.pid_exists(pid):
+        elif pid is None or not psutil.pid_exists(pid):
             exit_code = 1
             error_msg = (
                 f'Action runner pid {pid} no longer running; '
@@ -83,7 +83,7 @@ def run(fpath):
         sys.exit(existing_return_code)
 
     runner_pid = get_key_from_last_line(fpath, 'runner_pid')
-    if not psutil.pid_exists(runner_pid):
+    if runner_pid is None or not psutil.pid_exists(runner_pid):
         log.warning(
             f"Action runner pid {runner_pid} no longer running; "
             "unable to recover it"


### PR DESCRIPTION
### Description
There seems to be a race condition in which the pid can become None before the recover_batch process can read it, causing this traceback:
`['Traceback (most recent call last):', '  File "/opt/venvs/tron/bin/recover_batch.py", line 108, in <module>', '    run(args.filepath)', '  File "/opt/venvs/tron/bin/recover_batch.py", line 86, in run', '    if not psutil.pid_exists(runner_pid):', '  File "/opt/venvs/tron/lib/python3.6/site-packages/psutil/__init__.py", line 1502, in pid_exists', '    if pid < 0:', "TypeError: '<' not supported between instances of 'NoneType' and 'int'"]`

I am adding a check that the pid cannot be None. If it is, we assume the runner was terminated.

### Testing
make test
