### PR TITLE
Use starting update from Mesos

### DIFF
--- a/tests/mesos_test.py
+++ b/tests/mesos_test.py
@@ -136,7 +136,7 @@ class TestMesosTask(TestCase):
             platform_type='starting',
         )
         self.task.handle_event(event)
-        assert self.task.state == MesosTask.PENDING
+        assert self.task.state == MesosTask.RUNNING
 
     def test_handle_running(self):
         event = mock_task_event(
@@ -232,6 +232,12 @@ class TestMesosTask(TestCase):
             mock_task_event(
                 task_id=self.task_id,
                 platform_type='staging',
+            )
+        )
+        self.task.handle_event(
+            mock_task_event(
+                task_id=self.task_id,
+                platform_type='starting',
             )
         )
         self.task.handle_event(

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -234,7 +234,7 @@ class MesosTask(ActionCommand):
         if mesos_type == 'staging':
             pass
         elif mesos_type == 'starting':
-            pass
+            self.started()
         elif mesos_type == 'running':
             self.started()
         elif mesos_type == 'finished':


### PR DESCRIPTION
TRON-1185: some actions were finishing successfully with TASK_FINISHED but end up in the "failed" state because we missed the starting update.

Still don't know why we are sometimes missing the starting update, but it doesn't hurt to call `self.starting()` twice (once for STARTING, once for RUNNING).

