### PR TITLE
Removed the constant scheduler

### DIFF
--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -106,7 +106,6 @@ Optional Fields
     add the next run to a queue if this is **True**. Otherwise, cancel
     the job run. Note that if the scheduler used for this job is
     not defined to queue overlapping then this setting is ignored.
-    The ConstantScheduler will not queue overlapping.
 
 **allow_overlap** (default **False**)
     If **True** new job runs will start even if the previous run is still running.

--- a/tests/command_context_test.py
+++ b/tests/command_context_test.py
@@ -135,7 +135,7 @@ class TestJobContext(TestCase):
     @setup
     def setup_job(self):
         self.last_success = mock.Mock(run_time=datetime.datetime(2012, 3, 14))
-        mock_scheduler = mock.create_autospec(scheduler.ConstantScheduler)
+        mock_scheduler = mock.create_autospec(scheduler.GeneralScheduler)
         run_collection = mock.create_autospec(
             JobRunCollection,
             last_success=self.last_success,

--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -31,7 +31,7 @@ from tron.config.config_parse import valid_node_pool
 from tron.config.config_parse import valid_output_stream_dir
 from tron.config.config_parse import validate_fragment
 from tron.config.config_utils import NullConfigContext
-from tron.config.schedule_parse import ConfigConstantScheduler
+from tron.config.schedule_parse import ConfigDailyScheduler
 from tron.config.schema import MASTER_NAMESPACE
 
 BASE_CONFIG = dict(
@@ -56,6 +56,17 @@ def make_ssh_options():
         jitter_min_load=4,
         jitter_max_delay=20,
         jitter_load_factor=1,
+    )
+
+
+def make_mock_schedule():
+    return ConfigDailyScheduler(
+        days=set(),
+        hour=0,
+        minute=0,
+        second=0,
+        original="00:00:00 ",
+        jitter=None,
     )
 
 
@@ -160,7 +171,7 @@ def make_master_jobs():
         'MASTER.test_job0':
             make_job(
                 name='MASTER.test_job0',
-                schedule=ConfigConstantScheduler(),
+                schedule=make_mock_schedule(),
                 expected_runtime=datetime.timedelta(1)
             ),
         'MASTER.test_job1':
@@ -210,7 +221,7 @@ def make_master_jobs():
             make_job(
                 name='MASTER.test_job_actions_dict',
                 node='node1',
-                schedule=ConfigConstantScheduler(),
+                schedule=make_mock_schedule(),
                 actions={
                     'action':
                         make_action(),
@@ -310,7 +321,7 @@ class ConfigTestCase(TestCase):
             dict(
                 name="test_job0",
                 node='node0',
-                schedule="constant",
+                schedule="daily 00:00:00",
                 actions=[dict(name="action", command="command")],
                 cleanup_action=dict(command="command"),
             ),
@@ -345,7 +356,7 @@ class ConfigTestCase(TestCase):
             dict(
                 name="test_job_actions_dict",
                 node='node1',
-                schedule="constant",
+                schedule="daily 00:00:00 ",
                 actions=dict(
                     action=dict(command="command"),
                     action1=dict(command="command"),
@@ -426,7 +437,7 @@ class TestNamedConfig(TestCase):
                     make_job(
                         name="test_job",
                         namespace='test_namespace',
-                        schedule=ConfigConstantScheduler(),
+                        schedule=make_mock_schedule(),
                         expected_runtime=datetime.timedelta(1),
                     )
             }
@@ -439,7 +450,7 @@ class TestNamedConfig(TestCase):
                         name="test_job",
                         namespace='test_namespace',
                         node="node0",
-                        schedule="constant",
+                        schedule="daily 00:00:00 ",
                         actions=[dict(name="action", command="command")],
                         cleanup_action=dict(command="command"),
                     )
@@ -455,7 +466,7 @@ class TestNamedConfig(TestCase):
                     make_job(
                         name="test_namespace.test_job",
                         namespace="test_namespace",
-                        schedule=ConfigConstantScheduler(),
+                        schedule=make_mock_schedule(),
                         expected_runtime=datetime.timedelta(1),
                     )
             }
@@ -478,7 +489,7 @@ class TestNamedConfig(TestCase):
                         name="test_job",
                         namespace='test_namespace',
                         node="node0",
-                        schedule="constant",
+                        schedule="daily 00:00:00",
                         actions=[dict(name="action", command="command")],
                         cleanup_action=dict(command="command"),
                     )
@@ -501,7 +512,7 @@ class TestNamedConfig(TestCase):
                     name="test_job",
                     namespace='test_namespace',
                     node="node1",
-                    schedule="constant",
+                    schedule="daily 00:30:00 ",
                     actions=[dict(name="action", command="command")],
                     cleanup_action=dict(command="command"),
                 )
@@ -534,7 +545,7 @@ class TestNamedConfig(TestCase):
                     name="test_job",
                     namespace='test_namespace',
                     node="node0",
-                    schedule="constant",
+                    schedule="daily 00:30:00 ",
                     actions=
                     [dict(name="action", node="nodepool1", command="command")],
                     cleanup_action=dict(command="command"),
@@ -557,7 +568,7 @@ class TestJobConfig(TestCase):
     def test_no_actions(self):
         test_config = dict(
             jobs=[
-                dict(name='test_job0', node='node0', schedule='constant')
+                dict(name='test_job0', node='node0', schedule='daily 00:30:00 ')
             ],
             **BASE_CONFIG
         )
@@ -576,7 +587,7 @@ class TestJobConfig(TestCase):
                 dict(
                     name='test_job0',
                     node='node0',
-                    schedule='constant',
+                    schedule='daily 00:30:00 ',
                     actions=None
                 )
             ],
@@ -597,7 +608,7 @@ class TestJobConfig(TestCase):
                 dict(
                     name='test_job0',
                     node='node0',
-                    schedule='constant',
+                    schedule='daily 00:30:00',
                     actions=[
                         dict(name='action', command='cmd'),
                         dict(name='action', command='cmd'),
@@ -621,13 +632,13 @@ class TestJobConfig(TestCase):
                 dict(
                     name='test_job0',
                     node='node0',
-                    schedule='constant',
+                    schedule='daily 00:30:00',
                     actions=[dict(name='action', command='cmd')]
                 ),
                 dict(
                     name='test_job1',
                     node='node0',
-                    schedule='constant',
+                    schedule='daily 00:30:00',
                     actions=[
                         dict(
                             name='action1', command='cmd', requires=['action']
@@ -655,7 +666,7 @@ class TestJobConfig(TestCase):
                 dict(
                     name='test_job0',
                     node='node0',
-                    schedule='constant',
+                    schedule='daily 00:30:00',
                     actions=[
                         dict(
                             name='action1',
@@ -687,7 +698,7 @@ class TestJobConfig(TestCase):
                 dict(
                     name='test_job0',
                     node='node0',
-                    schedule='constant',
+                    schedule='daily 00:30:00',
                     actions=[
                         dict(name=CLEANUP_ACTION_NAME, command='cmd'),
                     ]
@@ -709,7 +720,7 @@ class TestJobConfig(TestCase):
                 dict(
                     name='test_job0',
                     node='node0',
-                    schedule='constant',
+                    schedule='daily 00:30:00',
                     actions=[
                         dict(name='action', command='cmd'),
                     ],
@@ -733,7 +744,7 @@ class TestJobConfig(TestCase):
                 dict(
                     name='test_job0',
                     node='node0',
-                    schedule='constant',
+                    schedule='daily 00:30:00',
                     actions=[
                         dict(name='action', command='cmd'),
                     ],
@@ -755,7 +766,7 @@ class TestJobConfig(TestCase):
         job_config = dict(
             name="job_name",
             node="localhost",
-            schedule="constant",
+            schedule="daily 00:30:00",
             actions=[],
         )
         config_context = config_utils.ConfigContext(
@@ -801,7 +812,7 @@ class TestNodeConfig(TestCase):
                 dict(
                     name='test_job0',
                     node='unknown_node',
-                    schedule='constant',
+                    schedule='daily 00:30:00',
                     actions=[dict(name='action', command='cmd')]
                 )
             ],
@@ -830,7 +841,7 @@ class TestNodeConfig(TestCase):
                 dict(
                     name='test_job0',
                     node='pool1',
-                    schedule='constant',
+                    schedule='daily 00:30:00',
                     actions=[dict(name='action', command='cmd')]
                 )
             ]
@@ -858,7 +869,7 @@ class TestNodeConfig(TestCase):
                 dict(
                     name='test_job0',
                     node='pool1',
-                    schedule='constant',
+                    schedule='daily 00:30:00',
                     actions=[dict(name='action', command='cmd')]
                 )
             ]
@@ -891,7 +902,7 @@ class TestValidateJobs(TestCase):
                 dict(
                     name="test_job0",
                     node='node0',
-                    schedule='constant',
+                    schedule='daily',
                     expected_runtime="20m",
                     actions=[
                         dict(
@@ -944,7 +955,7 @@ class TestValidateJobs(TestCase):
             'MASTER.test_job0':
                 make_job(
                     name='MASTER.test_job0',
-                    schedule=ConfigConstantScheduler(),
+                    schedule=make_mock_schedule(),
                     actions={
                         'action':
                             make_action(

--- a/tests/config/schedule_parse_test.py
+++ b/tests/config/schedule_parse_test.py
@@ -53,12 +53,6 @@ class TestScheduleConfigFromString(TestCase):
         )
         mock_parse_groc.assert_called_with(generic_config, context)
 
-    def test_constant_config(self):
-        schedule = 'constant'
-        context = config_utils.NullConfigContext
-        config = schedule_parse.schedule_config_from_string(schedule, context)
-        assert_equal(config, schedule_parse.ConfigConstantScheduler())
-
 
 class TestValidScheduler(TestCase):
     @mock.patch('tron.config.schedule_parse.schedulers', autospec=True)

--- a/tests/data/test_config.yaml
+++ b/tests/data/test_config.yaml
@@ -122,30 +122,6 @@ jobs:
             command: "%(ECHO)s %(actionname)s %(cleanup_job_status)s"
 
 
-    # ConstantScheduler successful
-    -   name: constant_job6
-        node: box2
-        schedule: "constant"
-        actions:
-            -   name: task0
-                command: "%(ECHO)s %(actionname)s"
-            -   name: task1
-                command: "%(ECHO)s %(actionname)s && sleep 10"
-                requires: [task0]
-
-
-    # ConstantScheduler failure
-    -   name: constant_job7
-        node: localhost
-        schedule: "constant"
-        actions:
-            -   name: task0
-                command: "%(ECHO)s %(actionname)s && sleep 7 && false"
-            -   name: task1
-                command: "%(ECHO)s %(actionname)s"
-                requires: [task0]
-
-
     # all_nodes Job
     -   name: allnodes_job8
         node: pool2

--- a/tests/scheduler_test.py
+++ b/tests/scheduler_test.py
@@ -51,22 +51,6 @@ class TestSchedulerFromConfig(TestCase):
         assert_equal(str(sched), "daily 17:32 MWF")
 
 
-class ConstantSchedulerTest(testingutils.MockTimeTestCase):
-
-    now = datetime.datetime(2012, 3, 14)
-
-    @setup
-    def build_scheduler(self):
-        self.scheduler = scheduler.ConstantScheduler()
-
-    def test_next_run_time(self):
-        scheduled_time = self.scheduler.next_run_time(None)
-        assert_equal(scheduled_time, self.now)
-
-    def test__str__(self):
-        assert_equal(str(self.scheduler), 'constant')
-
-
 class GeneralSchedulerTestCase(testingutils.MockTimeTestCase):
 
     now = datetime.datetime.now().replace(hour=15, minute=0)

--- a/tests/trond_test.py
+++ b/tests/trond_test.py
@@ -234,7 +234,7 @@ class JobEndToEndTestCase(sandbox.SandboxTestCase):
         jobs:
           - name: "failjob"
             node: local
-            schedule: "constant"
+            schedule: "daily 04:20"
             actions:
               - name: "failaction"
                 command: "failplz"
@@ -265,7 +265,7 @@ class JobEndToEndTestCase(sandbox.SandboxTestCase):
         jobs:
           - name: "multi_step_job"
             node: local
-            schedule: "constant"
+            schedule: "daily 04:20"
             actions:
               - name: "broken"
                 command: "failingcommand"
@@ -306,7 +306,7 @@ class JobEndToEndTestCase(sandbox.SandboxTestCase):
                 -   name: "random_failure_job"
                     node: local
                     queueing: true
-                    schedule: "constant"
+                    schedule: "daily 04:20"
                     actions:
                         -   name: "fa"
                             command: "sleep 0.1; failplz"
@@ -408,7 +408,7 @@ class JobEndToEndTestCase(sandbox.SandboxTestCase):
            jobs:
               - name: fast_job
                 node: local
-                schedule: constant
+                schedule: daily 04:20
                 actions:
                   - name: single_act
                     command: "sleep 20 && echo good"

--- a/tron/config/schedule_parse.py
+++ b/tron/config/schedule_parse.py
@@ -32,8 +32,6 @@ ConfigDailyScheduler = namedtuple(
     'original hour minute second days jitter',
 )
 
-ConfigConstantScheduler = namedtuple('ConfigConstantScheduler', [])
-
 
 class ScheduleParseError(ConfigError):
     pass
@@ -88,11 +86,6 @@ def valid_schedule(schedule, config_context):
 
     schedule = ScheduleValidator().validate(schedule, config_context)
     return validate_generic_schedule_config(schedule, config_context)
-
-
-def valid_constant_scheduler(_config, _context):
-    """Adapter for validation interface and constant scheduler."""
-    return ConfigConstantScheduler()
 
 
 def valid_daily_scheduler(config, config_context):
@@ -308,7 +301,6 @@ def valid_cron_scheduler(config, config_context):
 
 
 schedulers = {
-    'constant': valid_constant_scheduler,
     'daily': valid_daily_scheduler,
     'cron': valid_cron_scheduler,
     'groc daily': parse_groc_expression,

--- a/tron/scheduler.py
+++ b/tron/scheduler.py
@@ -34,9 +34,6 @@ log = logging.getLogger(__name__)
 
 def scheduler_from_config(config, time_zone):
     """A factory for creating a scheduler from a configuration object."""
-    if isinstance(config, schedule_parse.ConfigConstantScheduler):
-        return ConstantScheduler()
-
     if isinstance(config, schedule_parse.ConfigGrocScheduler):
         return GeneralScheduler(
             time_zone=time_zone,
@@ -76,32 +73,6 @@ def scheduler_from_config(config, time_zone):
             original=config.original,
             jitter=config.jitter,
         )
-
-
-class ConstantScheduler(object):
-    """The constant scheduler schedules a new job immediately."""
-    schedule_on_complete = True
-
-    def next_run_time(self, _):
-        return timeutils.current_time()
-
-    def __str__(self):
-        return self.get_name()
-
-    def __eq__(self, other):
-        return isinstance(other, ConstantScheduler)
-
-    def __ne__(self, other):
-        return not self == other
-
-    def get_jitter(self):
-        pass
-
-    def get_name(self):
-        return 'constant'
-
-    def get_value(self):
-        return ''
 
 
 def get_jitter(time_delta):

--- a/tronweb/coffee/job.coffee
+++ b/tronweb/coffee/job.coffee
@@ -348,7 +348,6 @@ formatInterval = (interval) ->
 
 window.formatScheduler = (scheduler) ->
     [icon, value] = switch scheduler.type
-        when 'constant' then ['icon-repeatone', 'constant']
         when 'interval' then ['icon-time', formatInterval(scheduler.value)]
         when 'groc'     then ['icon-calendarthree', scheduler.value]
         when 'daily'    then ['icon-notestasks', scheduler.value]


### PR DESCRIPTION
I have a review out to remove the last usage of this scheduler, so I'm feeling ambitious.

Just like we removed tron services, I don't think tron should be used to "constantly" schedule something.