### PR TITLE
Use a cluster_name attribute for check_tron_jobs and metrics

### DIFF
--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1581,6 +1581,7 @@ class TestCheckPreciousJobs(TestCase):
         mock_client,
     ):
         client = mock_client('fake_server')
+        client.cluster_name = 'fake_cluster'
         del self.job['monitoring'][check_tron_jobs.PRECIOUS_JOB_ATTR]
         client.job = mock.Mock(return_value=self.job)
         mock_check_job_runs.return_value = {
@@ -1605,6 +1606,7 @@ class TestCheckPreciousJobs(TestCase):
     @patch('tron.bin.check_tron_jobs.Client', autospec=True)
     def test_compute_check_result_for_job_disabled(self, mock_client):
         client = mock_client('fake_server')
+        client.cluster_name = 'fake_cluster'
         self.job['status'] = 'disabled'
 
         results = check_tron_jobs.compute_check_result_for_job(
@@ -1628,6 +1630,7 @@ class TestCheckPreciousJobs(TestCase):
         mock_client,
     ):
         client = mock_client('fake_server')
+        client.cluster_name = 'fake_cluster'
         self.job['monitoring']['check_every'] = 500
         client.job = mock.Mock(return_value=self.job)
         mock_check_job_runs.return_value = {

--- a/tests/commands/cmd_utils_test.py
+++ b/tests/commands/cmd_utils_test.py
@@ -125,21 +125,22 @@ class TestBuildOptionParser(TestCase):
             formatter_class=argparse.RawDescriptionHelpFormatter,
             epilog=epilog,
         )
-        assert_equal(parser.add_argument.call_count, 4)
+        assert parser.add_argument.call_count == 5
 
         args = [call[1] for call in parser.add_argument.mock_calls]
         expected = [
             ('--version', ),
             ('-v', '--verbose'),
             ('--server', ),
+            ('--cluster_name', ),
             ('-s', '--save'),
         ]
-        assert_equal(args, expected)
+        assert args == expected
 
         defaults = [
             call[2].get('default') for call in parser.add_argument.mock_calls
         ]
-        assert_equal(defaults, [None, None, None, None])
+        assert defaults == [None, None, None, None, None]
 
 
 class TestSuggestions(TestCase):

--- a/tron/bin/get_tron_metrics.py
+++ b/tron/bin/get_tron_metrics.py
@@ -27,16 +27,6 @@ def parse_cli():
         default=False,
         help="Don't actually send metrics out. Defaults: %(default)s"
     )
-    parser.add_argument(
-        "--cluster",
-        default=None,
-        type=str,
-        help=(
-            "Cluster from which these metrics originate. "
-            "Sent as a dimension to meteorite. "
-            "Default: %(default)s"
-        ),
-    )
     args = parser.parse_args()
     return args
 
@@ -170,11 +160,11 @@ def main():
     args = parse_cli()
     cmd_utils.setup_logging(args)
     cmd_utils.load_config(args)
-    client = Client(args.server)
+    client = Client(args.server, args.cluster_name)
 
     if check_bin_exists('meteorite'):
         metrics = client.metrics()
-        send_metrics(metrics, cluster=args.cluster, dry_run=args.dry_run)
+        send_metrics(metrics, cluster=client.cluster_name, dry_run=args.dry_run)
     else:
         log.error("'meteorite' was not found")
 

--- a/tron/commands/client.py
+++ b/tron/commands/client.py
@@ -96,11 +96,12 @@ class Client(object):
     """An HTTP client used to issue commands to the Tron API.
     """
 
-    def __init__(self, url_base):
+    def __init__(self, url_base, cluster_name=None):
         """Create a new client.
             url_base - A url with a schema, hostname and port
         """
         self.url_base = url_base
+        self.cluster_name = cluster_name
 
     def status(self):
         return self.http_get('/api/status')

--- a/tron/commands/cmd_utils.py
+++ b/tron/commands/cmd_utils.py
@@ -35,6 +35,7 @@ DEFAULT_PORT = 8089
 DEFAULT_CONFIG = {
     'server': "http://%s:%d" % (DEFAULT_HOST, DEFAULT_PORT),
     'display_color': False,
+    'cluster_name': 'Unnamed Cluster',
 }
 
 TAB_COMPLETE_FILE = '/var/cache/tron_tab_completions'
@@ -114,6 +115,11 @@ def build_option_parser(usage=None, epilog=None):
         "--server",
         default=None,
         help="Url including scheme, host and port, Default: %(default)s",
+    )
+    parser.add_argument(
+        "--cluster_name",
+        default=None,
+        help="Human friendly tron cluster name",
     )
     parser.add_argument(
         "-s",


### PR DESCRIPTION
I don't feel great about this, but I think we need to have cluster_name in two places:

1. In the client somehow so we can sprinkle it in places like this
2. In the server object (mcp) so it can be used as a global variable in many places.

This is part 1.