### PR TITLE
Don't do a retry_delay when manually retrying a failed command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ cluster_itests:
 	tox -e cluster_itests
 
 dev:
-	SSH_AUTH_SOCK=$(SSH_AUTH_SOCK) .tox/py36/bin/trond --debug --working-dir=dev -l logging.conf --host=$(shell hostname -f)
+	SSH_AUTH_SOCK=$(SSH_AUTH_SOCK) .tox/py36/bin/trond --debug --working-dir=dev -l logging.conf --host=0.0.0.0
 
 example_cluster:
 	tox -e example-cluster

--- a/dev/config/MASTER.yaml
+++ b/dev/config/MASTER.yaml
@@ -20,42 +20,54 @@ mesos_options:
   dockercfg_location: file:///root/.dockercfg
 
 jobs:
-    - name: testjob0
-      node: localhost
-      schedule: "cron * * * * *"
-      actions:
-        - name: zeroth
-          command: "sleep 5"
-          trigger_downstreams:
-            minutely: "{ymdhm}"
-          cpus: 1
-          mem: 100
+  testjob0:
+    enabled: false
+    node: localhost
+    schedule: "cron * * * * *"
+    actions:
+      zeroth:
+        command: "sleep 5"
+        trigger_downstreams:
+          minutely: "{ymdhm}"
+        cpus: 1
+        mem: 100
 
-    - name: "testjob1"
-      node: localhost
-      schedule: "cron * * * * *"
-      actions:
-        - name: "first"
-          command: "sleep 5"
-          cpus: 1
-          mem: 100
-        - name: "second"
-          command: "echo 'hello world'"
-          requires: [first]
-          triggered_by:
-            - "MASTER.testjob0.zeroth.minutely.{ymdhm}"
-          trigger_downstreams:
-            minutely: "{ymdhm}"
-          cpus: 1
-          mem: 100
+  testjob1:
+    enabled: false
+    node: localhost
+    schedule: "cron * * * * *"
+    actions:
+      first:
+        command: "sleep 5"
+        cpus: 1
+        mem: 100
+      second:
+        command: "echo 'hello world'"
+        requires: [first]
+        triggered_by:
+          - "MASTER.testjob0.zeroth.minutely.{ymdhm}"
+        trigger_downstreams:
+          minutely: "{ymdhm}"
+        cpus: 1
+        mem: 100
 
-    - name: "testjob2"
-      node: localhost
-      schedule: "cron * * * * *"
-      actions:
-        - name: "first"
-          command: "echo 'goodbye, world'"
-          cpus: 1
-          mem: 100
-          triggered_by:
-            - "MASTER.testjob1.second.minutely.{ymdhm}"
+  testjob2:
+    enabled: false
+    node: localhost
+    schedule: "cron * * * * *"
+    actions:
+      first:
+        command: "echo 'goodbye, world'"
+        cpus: 1
+        mem: 100
+        triggered_by:
+          - "MASTER.testjob1.second.minutely.{ymdhm}"
+
+  retrier:
+    node: localhost
+    schedule: "cron 0 0 1 1 *"
+    actions:
+      failing:
+        command: exit 1
+        retries: 1
+        retries_delay: 5m

--- a/example-cluster/tronfig/MASTER.yaml
+++ b/example-cluster/tronfig/MASTER.yaml
@@ -27,7 +27,9 @@ jobs:
     schedule: "cron */5 * * * *"
     actions:
       one:
-        command: sleep 10 && date
+        command: exit 1
+        retries: 3
+        retries_delay: 1m
         trigger_downstreams: {ymdhm: "{ymdhm}"}
   two:
     node: localhost

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -429,6 +429,7 @@ class ActionRun(Observable):
         if self.in_delay is not None:
             self.in_delay.cancel()
             self.in_delay = None
+        self.retries_delay = None
 
         if self.is_done:
             return self._exit_unsuccessful(self.exit_status)


### PR DESCRIPTION
I don't know if this is the best solution, but it does seem to do the trick. (tested with `make dev`)