### PR TITLE
Speed up check tron jobs

### DIFF
--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1590,7 +1590,7 @@ class TestCheckPreciousJobs(TestCase):
         }
 
         results = check_tron_jobs.compute_check_result_for_job(
-            client, self.job
+            client, self.job, url_index={},
         )
 
         # make sure all job runs for a job are included by not incl count arg
@@ -1610,7 +1610,7 @@ class TestCheckPreciousJobs(TestCase):
         self.job['status'] = 'disabled'
 
         results = check_tron_jobs.compute_check_result_for_job(
-            client, self.job
+            client, self.job, url_index={},
         )
 
         assert len(results) == 1
@@ -1639,7 +1639,7 @@ class TestCheckPreciousJobs(TestCase):
         }
 
         results = check_tron_jobs.compute_check_result_for_job(
-            client, self.job
+            client, self.job, url_index={},
         )
 
         # make sure all job runs for a job are included by not incl count arg

--- a/tron/bin/check_tron_jobs.py
+++ b/tron/bin/check_tron_jobs.py
@@ -95,11 +95,11 @@ def compute_check_result_for_job_runs(client, job, job_content, url_index):
         url_index,
         relevant_job_run['id'],
     )
-    action_runs = client.job(job_run_id.url, include_action_runs=True)
+
     # A job action is like MASTER.foo.1.step1
     actions_expected_runtime = job_content.get('actions_expected_runtime', {})
     relevant_action = get_relevant_action(
-        action_runs=action_runs["runs"],
+        action_runs=relevant_job_run["runs"],
         last_state=last_state,
         actions_expected_runtime=actions_expected_runtime
     )


### PR DESCRIPTION
3 changes to speed things up:
1. Don't called `client.index()` over and over again
2. Don't make a 2nd call to `client.job()` to get the specific job run -- we already have that info from what I can tell (but someone should check me on that)
3. Only get `client.action_runs()` if the job failed (this the is the big one)

On my dev box this takes running `check_tron_jobs` from ~4.5min to ~45 seconds.

See TRON-1385 for details