### PR TITLE
fix job run ids reported by check_tron_jobs

### DIFF
--- a/tron/bin/check_tron_jobs.py
+++ b/tron/bin/check_tron_jobs.py
@@ -91,10 +91,7 @@ def compute_check_result_for_job_runs(client, job, job_content, url_index):
         )
 
     # A job_run is like MASTER.foo.1
-    job_run_id = get_object_type_from_identifier(
-        url_index,
-        relevant_job_run['id'],
-    )
+    job_run_id = relevant_job_run['id']
 
     # A job action is like MASTER.foo.1.step1
     actions_expected_runtime = job_content.get('actions_expected_runtime', {})


### PR DESCRIPTION
The previous method was returning a `TronObjectIdentifier` namedtuple, resulting in alerts referencing jobs called things like `TronObjectIdentifier(type='JOB_RUN', url='/api/jobs/jolt.gc_zookeeper/32780')`.

For comparison:
```
(Pdb) relevant_job_run['id']
'ahab.update_docker_repositories.40088'
```