### PR TITLE
Fix YAML doc loading

### DIFF
--- a/tests/bin/recover_batch_test.py
+++ b/tests/bin/recover_batch_test.py
@@ -1,3 +1,4 @@
+import tempfile
 from queue import Queue
 
 import mock
@@ -5,6 +6,14 @@ import pytest
 import yaml
 
 from tron.bin import recover_batch
+from tron.bin.action_runner import StatusFile
+
+
+@pytest.fixture
+def mock_file():
+    f = tempfile.NamedTemporaryFile()
+    yield f.name
+    f.close()
 
 
 @mock.patch('tron.bin.recover_batch.read_last_yaml_entries', autospec=True)
@@ -35,3 +44,34 @@ def test_notify(mock_reactor, mock_read_last_yaml_entries, line, exit_code, erro
     assert actual_exit_code == exit_code
     assert actual_error_msg == error_msg
     assert mock_reactor.stop.call_count == 1
+
+
+def test_read_last_yaml_roundtrip(mock_file):
+    """Check that read_last_yaml_entries returns the same thing that the action
+    runner wrote."""
+    status = StatusFile(mock_file)
+    expected_content = [
+        {'return_code': None, 'pid': 10345, 'command': 'foo'},
+        {'return_code': 1, 'pid': 10345, 'command': 'foo'},
+    ]
+    with mock.patch.object(status, 'get_content', side_effect=expected_content):
+        with status.wrap(command='echo hello', run_id='job.1.action', proc=mock.Mock()):
+            # In the context manager, we've written the first value of get_content.
+            first = recover_batch.read_last_yaml_entries(mock_file)
+            assert first == expected_content[0]
+
+    # After, we write another status entry. We should return the latest.
+    second = recover_batch.read_last_yaml_entries(mock_file)
+    assert second == expected_content[1]
+
+
+@pytest.mark.parametrize('content,expected', [
+    ('', None),
+    ('{"bar": 1}', None),
+    ('{"foo": 1}', 1),
+])
+def test_get_key_from_last_line(mock_file, content, expected):
+    with open(mock_file, 'w') as f:
+        f.write(content)
+        f.flush()
+    assert recover_batch.get_key_from_last_line(mock_file, 'foo') == expected

--- a/tron/bin/recover_batch.py
+++ b/tron/bin/recover_batch.py
@@ -37,8 +37,11 @@ def parse_args():
 
 def read_last_yaml_entries(filename):
     with open(filename) as f:
-        last_line = f.readlines()[-1]
-        entries = yaml.load(last_line)
+        lines = list(yaml.load_all(f))
+        if not lines:
+            entries = {}
+        else:
+            entries = lines[-1]
     return entries
 
 
@@ -77,12 +80,8 @@ def get_key_from_last_line(filepath, key):
         log.warning(f"status file {filepath} is empty")
         return None
     try:
-        with open(filepath) as f:
-            lines = f.readlines()
-            if lines:
-                content = yaml.load(lines[-1])
-                return content.get(key)
-            return None
+        content = read_last_yaml_entries(filepath)
+        return content.get(key)
     except Exception as e:
         log.warning(f"Exception encountered when inspecting {filepath}: {e}")
         return None


### PR DESCRIPTION
While testing recovery, I found that recovery was hanging forever. There are a few bugs, which I'll do in separate PRs.

First, both read_last_yaml_entries and get_key_from_last_line were only loading part of the status entry, e.g. `{'timestamp': 1569013680.5727654}`. From pyyaml 3.11 to 5.1, they changed `default_flow_style` from True to False. With True, each status entry is in one line, while with False, each key is in a separate line:
```
>>> yaml.safe_dump({'a': 1, 'b': 2}, explicit_start=True, default_flow_style=True)
'--- {a: 1, b: 2}\n'
>>> yaml.safe_dump({'a': 1, 'b': 2}, explicit_start=True, default_flow_style=False)
'---\na: 1\nb: 2\n'
```

Now I'm using yaml.load_all to parse it for us instead of assuming things about the lines. That should work with either flow style.

