### PR TITLE
Incorrect type in logging message

### DIFF
--- a/tests/bin/recover_batch_test.py
+++ b/tests/bin/recover_batch_test.py
@@ -65,7 +65,7 @@ def test_notify(mock_get_exit_code, mock_reactor, exit_code, error_msg, should_s
     )
 ])
 def test_get_exit_code(mock_read_last_yaml_entries, mock_pid_running, line, exit_code, is_running, error_msg):
-    fake_path = mock.MagicMock()
+    fake_path = '/file/path'
     mock_read_last_yaml_entries.return_value = line
     mock_pid_running.side_effect = [is_running]
 

--- a/tron/bin/recover_batch.py
+++ b/tron/bin/recover_batch.py
@@ -67,7 +67,7 @@ def get_exit_code(filepath):
         else:
             exit_code = return_code
     elif pid is None:
-        log.warning(f"Status file {filepath.path} didn't have a PID. Will watch the file for updates.")
+        log.warning(f"Status file {filepath} didn't have a PID. Will watch the file for updates.")
     elif not psutil.pid_exists(pid):
         exit_code = 1
         error_message = f'Action runner pid {pid} no longer running. Assuming an exit of 1.'
@@ -80,7 +80,8 @@ def run(fpath):
     # If it has, we don't expect any more updates.
     return_code, error_message = get_exit_code(fpath)
     if return_code is not None:
-        log.warning(error_message)
+        if error_message is not None:
+            log.warning(error_message)
         sys.exit(return_code)
 
     # If not, wait for updates to the file.


### PR DESCRIPTION
I didn't catch this in stage because I think we only had short-running jobs there that already picked up the action_runner file-closing fix (https://github.com/Yelp/Tron/pull/694) before my restart. This bug happens when an SSH action starts with an old version (1.0.1) but is recovered with the new version (1.0.4).

```
Traceback (most recent call last):
 File "/opt/venvs/tron/bin/recover_batch.py", line 101, in <module>
   run(args.filepath)
 File "/opt/venvs/tron/bin/recover_batch.py", line 81, in run
   return_code, error_message = get_exit_code(fpath)
 File "/opt/venvs/tron/bin/recover_batch.py", line 70, in get_exit_code
   log.warning(f"Status file {filepath.path} didn't have a PID. Will watch the file for updates.")
AttributeError: 'str' object has no attribute 'path'
```

plus a minor logging change so users don't see "None" in their logs if the job succeeded.