### PR TITLE
RFC: Make the action runner on by default and a first class command

### DIFF
--- a/debian/tron.links
+++ b/debian/tron.links
@@ -1,5 +1,7 @@
 opt/venvs/tron/bin/check_tron_jobs usr/bin/check_tron_jobs.py
 opt/venvs/tron/bin/tronctl usr/bin/tronctl
+opt/venvs/tron/bin/tron-action-runner usr/bin/tron-action-runner
+opt/venvs/tron/bin/tron-action-status usr/bin/tron-action-status
 opt/venvs/tron/bin/trond usr/bin/trond
 opt/venvs/tron/bin/tronfig usr/bin/tronfig
 opt/venvs/tron/bin/tronview usr/bin/tronview

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -193,9 +193,6 @@ Example::
 Action Runners
 --------------
 
-**Note:** this is an experimental feature
-
-
 **action_runner**
     Action runner configuration allows you to run Job actions through a script
     which records it's pid. This provides support for a max_runtime option
@@ -204,21 +201,21 @@ Action Runners
     **runner_type**
         Valid options are:
             **none**
-                Run actions without a wrapper. This is the default
+                Run actions without a wrapper.
 
             **subprocess**
                 Run actions with a script which records the pid and runs the
                 action command in a subprocess (on the remote node). This
-                requires that :command:`bin/action_runner.py` and
-                :command:`bin/action_status.py` are available on the remote
-                host.
+                requires that ``tron-action-runner`` and
+                ``tron-action-status`` are available on the remote host.
+                This is the default.
 
     **remote_status_path**
-        Path used to store status files. Defaults to `/tmp`.
+        Path used to store status files. Defaults to `/tmp/tron`.
 
     **remote_exec_path**
-        Directory path which contains :command:`action_runner.py` and
-        :command:`action_status.py` scripts.
+        Directory path which contains ``tron-action-runner`` and
+        ``tron-action-status`` scripts. Defaults to ``/usr/bin/``
 
 
 Example::

--- a/example-cluster/tronfig/MASTER.yaml
+++ b/example-cluster/tronfig/MASTER.yaml
@@ -10,11 +10,6 @@ ssh_options:
   identities:
     - /work/example-cluster/insecure_key
 
-action_runner:
-  runner_type: "subprocess"
-  remote_status_path: "/tmp/tron"
-  remote_exec_path: "/work/tron/bin/"
-
 nodes:
   - hostname: localhost
     username: root

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,12 @@ setup(
         exclude=['tests.*', 'tests', 'example-cluster']
     ) + ['tronweb'],
     scripts=glob.glob('bin/*') + glob.glob('tron/bin/*.py'),
+    entry_points={
+        "console_scripts": [
+            "tron-action-runner=tron.bin.action_runner:main",
+            "tron-action-status=tron.bin.action_status:main",
+        ],
+    },
     include_package_data=True,
     long_description="""
 Tron is a centralized system for managing periodic batch processes across a

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -594,9 +594,9 @@ class ValidateActionRunner(Validator):
     config_class = schema.ConfigActionRunner
     optional = True
     defaults = {
-        'runner_type': None,
-        'remote_exec_path': '',
-        'remote_status_path': '/tmp',
+        'runner_type': "subprocess",
+        'remote_exec_path': '/usr/bin/',
+        'remote_status_path': '/tmp/tron',
     }
 
     validators = {
@@ -702,7 +702,11 @@ class ValidateConfig(Validator):
     """
     config_class = TronConfig
     defaults = {
-        'action_runner': {},
+        'action_runner': {
+            "runner_type": "subprocess",
+            "remote_status_path": "/tmp/tron",
+            "remote_exec_path": "/usr/bin/",
+        },
         'output_stream_dir': None,
         'command_context': {},
         'ssh_options': ConfigSSHOptions(**ValidateSSHOptions.defaults),


### PR DESCRIPTION
I think the fact that the action runner isn't enabled by default is surprising.
I think it is crazy that we haven't had it on at yelp until relatively recently.

RFC: I think it should be on by default. Heck, dare me to make it not even optional and have "no" configuration?

No tests changed yet.

