### PR TITLE
Move SSH action recovery logic into the class to enable retries

### DIFF
--- a/tests/core/recovery_test.py
+++ b/tests/core/recovery_test.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import mock
-from mock import call
 from mock import Mock
 
 from testifycompat import setup
@@ -12,10 +11,8 @@ from tron.actioncommand import SubprocessActionRunnerFactory
 from tron.core.actionrun import ActionRun
 from tron.core.actionrun import MesosActionRun
 from tron.core.actionrun import SSHActionRun
-from tron.core.recovery import build_recovery_command
 from tron.core.recovery import filter_action_runs_needing_recovery
 from tron.core.recovery import launch_recovery_actionruns_for_job_runs
-from tron.core.recovery import recover_action_run
 from tron.utils import timeutils
 
 
@@ -68,46 +65,8 @@ class TestRecovery(TestCase):
             [self.action_runs[3]],
         )
 
-    def test_build_recovery_command(self):
-        assert build_recovery_command(
-            "/bin/foo",
-            "/tmp/foo",
-        ) == "/bin/foo /tmp/foo"
-
-    def test_recover_action_run_no_action_runner(self):
-        no_action_runner = SSHActionRun(
-            job_run_id="test.succeeded",
-            name="test.succeeded",
-            node=Mock(),
-        )
-        assert recover_action_run(
-            no_action_runner, no_action_runner.action_runner
-        ) is None
-
-    def test_recover_action_run_action_runner(self):
-        action_runner = SubprocessActionRunnerFactory(
-            status_path='/tmp/foo',
-            exec_path='/bin/foo',
-        )
-        mock_node = mock.Mock()
-        action_run = SSHActionRun(
-            job_run_id="test.succeeded",
-            name="test.succeeded",
-            node=mock_node,
-            action_runner=action_runner,
-            end_time=timeutils.current_time(),
-            exit_status=0
-        )
-        action_run.machine.state = ActionRun.UNKNOWN
-        recover_action_run(action_run, action_runner)
-        mock_node.submit_command.assert_called_once()
-        assert action_run.machine.state == ActionRun.RUNNING
-        assert action_run.end_time is None
-        assert action_run.exit_status is None
-
-    @mock.patch('tron.core.recovery.recover_action_run', autospec=True)
     @mock.patch('tron.core.recovery.filter_action_runs_needing_recovery', autospec=True)
-    def test_launch_recovery_actionruns_for_job_runs(self, mock_filter, mock_recover_action_run):
+    def test_launch_recovery_actionruns_for_job_runs(self, mock_filter):
         mock_actions = (
             [
                 mock.Mock(
@@ -134,11 +93,8 @@ class TestRecovery(TestCase):
         launch_recovery_actionruns_for_job_runs([mock_job_run],
                                                 mock_action_runner)
         ssh_runs = mock_actions[0]
-        calls = [
-            call(ssh_runs[0], mock_action_runner),
-            call(ssh_runs[1], ssh_runs[1].action_runner)
-        ]
-        mock_recover_action_run.assert_has_calls(calls, any_order=True)
+        for run in ssh_runs:
+            assert run.recover.call_count == 1
 
         mesos_run = mock_actions[1][0]
         assert mesos_run.recover.call_count == 1

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 import logging
 
-from tron.actioncommand import NoActionRunnerFactory
 from tron.core.actionrun import ActionRun
 from tron.core.actionrun import MesosActionRun
 from tron.core.actionrun import SSHActionRun
@@ -24,63 +23,6 @@ def filter_action_runs_needing_recovery(action_runs):
     return ssh_runs, mesos_runs
 
 
-def build_recovery_command(recovery_binary, path):
-    return f"{recovery_binary} {path}"
-
-
-def recover_action_run(action_run, action_runner):
-    log.info(f"Creating recovery run for actionrun {action_run.id}")
-    if type(action_runner) == NoActionRunnerFactory:
-        log.info(
-            f"Unable to recover action_run {action_run.id}: "
-            "action_run has no action_runner"
-        )
-        return None
-
-    recovery_run = SSHActionRun(
-        job_run_id=action_run.job_run_id,
-        name=f"recovery-{action_run.id}",
-        node=action_run.node,
-        bare_command=build_recovery_command(
-            recovery_binary=f"{action_runner.exec_path}/recover_batch.py",
-            path=f"{action_runner.status_path}/{action_run.id}/status",
-        ),
-        output_path=action_run.output_path,
-    )
-    recovery_action_command = recovery_run.build_action_command()
-    recovery_action_command.write_stdout(
-        f"Recovering action run {action_run.id}",
-    )
-    # Put action command in "running" state so if it fails to connect
-    # and exits with no exit code, the real action run will not retry.
-    recovery_action_command.started()
-
-    # this line is where the magic happens.
-    # the action run watches another actioncommand,
-    # and updates its internal state according to its result.
-    action_run.watch(recovery_action_command)
-
-    if not action_run.machine.check('running'):
-        log.error(
-            f'Unable to transition action run {action_run.id} '
-            f'from {action_run.machine.state} to start'
-        )
-    else:
-        action_run.exit_status = None
-        action_run.end_time = None
-        action_run.machine.transition('running')
-
-    log.info(
-        f"Submitting recovery job with command {recovery_action_command.command} "
-        f"to node {recovery_run.node}"
-    )
-    deferred = recovery_run.node.submit_command(recovery_action_command)
-    deferred.addCallback(
-        lambda x: log.info(f"Completed recovery run {recovery_run.id}")
-    )
-    return deferred
-
-
 def launch_recovery_actionruns_for_job_runs(job_runs, master_action_runner):
     for run in job_runs:
         if not run._action_runs:
@@ -89,14 +31,7 @@ def launch_recovery_actionruns_for_job_runs(job_runs, master_action_runner):
 
         ssh_runs, mesos_runs = filter_action_runs_needing_recovery(run._action_runs)
         for action_run in ssh_runs:
-            if type(action_run.action_runner) == NoActionRunnerFactory and \
-               type(master_action_runner) != NoActionRunnerFactory:
-                action_runner = master_action_runner
-            else:
-                action_runner = action_run.action_runner
-            deferred = recover_action_run(action_run, action_runner)
-            if not deferred:
-                log.debug("unable to recover action run %s" % action_run.id)
+            action_run.recover()
 
         for action_run in mesos_runs:
             action_run.recover()


### PR DESCRIPTION
I tested this with `make dev` locally.

I (or someone else) can follow up with the actual retries later, wanted to keep the diff small to reduce the chance of mistakes 😬 