### PR TITLE
RFC: external_text and external_urls for all tron jobs/job runs/action runs

### DIFF
--- a/dev/config/MASTER.yaml
+++ b/dev/config/MASTER.yaml
@@ -12,6 +12,28 @@ ssh_options:
 nodes:
   - hostname: localhost
 
+external_urls:
+  job:
+    "Compute Resources": 'https://app.signalfx.com/#/dashboard/DJzYJDkAcAA?density=4&groupId=DJzYWe9AcAA&configId=DpqyzW_AgB&&startTime=-1d&endTime=Now&variables%5B%5D=PaaSTA%20Service%3Dpaasta_service:%5B"{namespace}"%5D&variables%5B%5D=PaaSTA%20Instance%3Dpaasta_instance:%5B"{name}.*"%5D&variables%5B%5D=PaaSTA%20Cluster%3Dpaasta_cluster:%5B"{cluster}"%5D'
+  job_run:
+    "Compute Resources": 'https://app.signalfx.com/#/dashboard/DJzYJDkAcAA?density=4&groupId=DJzYWe9AcAA&configId=DpqyzW_AgBA&startTime=-1d&endTime=Now&variables%5B%5D=PaaSTA%20Service%3Dpaasta_service:%5B"{namespace}"%5D&variables%5B%5D=PaaSTA%20Instance%3Dpaasta_instance:%5B"{actionname}"%5D&variables%5B%5D=PaaSTA%20Cluster%3Dpaasta_cluster:%5B"{cluster}"%5D'
+  action_run:
+    "Compute Resources": 'https://app.signalfx.com/#/dashboard/DJzYJDkAcAA?density=4&groupId=DJzYWe9AcAA&configId=DpqyzW_AgBA&startTime=-1d&endTime=Now&variables%5B%5D=PaaSTA%20Service%3Dpaasta_service:%5B"{namespace}"%5D&variables%5B%5D=PaaSTA%20Instance%3Dpaasta_instance:%5B"{actionname}"%5D&variables%5B%5D=PaaSTA%20Cluster%3Dpaasta_cluster:%5B"{cluster}"%5D'
+
+external_text:
+  job:
+    "CLI Commands": |
+      tronview-{cluster} {name}
+      tronctl-{cluster} start {name}
+  job_run:
+    "CLI Commands": |
+      tronview-{cluster} {name}.{runid}
+      tronctl-{cluster} rerun {name}.{runid}
+  action_run:
+    "CLI Commands": |
+      tronview-{cluster} {name}.{runid}.{actionname}
+      tronctl-{cluster} retry {name}.{runid}.{actionname}
+
 mesos_options:
   master_address: mesos.paasta-mesosstage.yelp
   master_port: 5050

--- a/tests/api/resource_test.py
+++ b/tests/api/resource_test.py
@@ -237,6 +237,8 @@ class TestJobResource(WWWTestCase):
             node_pool=mock.create_autospec(node.NodePool, ),
             max_runtime=mock.Mock(),
             expected_runtime=mock.MagicMock(),
+            external_text=None,
+            external_urls=None,
         )
         self.job.get_name.return_value = 'foo'
         self.job_scheduler.get_job.return_value = self.job

--- a/tests/core/job_scheduler_test.py
+++ b/tests/core/job_scheduler_test.py
@@ -311,6 +311,8 @@ class TestJobSchedulerFactory(TestCase):
             self.time_zone,
             self.action_runner,
             mock.Mock(),
+            external_text=None,
+            external_urls=None,
         )
 
     def test_build(self):

--- a/tron/api/adapter.py
+++ b/tron/api/adapter.py
@@ -116,6 +116,8 @@ class ActionRunAdapter(RunAdapter):
         'in_delay',
         'triggered_by',
         'trigger_downstreams',
+        'external_text',
+        'external_urls',
     ]
 
     def __init__(
@@ -182,6 +184,12 @@ class ActionRunAdapter(RunAdapter):
     def get_trigger_downstreams(self) -> str:
         triggers_to_emit = self._obj.triggers_to_emit()
         return ', '.join(sorted(triggers_to_emit))
+
+    def get_external_text(self):
+        return "EXTERNAL TEXT"
+
+    def get_external_urls(self):
+        return "EXTERNAL TEXT"
 
 
 class ActionGraphAdapter(object):
@@ -255,6 +263,8 @@ class JobRunAdapter(RunAdapter):
         'url',
         'runs',
         'action_graph',
+        'external_text',
+        'external_urls',
     ]
 
     def __init__(
@@ -278,10 +288,23 @@ class JobRunAdapter(RunAdapter):
     def get_action_graph(self):
         return ActionRunGraphAdapter(self._obj.action_runs).get_repr()
 
+    def get_external_text(self):
+        return "EXTERNAL JOB RUN TEXT"
+
+    def get_external_urls(self):
+        return "EXTERNAL JOB RUN URLS"
+
 
 class JobAdapter(ReprAdapter):
 
-    field_names = ['status', 'all_nodes', 'allow_overlap', 'queueing']
+    field_names = [
+        'status',
+        'all_nodes',
+        'allow_overlap',
+        'queueing',
+        'external_text',
+        'external_urls',
+    ]
     translated_field_names = [
         'name',
         'scheduler',

--- a/tron/commands/display.py
+++ b/tron/commands/display.py
@@ -321,6 +321,8 @@ class DisplayJobs(TableDisplay):
         ('Run on all nodes', 'all_nodes'),
         ('Allow overlapping', 'allow_overlap'),
         ('Queue overlapping', 'queueing'),
+        ('Text', 'external_text'),
+        ('Urls', 'external_urls'),
     ]
 
     colors = {
@@ -355,6 +357,8 @@ class DisplayActionRuns(TableDisplay):
         ('Retry exit statuses', 'exit_statuses'),
         ('Waits for triggers', 'triggered_by'),
         ('Publishes triggers', 'trigger_downstreams'),
+        ('Text', 'external_text'),
+        ('Urls', 'external_urls'),
     ]
 
     colors = {

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -49,6 +49,8 @@ TronConfig = config_object_factory(
         'jobs',  # dict of ConfigJob
         'mesos_options',  # ConfigMesos
         'eventbus_enabled',  # bool or None
+        'external_text',
+        'external_urls',
     ],
 )
 

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -57,6 +57,8 @@ class Job(Observable, Observer):
         'monitoring',
         'time_zone',
         'expected_runtime',
+        'external_text',
+        'external_urls',
     ]
 
     # TODO: use config object
@@ -77,7 +79,9 @@ class Job(Observable, Observer):
         action_runner=None,
         max_runtime=None,
         time_zone=None,
-        expected_runtime=None
+        expected_runtime=None,
+        external_text=None,
+        external_urls=None,
     ):
         super(Job, self).__init__()
         self.name = maybe_decode(name)
@@ -98,6 +102,8 @@ class Job(Observable, Observer):
         self.output_path = output_path or filehandler.OutputPath()
         self.output_path.append(name)
         self.context = command_context.build_context(self, parent_context)
+        self.external_text = external_text
+        self.external_urls = external_urls
         log.info(f'{self} created')
 
     @classmethod
@@ -109,6 +115,8 @@ class Job(Observable, Observer):
         output_path,
         action_runner,
         action_graph,
+        external_text=None,
+        external_urls=None,
     ):
         """Factory method to create a new Job instance from configuration."""
         runs = jobrun.JobRunCollection.from_config(job_config)
@@ -131,6 +139,8 @@ class Job(Observable, Observer):
             action_runner=action_runner,
             max_runtime=job_config.max_runtime,
             expected_runtime=job_config.expected_runtime,
+            external_text=external_text,
+            external_urls=external_urls,
         )
 
     def update_from_job(self, job):
@@ -167,6 +177,12 @@ class Job(Observable, Observer):
 
     def get_runs(self):
         return self.runs
+
+    def get_external_text(self):
+        return self.external_text
+
+    def get_external_urls(self):
+        return self.external_urls
 
     @property
     def state_data(self):

--- a/tron/core/job_scheduler.py
+++ b/tron/core/job_scheduler.py
@@ -231,12 +231,14 @@ class JobScheduler(Observer):
 class JobSchedulerFactory(object):
     """Construct JobScheduler instances from configuration."""
 
-    def __init__(self, context, output_stream_dir, time_zone, action_runner, job_graph):
+    def __init__(self, context, output_stream_dir, time_zone, action_runner, job_graph, external_text, external_urls):
         self.context = context
         self.output_stream_dir = output_stream_dir
         self.time_zone = time_zone
         self.action_runner = action_runner
         self.job_graph = job_graph
+        self.external_text = external_text
+        self.external_urls = external_urls
 
     def build(self, job_config):
         log.debug(f"Building new job {job_config.name}")
@@ -251,5 +253,7 @@ class JobSchedulerFactory(object):
             output_path=output_path,
             action_runner=self.action_runner,
             action_graph=action_graph,
+            external_text=self.external_text,
+            external_urls=self.external_urls,
         )
         return JobScheduler(job)

--- a/tron/mcp.py
+++ b/tron/mcp.py
@@ -108,11 +108,13 @@ class MasterControlProgram(object):
             master_config.action_runner,
         )
         return JobSchedulerFactory(
-            self.context,
-            output_stream_dir,
-            master_config.time_zone,
-            action_runner,
-            job_graph,
+            context=self.context,
+            output_stream_dir=output_stream_dir,
+            time_zone=master_config.time_zone,
+            action_runner=action_runner,
+            job_graph=job_graph,
+            external_text=master_config.external_text,
+            external_urls=master_config.external_urls,
         )
 
     def update_state_watcher_config(self, state_config):


### PR DESCRIPTION
Before I go too deep into tron and threading these things into all the objects and factories, I would like some feedback (go/nogo) on how I'm doing it.

No rendering is done yet, but this gets the config to the right (job) objects.

```
tronview  --server=http://`hostname`:8089   MASTER.testjob0
Job                 : MASTER.testjob0
State               : running
Scheduler           : cron * * * * *
Max runtime         : None
Node Pool           : localhost (1 node(s))
Run on all nodes    : False
Allow overlapping   : False
Queue overlapping   : True
Text                : {'job': {'CLI Commands': 'tronview-{cluster} {name}\ntronctl-{cluster} start {name}\n'}, 'job_run': {'CLI Commands': 'tronview-{cluster} {name}.{runid}\ntronctl-{cluster} rerun {name}.{runid}\n'}, 'action_run': {'CLI Commands': 'tronview-{cluster} {name}.{runid}.{actionname}\ntronctl-{cluster} retry {name}.{runid}.{actionname}\n'}}
Urls                : {'job': {'Compute Resources': 'https://app.signalfx.com/#/dashboard/DJzYJDkAcAA?density=4&groupId=DJzYWe9AcAA&configId=DpqyzW_AgB&&startTime=-1d&endTime=Now&variables%5B%5D=PaaSTA%20Service%3Dpaasta_service:%5B"{namespace}"%5D&variables%5B%5D=PaaSTA%20Instance%3Dpaasta_instance:%5B"{name}.*"%5D&variables%5B%5D=PaaSTA%20Cluster%3Dpaasta_cluster:%5B"{cluster}"%5D'}, 'job_run': {'Compute Resources': 'https://app.signalfx.com/#/dashboard/DJzYJDkAcAA?density=4&groupId=DJzYWe9AcAA&configId=DpqyzW_AgBA&startTime=-1d&endTime=Now&variables%5B%5D=PaaSTA%20Service%3Dpaasta_service:%5B"{namespace}"%5D&variables%5B%5D=PaaSTA%20Instance%3Dpaasta_instance:%5B"{actionname}"%5D&variables%5B%5D=PaaSTA%20Cluster%3Dpaasta_cluster:%5B"{cluster}"%5D'}, 'action_run': {'Compute Resources': 'https://app.signalfx.com/#/dashboard/DJzYJDkAcAA?density=4&groupId=DJzYWe9AcAA&configId=DpqyzW_AgBA&startTime=-1d&endTime=Now&variables%5B%5D=PaaSTA%20Service%3Dpaasta_service:%5B"{namespace}"%5D&variables%5B%5D=PaaSTA%20Instance%3Dpaasta_instance:%5B"{actionname}"%5D&variables%5B%5D=PaaSTA%20Cluster%3Dpaasta_cluster:%5B"{cluster}"%5D'}}

List of Actions:
zeroth

Job runs:
Run ID    State       Node                          Scheduled Time
.29279    queued      kwa@localhost                 2019-09-13 00:10:00
          Start: -  End: -  (-)
.29278    running     kwa@localhost                 2019-09-13 00:09:00
```

This should make it so we can give users some quick easy copy-paste commands for them for retrying and such. I think it is not that easy to construct the exact tronctl command to retry a particular failed action.

 Also it means embed graphs and costs and stuff into tronweb, which I think would be cool. This would give our users a more holistic picture of their job, including cpu/ram/cost. 