### PR TITLE
Add manual recovery command to api

### DIFF
--- a/bin/tronctl
+++ b/bin/tronctl
@@ -24,6 +24,7 @@ COMMAND_HELP = (
     ('start', 'Start the selected job, job run, or action'),
     ('rerun', 'Re-run a full job (all actions) with a new job id'),
     ('retry', 'Re-run a job action within an existing job run'),
+    ('recover', 'Ask Tron to start tracking an UNKNOWN action run again'),
     ('cancel', 'Cancel the selected job run'),
     ('backfill', 'Start many jobs for a particular date range'),
     ('disable', 'Disable selected job and cancel any outstanding runs'),

--- a/tests/api/controller_test.py
+++ b/tests/api/controller_test.py
@@ -70,7 +70,13 @@ class TestActionRunController:
         self.job_run.is_scheduled = True
         result = self.controller.handle_command('start')
         assert not self.action_run.start.mock_calls
-        assert "can not be started" in result
+        assert "cannot be started" in result
+
+    def test_handle_command_recover_failed(self):
+        self.action_run.is_unknown = False
+        result = self.controller.handle_command('recover')
+        assert not self.action_run.recover.mock_calls
+        assert "cannot be recovered" in result
 
     def test_handle_command_mapped_command(self):
         result = self.controller.handle_command('cancel')

--- a/tron/api/controller.py
+++ b/tron/api/controller.py
@@ -39,6 +39,7 @@ class ActionRunController(object):
         'stop',
         'kill',
         'retry',
+        'recover',
     }
 
     def __init__(self, action_run, job_run):
@@ -51,8 +52,13 @@ class ActionRunController(object):
 
         if command == 'start' and self.job_run.is_scheduled:
             return (
-                "Action run can not be started if it's job run is still "
+                "Action run cannot be started if its job run is still "
                 "scheduled."
+            )
+
+        if command == 'recover' and not self.action_run.is_unknown:
+            return (
+                "Action run cannot be recovered if its state is not unknown."
             )
 
         if command in ('stop', 'kill'):


### PR DESCRIPTION
Now that both SSH and Mesos actions have a recover method, recovery can be a first-class command. Now the wiki for handling unknown action runs can just say "run tronctl recover".

The next step is to make recovery automatic, but this was a simple first step.