### PR TITLE
Do not auto retry action if state is already succeeded

### DIFF
--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -435,6 +435,7 @@ class ActionRun(Observable):
         self.retries_delay = None
 
         if self.is_done:
+            self.machine.reset()
             return self._exit_unsuccessful(self.exit_status)
         else:
             log.info(f"{self} getting killed for a retry")
@@ -465,6 +466,12 @@ class ActionRun(Observable):
         return self._done('fail', exit_status)
 
     def _exit_unsuccessful(self, exit_status=None):
+        if self.is_done:
+            log.info(
+                f'{self} got exit code {exit_status} but already in terminal '
+                f'state "{self.state}", not retrying',
+            )
+            return
         if self.retries_remaining is not None:
             if self.retries_remaining > 0:
                 self.retries_remaining -= 1


### PR DESCRIPTION
Yesterday the docker daemon on a batch box got stuck and many actions never "completed" just because the container didn't exit. A user saw that their action had already produced a COMPLETE file and used `tronctl success` to finish it. Once I got around to restarting the docker daemon, the process finally exited and triggered a retry, which is bad because the retry cleared the s3 output directory and dependencies had already started running.

Most of the tests I just moved around because I thought they should go in the general ActionRun test rather than the SSHActionRun test, but test_auto_retry_already_done is the one that covers this case.