### PR TITLE
Added an option to hide stderr from checks

### DIFF
--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -1661,6 +1661,7 @@ class TestCheckPreciousJobs:
         client = mock_client('fake_server')
         client.cluster_name = 'fake_cluster'
         self.job['monitoring']['check_every'] = 500
+        self.job['monitoring']['hide_stderr'] = True
         client.job = mock.Mock(return_value=self.job)
         mock_check_job_runs.return_value = {
             'output': 'fake_output',
@@ -1670,6 +1671,9 @@ class TestCheckPreciousJobs:
         results = check_tron_jobs.compute_check_result_for_job(
             client, self.job, url_index={},
         )
+
+        # Test that hide_stderr is passed to check_job_runs
+        assert mock_check_job_runs.call_args_list[0][1]['hide_stderr'] is True
 
         # make sure all job runs for a job are included by not incl count arg
         assert client.job.call_args_list == [mock.call(

--- a/tron/bin/check_tron_jobs.py
+++ b/tron/bin/check_tron_jobs.py
@@ -72,7 +72,7 @@ def _timestamp_to_shortdate(timestamp, separator='.'):
     )
 
 
-def compute_check_result_for_job_runs(client, job, job_content, url_index):
+def compute_check_result_for_job_runs(client, job, job_content, url_index, hide_stderr=False):
     cluster = client.cluster_name
     kwargs = {}
     if job_content is None:
@@ -138,6 +138,9 @@ def compute_check_result_for_job_runs(client, job, job_content, url_index):
     else:
         prefix = f"UNKNOWN: Job {job_run_id} is in a state that check_tron_jobs doesn't understand"
         status = 3
+        stderr = ""
+
+    if hide_stderr:
         stderr = ""
 
     precious_runs_note = ''
@@ -386,7 +389,7 @@ def compute_check_result_for_job(client, job, url_index):
         .discard('check_every')
     )
     kwargs = kwargs.update(sensu_kwargs)
-
+    hide_stderr = kwargs.get('hide_stderr', False)
     kwargs_list = []
     if job["status"] == "disabled":
         kwargs = kwargs.set(
@@ -416,6 +419,7 @@ def compute_check_result_for_job(client, job, url_index):
                 job_content=job_content.set('runs', runs),
                 client=client,
                 url_index=url_index,
+                hide_stderr=hide_stderr,
             )
             dated_kwargs = kwargs.update(results)
             if date:  # if empty date, leave job name alone


### PR DESCRIPTION
The stderr in the output of Tron checks can be obnoxiously big and usually does not actually contain output from the task itself, but rather Mesos. This adds an setting to turn it off.