### PR TITLE
run_limit changes are picked up by tronfig

### DIFF
--- a/dev/config/MASTER.yaml
+++ b/dev/config/MASTER.yaml
@@ -30,6 +30,7 @@ jobs:
     enabled: true
     node: localhost
     schedule: "cron * * * * *"
+    run_limit: 5
     actions:
       zeroth:
         command: env

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -98,11 +98,13 @@ class TestJob(TestCase):
             'otherjob',
             'scheduler',
             action_runner=action_runner,
+            run_limit=10,
         )
         self.job.update_from_job(other_job)
         assert_equal(self.job.name, 'otherjob')
         assert_equal(self.job.scheduler, 'scheduler')
         assert_equal(self.job, other_job)
+        assert_equal(self.job.runs.run_limit, 10)
 
     def test_status_disabled(self):
         self.job.enabled = False
@@ -209,13 +211,13 @@ class TestJob(TestCase):
         self.job.notify.assert_called_with(self.job.NOTIFY_RUN_DONE)
 
     def test__eq__(self):
-        other_job = job.Job("jobname", 'scheduler')
+        other_job = job.Job("jobname", 'scheduler', run_collection=MagicMock())
         assert not self.job == other_job
         other_job.update_from_job(self.job)
         assert_equal(self.job, other_job)
 
     def test__ne__(self):
-        other_job = job.Job("jobname", 'scheduler')
+        other_job = job.Job("jobname", 'scheduler', run_collection=MagicMock())
         assert self.job != other_job
         other_job.update_from_job(self.job)
         assert not self.job != other_job

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -57,6 +57,7 @@ class Job(Observable, Observer):
         'monitoring',
         'time_zone',
         'expected_runtime',
+        'run_limit',
     ]
 
     # TODO: use config object
@@ -77,7 +78,8 @@ class Job(Observable, Observer):
         action_runner=None,
         max_runtime=None,
         time_zone=None,
-        expected_runtime=None
+        expected_runtime=None,
+        run_limit=None,
     ):
         super(Job, self).__init__()
         self.name = maybe_decode(name)
@@ -98,6 +100,7 @@ class Job(Observable, Observer):
         self.output_path = output_path or filehandler.OutputPath()
         self.output_path.append(name)
         self.context = command_context.build_context(self, parent_context)
+        self.run_limit = run_limit
         log.info(f'{self} created')
 
     @classmethod
@@ -131,6 +134,7 @@ class Job(Observable, Observer):
             action_runner=action_runner,
             max_runtime=job_config.max_runtime,
             expected_runtime=job_config.expected_runtime,
+            run_limit=job_config.run_limit,
         )
 
     def update_from_job(self, job):
@@ -140,6 +144,10 @@ class Job(Observable, Observer):
         """
         for attr in self.equality_attributes:
             setattr(self, attr, getattr(job, attr))
+
+        # the run_limit is a property on the JobRunCollection, not on the
+        # Job itself so we need to handle that separately
+        self.runs.run_limit = job.run_limit
         log.info(f'{self} reconfigured')
 
     @property


### PR DESCRIPTION
It's a little more complicated than _just_ adding to the equality list because the run_limit is a property of the JobRunCollection.  I couldn't think of a cleaner way to do this, but it's possible one exists.