### PR TITLE
refactor in preparation for adding the SparkActionRun class

### DIFF
--- a/tests/api/adapter_test.py
+++ b/tests/api/adapter_test.py
@@ -21,8 +21,8 @@ from tron.api.adapter import JobRunAdapter
 from tron.api.adapter import ReprAdapter
 from tron.api.adapter import RunAdapter
 from tron.core import actiongraph
-from tron.core import actionrun
 from tron.core import job
+from tron.core.actionrun import base as actionrun
 
 
 class MockAdapter(ReprAdapter):

--- a/tests/api/controller_test.py
+++ b/tests/api/controller_test.py
@@ -9,8 +9,8 @@ from tron.api.controller import JobCollectionController
 from tron.api.controller import UnknownCommandError
 from tron.config import ConfigError
 from tron.config import manager
-from tron.core import actionrun
 from tron.core import jobrun
+from tron.core.actionrun import base as actionrun
 from tron.core.job_collection import JobCollection
 from tron.core.job_scheduler import JobScheduler
 

--- a/tests/command_context_test.py
+++ b/tests/command_context_test.py
@@ -13,9 +13,9 @@ from testifycompat import TestCase
 from tron import command_context
 from tron import node
 from tron import scheduler
-from tron.core import actionrun
 from tron.core import job
 from tron.core import jobrun
+from tron.core.actionrun import base as actionrun
 from tron.core.jobrun import JobRunCollection
 
 

--- a/tests/commands/display_test.py
+++ b/tests/commands/display_test.py
@@ -10,8 +10,8 @@ from tron.commands import display
 from tron.commands.display import DisplayActionRuns
 from tron.commands.display import DisplayJobRuns
 from tron.commands.display import DisplayJobs
-from tron.core import actionrun
 from tron.core import job
+from tron.core.actionrun import base as actionrun
 
 
 class TestDisplayJobRuns(TestCase):

--- a/tests/core/actionrun/conftest.py
+++ b/tests/core/actionrun/conftest.py
@@ -1,0 +1,13 @@
+import shutil
+import tempfile
+
+import pytest
+
+from tron.serialize import filehandler
+
+
+@pytest.fixture
+def output_path():
+    output_path = filehandler.OutputPath(tempfile.mkdtemp())
+    yield output_path
+    shutil.rmtree(output_path.base, ignore_errors=True)

--- a/tests/core/actionrun/mesosactionrun_test.py
+++ b/tests/core/actionrun/mesosactionrun_test.py
@@ -1,0 +1,249 @@
+import mock
+import pytest
+
+from tron import actioncommand
+from tron import node
+from tron.config.schema import ConfigConstraint
+from tron.config.schema import ConfigParameter
+from tron.config.schema import ConfigVolume
+from tron.config.schema import ExecutorTypes
+from tron.core.actionrun.mesos import ActionCommand
+from tron.core.actionrun.mesos import ActionRun
+from tron.core.actionrun.mesos import MesosActionRun
+
+
+class TestMesosActionRun:
+    @pytest.fixture(autouse=True)
+    def setup_action_run(self):
+        self.output_path = mock.MagicMock()
+        self.command = "do the command"
+        self.extra_volumes = [ConfigVolume('/mnt/foo', '/mnt/foo', 'RO')]
+        self.constraints = [ConfigConstraint('an attr', 'an op', 'a val')]
+        self.docker_parameters = [ConfigParameter('init', 'true')]
+        self.other_task_kwargs = {
+            'cpus': 1,
+            'mem': 50,
+            'disk': 42,
+            'docker_image': 'container:v2',
+            'env': {
+                'TESTING': 'true',
+                'TRON_JOB_NAMESPACE': 'mynamespace',
+                'TRON_JOB_NAME': 'myjob',
+                'TRON_RUN_NUM': '42',
+                'TRON_ACTION': 'action_name',
+            },
+        }
+        self.action_run = MesosActionRun(
+            job_run_id="mynamespace.myjob.42",
+            name="action_name",
+            node=mock.create_autospec(node.Node),
+            rendered_command=self.command,
+            output_path=self.output_path,
+            executor=ExecutorTypes.mesos.value,
+            extra_volumes=self.extra_volumes,
+            constraints=self.constraints,
+            docker_parameters=self.docker_parameters,
+            **self.other_task_kwargs
+        )
+
+    @mock.patch('tron.core.actionrun.mesos.filehandler', autospec=True)
+    @mock.patch('tron.core.actionrun.mesos.MesosClusterRepository', autospec=True)
+    def test_submit_command(self, mock_cluster_repo, mock_filehandler):
+        serializer = mock_filehandler.OutputStreamSerializer.return_value
+        # submit_command should reset the task_id
+        self.action_run.mesos_task_id = 'last_attempt'
+        with mock.patch.object(
+            self.action_run,
+            'watch',
+            autospec=True,
+        ) as mock_watch:
+            self.action_run.submit_command()
+
+            mock_get_cluster = mock_cluster_repo.get_cluster
+            mock_get_cluster.assert_called_once_with()
+
+            mock_get_cluster.return_value.create_task.assert_called_once_with(
+                action_run_id=self.action_run.id,
+                command=self.command,
+                serializer=serializer,
+                task_id=None,
+                extra_volumes=[e._asdict() for e in self.extra_volumes],
+                constraints=[['an attr', 'an op', 'a val']],
+                docker_parameters=[{'key': 'init', 'value': 'true'}],
+                **self.other_task_kwargs
+            )
+            task = mock_get_cluster.return_value.create_task.return_value
+            mock_get_cluster.return_value.submit.assert_called_once_with(task)
+            mock_watch.assert_called_once_with(task)
+            assert self.action_run.mesos_task_id == task.get_mesos_id.return_value
+
+        mock_filehandler.OutputStreamSerializer.assert_called_with(
+            self.action_run.output_path,
+        )
+
+    @mock.patch('tron.core.actionrun.mesos.filehandler', autospec=True)
+    @mock.patch('tron.core.actionrun.mesos.MesosClusterRepository', autospec=True)
+    def test_submit_command_task_none(
+        self, mock_cluster_repo, mock_filehandler
+    ):
+        # Task is None if Mesos is disabled
+        mock_get_cluster = mock_cluster_repo.get_cluster
+        mock_get_cluster.return_value.create_task.return_value = None
+        self.action_run.submit_command()
+
+        mock_get_cluster.assert_called_once_with()
+        assert mock_get_cluster.return_value.submit.call_count == 0
+        assert self.action_run.is_failed
+
+    @mock.patch('tron.core.actionrun.mesos.filehandler', autospec=True)
+    @mock.patch('tron.core.actionrun.mesos.MesosClusterRepository', autospec=True)
+    def test_recover(self, mock_cluster_repo, mock_filehandler):
+        self.action_run.machine.state = ActionRun.UNKNOWN
+        self.action_run.mesos_task_id = 'my_mesos_id'
+        serializer = mock_filehandler.OutputStreamSerializer.return_value
+        with mock.patch.object(
+            self.action_run,
+            'watch',
+            autospec=True,
+        ) as mock_watch:
+            assert self.action_run.recover()
+
+            mock_get_cluster = mock_cluster_repo.get_cluster
+            mock_get_cluster.assert_called_once_with()
+            mock_get_cluster.return_value.create_task.assert_called_once_with(
+                action_run_id=self.action_run.id,
+                command=self.command,
+                serializer=serializer,
+                task_id='my_mesos_id',
+                extra_volumes=[e._asdict() for e in self.extra_volumes],
+                constraints=[['an attr', 'an op', 'a val']],
+                docker_parameters=[{'key': 'init', 'value': 'true'}],
+                **self.other_task_kwargs
+            ), mock_get_cluster.return_value.create_task.calls
+            task = mock_get_cluster.return_value.create_task.return_value
+            mock_get_cluster.return_value.recover.assert_called_once_with(task)
+            mock_watch.assert_called_once_with(task)
+
+        assert self.action_run.is_running
+        assert self.action_run.end_time is None
+        mock_filehandler.OutputStreamSerializer.assert_called_with(
+            self.action_run.output_path,
+        )
+
+    @mock.patch('tron.core.actionrun.mesos.filehandler', autospec=True)
+    @mock.patch('tron.core.actionrun.mesos.MesosClusterRepository', autospec=True)
+    def test_recover_done_no_change(self, mock_cluster_repo, mock_filehandler):
+        self.action_run.machine.state = ActionRun.SUCCEEDED
+        self.action_run.mesos_task_id = 'my_mesos_id'
+
+        assert not self.action_run.recover()
+        assert mock_cluster_repo.get_cluster.call_count == 0
+        assert self.action_run.is_succeeded
+
+    @mock.patch('tron.core.actionrun.mesos.filehandler', autospec=True)
+    @mock.patch('tron.core.actionrun.mesos.MesosClusterRepository', autospec=True)
+    def test_recover_no_mesos_task_id(
+        self, mock_cluster_repo, mock_filehandler
+    ):
+        self.action_run.machine.state = ActionRun.UNKNOWN
+        self.action_run.mesos_task_id = None
+
+        assert not self.action_run.recover()
+        assert mock_cluster_repo.get_cluster.call_count == 0
+        assert self.action_run.is_unknown
+        assert self.action_run.end_time is not None
+
+    @mock.patch('tron.core.actionrun.mesos.filehandler', autospec=True)
+    @mock.patch('tron.core.actionrun.mesos.MesosClusterRepository', autospec=True)
+    def test_recover_task_none(self, mock_cluster_repo, mock_filehandler):
+        self.action_run.machine.state = ActionRun.UNKNOWN
+        self.action_run.mesos_task_id = 'my_mesos_id'
+        # Task is None if Mesos is disabled
+        mock_get_cluster = mock_cluster_repo.get_cluster
+        mock_get_cluster.return_value.create_task.return_value = None
+        assert not self.action_run.recover()
+
+        mock_get_cluster.assert_called_once_with()
+        assert self.action_run.is_unknown
+        assert mock_get_cluster.return_value.recover.call_count == 0
+        assert self.action_run.end_time is not None
+
+    @mock.patch('tron.core.actionrun.mesos.MesosClusterRepository', autospec=True)
+    def test_kill_task(self, mock_cluster_repo):
+        mock_get_cluster = mock_cluster_repo.get_cluster
+        self.action_run.mesos_task_id = 'fake_task_id'
+        self.action_run.machine.state = ActionRun.RUNNING
+
+        self.action_run.kill()
+        mock_get_cluster.return_value.kill.assert_called_once_with(
+            self.action_run.mesos_task_id
+        )
+
+    @mock.patch('tron.core.actionrun.mesos.MesosClusterRepository', autospec=True)
+    def test_kill_task_no_task_id(self, mock_cluster_repo):
+        self.action_run.machine.state = ActionRun.RUNNING
+        error_message = self.action_run.kill()
+        assert error_message == "Error: Can't find task id for the action."
+
+    @mock.patch('tron.core.actionrun.mesos.MesosClusterRepository', autospec=True)
+    def test_stop_task(self, mock_cluster_repo):
+        mock_get_cluster = mock_cluster_repo.get_cluster
+        self.action_run.mesos_task_id = 'fake_task_id'
+        self.action_run.machine.state = ActionRun.RUNNING
+
+        self.action_run.stop()
+        mock_get_cluster.return_value.kill.assert_called_once_with(
+            self.action_run.mesos_task_id
+        )
+
+    @mock.patch('tron.core.actionrun.mesos.MesosClusterRepository', autospec=True)
+    def test_stop_task_no_task_id(self, mock_cluster_repo):
+        self.action_run.machine.state = ActionRun.RUNNING
+        error_message = self.action_run.stop()
+        assert error_message == "Error: Can't find task id for the action."
+
+    def test_handler_exiting_unknown(self):
+        self.action_run.action_command = mock.create_autospec(
+            actioncommand.ActionCommand,
+            exit_status=None,
+        )
+        self.action_run.machine.transition('start')
+        self.action_run.machine.transition('started')
+        assert self.action_run.handler(
+            self.action_run.action_command,
+            ActionCommand.EXITING,
+        )
+        assert self.action_run.is_unknown
+        assert self.action_run.exit_status is None
+        assert self.action_run.end_time is not None
+
+    def test_handler_exiting_unknown_retry(self):
+        self.action_run.action_command = mock.create_autospec(
+            actioncommand.ActionCommand,
+            exit_status=None,
+        )
+        self.action_run.retries_remaining = 1
+        self.action_run.exit_statuses = []
+        self.action_run.start = mock.Mock()
+
+        self.action_run.machine.transition('start')
+        self.action_run.machine.transition('started')
+        assert self.action_run.handler(
+            self.action_run.action_command,
+            ActionCommand.EXITING,
+        )
+        assert self.action_run.retries_remaining == 0
+        assert not self.action_run.is_unknown
+        assert self.action_run.start.call_count == 1
+
+    def test_handler_exiting_failstart_failed(self):
+        self.action_run.action_command = mock.create_autospec(
+            actioncommand.ActionCommand,
+            exit_status=1,
+        )
+        self.action_run.machine.transition('start')
+        assert self.action_run.handler(
+            self.action_run.action_command,
+            ActionCommand.FAILSTART,
+        )
+        assert self.action_run.is_failed

--- a/tests/core/actionrun/sshactionrun_test.py
+++ b/tests/core/actionrun/sshactionrun_test.py
@@ -1,0 +1,226 @@
+import mock
+import pytest
+
+from tron import actioncommand
+from tron import node
+from tron.actioncommand import SubprocessActionRunnerFactory
+from tron.core.actionrun.base import ActionRun
+from tron.core.actionrun.ssh import ActionCommand
+from tron.core.actionrun.ssh import INITIAL_RECOVER_DELAY
+from tron.core.actionrun.ssh import MAX_RECOVER_TRIES
+from tron.core.actionrun.ssh import SSHActionRun
+
+
+class TestSSHActionRun:
+    @pytest.fixture(autouse=True)
+    def setup_action_run(self, output_path):
+        self.action_runner = mock.create_autospec(
+            actioncommand.NoActionRunnerFactory,
+        )
+        self.command = "do command {actionname}"
+        self.action_run = SSHActionRun(
+            job_run_id="job_name.5",
+            name="action_name",
+            node=mock.create_autospec(node.Node),
+            bare_command=self.command,
+            output_path=output_path,
+            action_runner=self.action_runner,
+        )
+
+    def test_start_node_error(self):
+        def raise_error(c):
+            raise node.Error("The error")
+
+        self.action_run.node = mock.MagicMock()
+        self.action_run.node.submit_command.side_effect = raise_error
+        self.action_run.machine.transition('ready')
+        assert not self.action_run.start()
+        assert self.action_run.exit_status == -2
+        assert self.action_run.is_failed
+
+    @mock.patch('tron.core.actionrun.ssh.filehandler', autospec=True)
+    def test_build_action_command(self, mock_filehandler):
+        self.action_run.watch = mock.MagicMock()
+        serializer = mock_filehandler.OutputStreamSerializer.return_value
+        action_command = self.action_run.build_action_command()
+        assert action_command == self.action_run.action_command
+        assert action_command == self.action_runner.create.return_value
+        self.action_runner.create.assert_called_with(
+            self.action_run.id,
+            self.action_run.command,
+            serializer,
+        )
+        mock_filehandler.OutputStreamSerializer.assert_called_with(
+            self.action_run.output_path,
+        )
+        self.action_run.watch.assert_called_with(action_command)
+
+    def test_handler_running(self):
+        self.action_run.build_action_command()
+        self.action_run.machine.transition('start')
+        assert self.action_run.handler(
+            self.action_run.action_command,
+            ActionCommand.RUNNING,
+        )
+        assert self.action_run.is_running
+
+    def test_handler_failstart(self):
+        self.action_run.build_action_command()
+        assert self.action_run.handler(
+            self.action_run.action_command,
+            ActionCommand.FAILSTART,
+        )
+        assert self.action_run.is_failed
+
+    def test_handler_exiting_fail(self):
+        self.action_run.build_action_command()
+        self.action_run.action_command.exit_status = -1
+        self.action_run.machine.transition('start')
+        assert self.action_run.handler(
+            self.action_run.action_command,
+            ActionCommand.EXITING,
+        )
+        assert self.action_run.is_failed
+        assert self.action_run.exit_status == -1
+
+    def test_handler_exiting_success(self):
+        self.action_run.build_action_command()
+        self.action_run.action_command.exit_status = 0
+        self.action_run.machine.transition('start')
+        self.action_run.machine.transition('started')
+        assert self.action_run.handler(
+            self.action_run.action_command,
+            ActionCommand.EXITING,
+        )
+        assert self.action_run.is_succeeded
+        assert self.action_run.exit_status == 0
+
+    def test_handler_exiting_failunknown(self):
+        self.action_run.action_command = mock.create_autospec(
+            actioncommand.ActionCommand,
+            exit_status=None,
+        )
+        self.action_run.machine.transition('start')
+        self.action_run.machine.transition('started')
+        assert self.action_run.handler(
+            self.action_run.action_command,
+            ActionCommand.EXITING,
+        )
+        assert self.action_run.is_unknown
+        assert self.action_run.exit_status is None
+        assert self.action_run.end_time is not None
+
+    def test_handler_unhandled(self):
+        self.action_run.build_action_command()
+        assert self.action_run.handler(
+            self.action_run.action_command,
+            ActionCommand.PENDING,
+        ) is None
+        assert self.action_run.is_scheduled
+
+    def test_recover_no_action_runner(self):
+        # Default setup has no action runner
+        assert not self.action_run.recover()
+
+
+class TestSSHActionRunRecover:
+    @pytest.fixture(autouse=True)
+    def setup_action_run(self, output_path):
+        self.action_runner = SubprocessActionRunnerFactory(
+            status_path='/tmp/foo',
+            exec_path='/bin/foo',
+        )
+        self.command = "do command {actionname}"
+        self.action_run = SSHActionRun(
+            job_run_id="job_name.5",
+            name="action_name",
+            node=mock.create_autospec(node.Node),
+            bare_command=self.command,
+            output_path=output_path,
+            action_runner=self.action_runner,
+        )
+
+    def test_recover_incorrect_state(self):
+        # Should return falsy if not UNKNOWN.
+        self.action_run.machine.state = ActionRun.FAILED
+        assert not self.action_run.recover()
+
+    def test_recover_action_runner(self):
+        self.action_run.end_time = 1000
+        self.action_run.exit_status = 0
+        self.action_run.machine.state = ActionRun.UNKNOWN
+        assert self.action_run.recover()
+        assert self.action_run.machine.state == ActionRun.RUNNING
+        assert self.action_run.end_time is None
+        assert self.action_run.exit_status is None
+        self.action_run.node.submit_command.assert_called_once()
+
+        # Check recovery command
+        submit_args = self.action_run.node.submit_command.call_args[0]
+        assert len(submit_args) == 1
+        recovery_command = submit_args[0]
+        assert recovery_command.command == '/bin/foo/recover_batch.py /tmp/foo/job_name.5.action_name/status'
+        assert recovery_command.start_time is not None  # already started
+
+    @mock.patch('tron.core.actionrun.ssh.reactor', autospec=True)
+    def test_handler_exiting_failunknown(self, mock_reactor):
+        self.action_run.action_command = mock.create_autospec(
+            actioncommand.ActionCommand,
+            exit_status=None,
+        )
+        self.action_run.machine.transition('start')
+        self.action_run.machine.transition('started')
+        delay_deferred = self.action_run.handler(
+            self.action_run.action_command,
+            ActionCommand.EXITING,
+        )
+        assert delay_deferred == mock_reactor.callLater.return_value
+        assert self.action_run.is_running
+        assert self.action_run.exit_status is None
+        assert self.action_run.end_time is None
+
+        call_args = mock_reactor.callLater.call_args[0]
+        assert call_args[0] == INITIAL_RECOVER_DELAY
+        assert call_args[1] == self.action_run.submit_recovery_command
+
+        # Check recovery run
+        recovery_run = call_args[2]
+        assert 'recovery' in recovery_run.name
+        assert isinstance(recovery_run, SSHActionRun)
+        # Recovery run should not be recovering itself, parent run handles its unknown status
+        assert recovery_run.recover() is None
+
+        # Check command
+        recovery_command = call_args[3]
+        assert recovery_command.command == '/bin/foo/recover_batch.py /tmp/foo/job_name.5.action_name/status'
+        assert recovery_command.start_time is not None  # already started
+
+    @mock.patch('tron.core.actionrun.ssh.SSHActionRun.do_recover', autospec=True)
+    @mock.patch('tron.core.actionrun.ssh.reactor', autospec=True)
+    def test_handler_exiting_failunknown_max_retries(self, mock_reactor, mock_do_recover):
+        self.action_run.action_command = mock.create_autospec(
+            actioncommand.ActionCommand,
+            exit_status=None,
+        )
+        self.action_run.machine.transition('start')
+        self.action_run.machine.transition('started')
+
+        def exit_unknown(*args, **kwargs):
+            self.action_run.handler(
+                self.action_run.action_command,
+                ActionCommand.EXITING,
+            )
+        # Each time do_recover is called, end up exiting unknown again
+        mock_do_recover.side_effect = exit_unknown
+
+        # Start the cycle
+        exit_unknown()
+
+        assert mock_do_recover.call_count == MAX_RECOVER_TRIES
+        last_call = mock_do_recover.call_args
+        expected_delay = INITIAL_RECOVER_DELAY * (3 ** (MAX_RECOVER_TRIES - 1))
+        assert last_call == mock.call(self.action_run, delay=expected_delay)
+
+        assert self.action_run.is_unknown
+        assert self.action_run.exit_status is None
+        assert self.action_run.end_time is not None

--- a/tests/core/job_scheduler_test.py
+++ b/tests/core/job_scheduler_test.py
@@ -9,7 +9,7 @@ from tests import testingutils
 from tests.assertions import assert_length
 from tron import actioncommand
 from tron.core import job
-from tron.core.actionrun import ActionRun
+from tron.core.actionrun.base import ActionRun
 from tron.core.job_scheduler import JobScheduler
 from tron.core.job_scheduler import JobSchedulerFactory
 

--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -16,7 +16,7 @@ from tron import actioncommand
 from tron import node
 from tron.core import job
 from tron.core import jobrun
-from tron.core.actionrun import ActionRun
+from tron.core.actionrun.base import ActionRun
 from tron.core.job_scheduler import JobScheduler
 
 

--- a/tests/core/jobrun_test.py
+++ b/tests/core/jobrun_test.py
@@ -17,9 +17,9 @@ from tron import actioncommand
 from tron import node
 from tron.core import action
 from tron.core import actiongraph
-from tron.core import actionrun
 from tron.core import job
 from tron.core import jobrun
+from tron.core.actionrun import base as actionrun
 from tron.serialize import filehandler
 
 
@@ -686,7 +686,7 @@ class TestJobRunStateTransitions:
     @pytest.fixture
     def mock_event_bus(self):
         with mock.patch(
-            'tron.core.actionrun.EventBus',
+            'tron.core.actionrun.base.EventBus',
             autospec=True,
         ) as mock_event_bus:
             mock_event_bus.has_event.return_value = True

--- a/tests/core/recovery_test.py
+++ b/tests/core/recovery_test.py
@@ -8,9 +8,9 @@ from testifycompat import setup
 from testifycompat import TestCase
 from tron.actioncommand import NoActionRunnerFactory
 from tron.actioncommand import SubprocessActionRunnerFactory
-from tron.core.actionrun import ActionRun
-from tron.core.actionrun import MesosActionRun
-from tron.core.actionrun import SSHActionRun
+from tron.core.actionrun.base import ActionRun
+from tron.core.actionrun.mesos import MesosActionRun
+from tron.core.actionrun.ssh import SSHActionRun
 from tron.core.recovery import filter_action_runs_needing_recovery
 from tron.core.recovery import launch_recovery_actionruns_for_job_runs
 from tron.utils import timeutils

--- a/tests/node_test.py
+++ b/tests/node_test.py
@@ -17,8 +17,8 @@ from tests.testingutils import autospec_method
 from tron import actioncommand
 from tron import node
 from tron import ssh
+from tron.actioncommand import ActionCommand
 from tron.config import schema
-from tron.core import actionrun
 from tron.serialize import filehandler
 
 
@@ -164,7 +164,7 @@ class TestNode(TestCase):
     def test_output_logging(self):
         test_node = build_node()
         serializer = mock.create_autospec(filehandler.FileHandleManager)
-        action_cmd = actionrun.ActionCommand("test", "false", serializer)
+        action_cmd = ActionCommand("test", "false", serializer)
 
         test_node.connection = self.TestConnection()
         test_node.run_states = {action_cmd.id: mock.Mock(state=0)}

--- a/tests/trond_test.py
+++ b/tests/trond_test.py
@@ -11,7 +11,7 @@ import pytest
 from testifycompat import assert_equal
 from testifycompat import assert_gt
 from tests import sandbox
-from tron.core import actionrun
+from tron.core.actionrun import base as actionrun
 
 BASIC_CONFIG = """
 ssh_options:

--- a/tron/commands/display.py
+++ b/tron/commands/display.py
@@ -8,8 +8,8 @@ import contextlib
 from functools import partial
 from operator import itemgetter
 
-from tron.core import actionrun
 from tron.core import job
+from tron.core.actionrun import base as actionrun
 from tron.utils import maybe_encode
 
 

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -226,7 +226,7 @@ StatePersistenceTypes = Enum(
     'StatePersistenceTypes', dict(shelve='shelve', yaml='yaml', dynamodb='dynamodb')
 )
 
-ExecutorTypes = Enum('ExecutorTypes', dict(ssh='ssh', mesos='mesos'))
+ExecutorTypes = Enum('ExecutorTypes', dict(ssh='ssh', mesos='mesos', spark='spark'))
 
 ActionRunnerTypes = Enum('ActionRunnerTypes', dict(none='none', subprocess='subprocess'))
 

--- a/tron/core/actionrun/mesos.py
+++ b/tron/core/actionrun/mesos.py
@@ -1,0 +1,156 @@
+"""
+ tron.core.actionrun.mesos
+"""
+import logging
+
+from tron.actioncommand import ActionCommand
+from tron.bin.action_runner import build_environment
+from tron.core.actionrun.base import ActionRun
+from tron.mesos import MesosClusterRepository
+from tron.serialize import filehandler
+from tron.utils.observer import Observer
+
+log = logging.getLogger(__name__)
+
+
+class MesosActionRun(ActionRun, Observer):
+    """An ActionRun that executes the command on a Mesos cluster.
+    """
+    def _create_mesos_task(self, mesos_cluster, serializer, task_id=None):
+        return mesos_cluster.create_task(
+            action_run_id=self.id,
+            command=self.command,
+            cpus=self.cpus,
+            mem=self.mem,
+            disk=1024.0 if self.disk is None else self.disk,
+            constraints=[[c.attribute, c.operator, c.value]
+                         for c in self.constraints],
+            docker_image=self.docker_image,
+            docker_parameters=[e._asdict() for e in self.docker_parameters],
+            env=build_environment(original_env=self.env, run_id=self.id),
+            extra_volumes=[e._asdict() for e in self.extra_volumes],
+            serializer=serializer,
+            task_id=task_id,
+        )
+
+    def submit_command(self):
+        serializer = filehandler.OutputStreamSerializer(self.output_path)
+        mesos_cluster = MesosClusterRepository.get_cluster()
+        task = self._create_mesos_task(mesos_cluster, serializer)
+        if not task:  # Mesos is disabled
+            self.fail(self.EXIT_MESOS_DISABLED)
+            return
+
+        self.mesos_task_id = task.get_mesos_id()
+
+        # Watch before submitting, in case submit causes a transition
+        self.watch(task)
+        mesos_cluster.submit(task)
+        return task
+
+    def recover(self):
+        if not self.machine.check('running'):
+            log.error(
+                f'{self} unable to transition from {self.machine.state}'
+                'to running for recovery'
+            )
+            return
+
+        if self.mesos_task_id is None:
+            log.error(f'{self} no task ID, cannot recover')
+            self.fail_unknown()
+            return
+
+        log.info(f'{self} recovering Mesos run')
+
+        serializer = filehandler.OutputStreamSerializer(self.output_path)
+        mesos_cluster = MesosClusterRepository.get_cluster()
+        task = self._create_mesos_task(
+            mesos_cluster,
+            serializer,
+            self.mesos_task_id,
+        )
+        if not task:
+            log.warning(
+                f'{self} cannot recover, Mesos is disabled or '
+                f'invalid task ID {self.mesos_task_id!r}'
+            )
+            self.fail_unknown()
+            return
+
+        self.watch(task)
+        mesos_cluster.recover(task)
+
+        # Reset status
+        self.exit_status = None
+        self.end_time = None
+        self.transition_and_notify('running')
+
+        return task
+
+    def stop(self):
+        if self.retries_remaining is not None:
+            self.retries_remaining = -1
+
+        if self.cancel_delay():
+            return
+
+        return self._kill_mesos_task()
+
+    def kill(self, final=True):
+        if self.retries_remaining is not None and final:
+            self.retries_remaining = -1
+
+        if self.cancel_delay():
+            return
+
+        return self._kill_mesos_task()
+
+    def _kill_mesos_task(self):
+        msgs = []
+        if not self.is_active:
+            msgs.append(
+                f'Action is {self.state}, not running. Continuing anyway.'
+            )
+
+        mesos_cluster = MesosClusterRepository.get_cluster()
+        if self.mesos_task_id is None:
+            msgs.append("Error: Can't find task id for the action.")
+        else:
+            msgs.append(f"Sending kill for {self.mesos_task_id}...")
+            succeeded = mesos_cluster.kill(self.mesos_task_id)
+            if succeeded:
+                msgs.append(
+                    "Sent! It can take up to docker_stop_timeout (current setting is 2 mins) to stop."
+                )
+            else:
+                msgs.append(
+                    "Error while sending kill request. Please try again."
+                )
+
+        return '\n'.join(msgs)
+
+    def handle_action_command_state_change(self, action_command, event):
+        """Observe ActionCommand state changes."""
+        log.debug(
+            f"{self} action_command state change: {action_command.state}"
+        )
+
+        if event == ActionCommand.RUNNING:
+            return self.transition_and_notify('started')
+
+        if event == ActionCommand.FAILSTART:
+            return self._exit_unsuccessful(action_command.exit_status)
+
+        if event == ActionCommand.EXITING:
+            if action_command.exit_status is None:
+                # This is different from SSHActionRun
+                # Allows retries to happen, if configured
+                return self._exit_unsuccessful(None)
+
+            if not action_command.exit_status:
+                return self.success()
+
+            return self._exit_unsuccessful(action_command.exit_status)
+
+    handler = handle_action_command_state_change

--- a/tron/core/actionrun/ssh.py
+++ b/tron/core/actionrun/ssh.py
@@ -1,0 +1,182 @@
+"""
+ tron.core.actionrun.ssh
+"""
+import logging
+
+from twisted.internet import reactor
+
+from tron import node
+from tron.actioncommand import ActionCommand
+from tron.actioncommand import NoActionRunnerFactory
+from tron.core.actionrun.base import ActionRun
+from tron.serialize import filehandler
+from tron.utils.observer import Observer
+
+log = logging.getLogger(__name__)
+MAX_RECOVER_TRIES = 5
+INITIAL_RECOVER_DELAY = 3
+
+
+class SSHActionRun(ActionRun, Observer):
+    """An ActionRun that executes the command on a node through SSH.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(SSHActionRun, self).__init__(*args, **kwargs)
+        self.recover_tries = 0
+
+    def submit_command(self):
+        action_command = self.build_action_command()
+        try:
+            self.node.submit_command(action_command)
+        except node.Error as e:
+            log.warning("Failed to start %s: %r", self.id, e)
+            self._exit_unsuccessful(self.EXIT_NODE_ERROR)
+            return
+        return True
+
+    def stop(self):
+        if self.retries_remaining is not None:
+            self.retries_remaining = -1
+
+        if self.cancel_delay():
+            return
+
+        stop_command = self.action_runner.build_stop_action_command(
+            self.id,
+            'terminate',
+        )
+        self.node.submit_command(stop_command)
+
+    def kill(self, final=True):
+        if self.retries_remaining is not None and final:
+            self.retries_remaining = -1
+
+        if self.cancel_delay():
+            return
+
+        kill_command = self.action_runner.build_stop_action_command(
+            self.id,
+            'kill',
+        )
+        self.node.submit_command(kill_command)
+
+    def build_action_command(self):
+        """Create a new ActionCommand instance to send to the node."""
+        serializer = filehandler.OutputStreamSerializer(self.output_path)
+        self.action_command = self.action_runner.create(
+            id=self.id,
+            command=self.command,
+            serializer=serializer,
+        )
+        self.watch(self.action_command)
+        return self.action_command
+
+    def handle_unknown(self):
+        if isinstance(self.action_runner, NoActionRunnerFactory):
+            log.info(
+                f"Unable to recover action_run {self.id}: "
+                "action_run has no action_runner"
+            )
+            return self.fail_unknown()
+
+        if self.recover_tries >= MAX_RECOVER_TRIES:
+            log.info(f'Reached maximum tries {MAX_RECOVER_TRIES} for recovering {self.id}')
+            return self.fail_unknown()
+
+        desired_delay = INITIAL_RECOVER_DELAY * (3 ** self.recover_tries)
+        self.recover_tries += 1
+        log.info(f'Starting try #{self.recover_tries} to recover {self.id}, waiting {desired_delay}')
+        return self.do_recover(delay=desired_delay)
+
+    def recover(self):
+        log.info(f"Creating recovery run for actionrun {self.id}")
+        if isinstance(self.action_runner, NoActionRunnerFactory):
+            log.info(
+                f"Unable to recover action_run {self.id}: "
+                "action_run has no action_runner"
+            )
+            return None
+
+        if not self.machine.check('running'):
+            log.error(
+                f'Unable to transition action run {self.id} '
+                f'from {self.machine.state} to running. '
+                f'Only UNKNOWN actions can be recovered. '
+            )
+            return None
+
+        return self.do_recover(delay=0)
+
+    def do_recover(self, delay):
+        recovery_command = f"{self.action_runner.exec_path}/recover_batch.py {self.action_runner.status_path}/{self.id}/status"
+
+        # Might not need a separate action run
+        # Using for the separate name
+        recovery_run = SSHActionRun(
+            job_run_id=self.job_run_id,
+            name=f"recovery-{self.id}",
+            node=self.node,
+            bare_command=recovery_command,
+            output_path=self.output_path,
+        )
+        recovery_action_command = recovery_run.build_action_command()
+        recovery_action_command.write_stdout(
+            f"Recovering action run {self.id}",
+        )
+        # Put action command in "running" state so if it fails to connect
+        # and exits with no exit code, the real action run will not retry.
+        recovery_action_command.started()
+
+        # this line is where the magic happens.
+        # the action run watches another actioncommand,
+        # and updates its internal state according to its result.
+        self.watch(recovery_action_command)
+
+        self.exit_status = None
+        self.end_time = None
+        self.machine.transition('running')
+
+        # Still want the action to appear running while we're waiting to submit the recovery
+        # So we do the delay at the end, after the transition to 'running' above
+        if not delay:
+            return self.submit_recovery_command(recovery_run, recovery_action_command)
+        else:
+            return reactor.callLater(delay, self.submit_recovery_command, recovery_run, recovery_action_command)
+
+    def submit_recovery_command(self, recovery_run, recovery_action_command):
+        log.info(
+            f"Submitting recovery job with command {recovery_action_command.command} "
+            f"to node {recovery_run.node}"
+        )
+        try:
+            deferred = recovery_run.node.submit_command(recovery_action_command)
+            deferred.addCallback(
+                lambda x: log.info(f"Completed recovery run {recovery_run.id}")
+            )
+            return True
+        except node.Error as e:
+            log.warning(f"Failed to submit recovery for {self.id}: {e!r}")
+
+    def handle_action_command_state_change(self, action_command, event):
+        """Observe ActionCommand state changes."""
+        log.debug(
+            f"{self} action_command state change: {action_command.state}"
+        )
+
+        if event == ActionCommand.RUNNING:
+            return self.transition_and_notify('started')
+
+        if event == ActionCommand.FAILSTART:
+            return self._exit_unsuccessful(self.EXIT_NODE_ERROR)
+
+        if event == ActionCommand.EXITING:
+            if action_command.exit_status is None:
+                return self.handle_unknown()
+
+            if not action_command.exit_status:
+                return self.success()
+
+            return self._exit_unsuccessful(action_command.exit_status)
+
+    handler = handle_action_command_state_change

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -3,7 +3,7 @@ import logging
 from tron import command_context
 from tron import node
 from tron.core import jobrun
-from tron.core.actionrun import ActionRun
+from tron.core.actionrun.base import ActionRun
 from tron.serialize import filehandler
 from tron.utils import maybe_decode
 from tron.utils.observer import Observable

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -9,8 +9,8 @@ from collections import deque
 import tron.metrics as metrics
 from tron import command_context
 from tron import node
-from tron.core.actionrun import ActionRun
-from tron.core.actionrun import ActionRunFactory
+from tron.core.actionrun.base import ActionRun
+from tron.core.actionrun.base import ActionRunFactory
 from tron.serialize import filehandler
 from tron.utils import maybe_decode
 from tron.utils import next_or_none

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 
 import logging
 
-from tron.core.actionrun import ActionRun
-from tron.core.actionrun import MesosActionRun
-from tron.core.actionrun import SSHActionRun
+from tron.core.actionrun.base import ActionRun
+from tron.core.actionrun.mesos import MesosActionRun
+from tron.core.actionrun.ssh import SSHActionRun
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
As we consider adding more and more executor types to Tron, I don't want to end up in this situation where all of them get dumped in one giant file, so I'm just going to split them out right now.  The only annoying thing here is the circular import, which means we have to import the specific ActionRun classes inside the Factory instead of at the top of the file.