### PR TITLE
Enforce job graph dependency

### DIFF
--- a/dev/config/_manifest.yaml
+++ b/dev/config/_manifest.yaml
@@ -1,1 +1,1 @@
-{MASTER: config/MASTER.yaml}
+MASTER: config/MASTER.yaml

--- a/tests/config/manager_test.py
+++ b/tests/config/manager_test.py
@@ -180,10 +180,14 @@ class TestConfigManager(TestCase):
         assert_equal(mock_remove.call_count, 0)
 
     @mock.patch(
+        'tron.config.manager.JobGraph',
+        autospec=True,
+    )
+    @mock.patch(
         'tron.config.manager.config_parse.ConfigContainer',
         autospec=True,
     )
-    def test_validate_with_fragment(self, mock_config_container):
+    def test_validate_with_fragment(self, mock_config_container, mock_job_graph):
         name = 'the_name'
         name_mapping = {'something': 'content', name: 'old_content'}
         autospec_method(self.manager.get_config_name_mapping)
@@ -192,6 +196,10 @@ class TestConfigManager(TestCase):
         expected_mapping = dict(name_mapping)
         expected_mapping[name] = self.content
         mock_config_container.create.assert_called_with(expected_mapping)
+        mock_job_graph.assert_called_once_with(
+            mock_config_container.create.return_value,
+            should_validate_missing_dependency=True,
+        )
 
     @mock.patch('tron.config.manager.read', autospec=True)
     @mock.patch(

--- a/tests/core/jobgraph_test.py
+++ b/tests/core/jobgraph_test.py
@@ -1,68 +1,87 @@
 from unittest import mock
 
+import pytest
+
 from tron.config.schema import ConfigAction
 from tron.config.schema import ConfigJob
 from tron.core.jobgraph import AdjListEntry
 from tron.core.jobgraph import JobGraph
 
 
+MISSING_DEPENDENCY_ERR_MSG = '''The following actions are dependencies of other actions but missing:
+Action other.job2.action3 is dependency of actions:
+  - MASTER.job3.action5
+Please check if you have deleted/renamed any of them or their containing jobs.'''
+
+
+def _setup_job_graph_config_container():
+    action1 = ConfigAction(
+        name='action1',
+        command='do something',
+    )
+    action2 = ConfigAction(
+        name='action2',
+        command='do something',
+        requires=['action1'],
+    )
+    job1_config = ConfigJob(
+        name='job1',
+        node='default',
+        schedule=mock.Mock(),
+        actions={'action1': action1, 'action2': action2},
+        namespace='MASTER',
+    )
+
+    action3 = ConfigAction(
+        name='action3',
+        command='do something',
+        triggered_by=['MASTER.job1.action2.shortdate.{shortdate}'],
+    )
+    job2_config = ConfigJob(
+        name='job1',
+        node='default',
+        schedule=mock.Mock(),
+        actions={'action3': action3},
+        namespace='other',
+    )
+
+    action4 = ConfigAction(
+        name='action4',
+        command='do something',
+    )
+    action5 = ConfigAction(
+        name='action5',
+        command='do something',
+        requires=['action4'],
+        triggered_by=['other.job2.action3.shortdate.{shortdate}'],
+    )
+    job3_config = ConfigJob(
+        name='job1',
+        node='default',
+        schedule=mock.Mock(),
+        actions={'action4': action4, 'action5': action5},
+        namespace='MASTER',
+    )
+    config_container = mock.Mock()
+    config_container.get_jobs.return_value = {
+        'MASTER.job1': job1_config,
+        'other.job2': job2_config,
+        'MASTER.job3': job3_config,
+    }
+    return config_container
+
+
 class TestJobGraph:
+
     def setup_method(self):
-        action1 = ConfigAction(
-            name='action1',
-            command='do something',
-        )
-        action2 = ConfigAction(
-            name='action2',
-            command='do something',
-            requires=['action1'],
-        )
-        job1_config = ConfigJob(
-            name='job1',
-            node='default',
-            schedule=mock.Mock(),
-            actions={'action1': action1, 'action2': action2},
-            namespace='MASTER',
-        )
+        self.job_graph = JobGraph(_setup_job_graph_config_container(), should_validate_missing_dependency=True)
 
-        action3 = ConfigAction(
-            name='action3',
-            command='do something',
-            triggered_by=['MASTER.job1.action2.shortdate.{shortdate}'],
-        )
-        job2_config = ConfigJob(
-            name='job1',
-            node='default',
-            schedule=mock.Mock(),
-            actions={'action3': action3},
-            namespace='other',
-        )
-
-        action4 = ConfigAction(
-            name='action4',
-            command='do something',
-        )
-        action5 = ConfigAction(
-            name='action5',
-            command='do something',
-            requires=['action4'],
-            triggered_by=['other.job2.action3.shortdate.{shortdate}'],
-        )
-        job3_config = ConfigJob(
-            name='job1',
-            node='default',
-            schedule=mock.Mock(),
-            actions={'action4': action4, 'action5': action5},
-            namespace='MASTER',
-        )
-        config_container = mock.Mock()
-        config_container.get_jobs.return_value = {
-            'MASTER.job1': job1_config,
-            'other.job2': job2_config,
-            'MASTER.job3': job3_config,
-        }
-
-        self.job_graph = JobGraph(config_container)
+    def test_job_graph_missing_dependency(self):
+        missing_dependency_config_container = _setup_job_graph_config_container()
+        missing_dependency_config_container.get_jobs.return_value.pop('other.job2')
+        with pytest.raises(ValueError) as e:
+            JobGraph(missing_dependency_config_container, should_validate_missing_dependency=True)
+        assert str(e.value) == MISSING_DEPENDENCY_ERR_MSG
 
     def test_job_graph(self):
         assert sorted(list(self.job_graph.action_map.keys())) == [

--- a/tron/config/manager.py
+++ b/tron/config/manager.py
@@ -6,6 +6,7 @@ from tron import yaml
 from tron.config import config_parse
 from tron.config import ConfigError
 from tron.config import schema
+from tron.core.jobgraph import JobGraph
 from tron.utils import maybe_decode
 from tron.utils import maybe_encode
 
@@ -128,7 +129,13 @@ class ConfigManager(object):
     def validate_with_fragment(self, name, content):
         name_mapping = self.get_config_name_mapping()
         name_mapping[name] = content
-        config_parse.ConfigContainer.create(name_mapping)
+        try:
+            JobGraph(
+                config_parse.ConfigContainer.create(name_mapping),
+                should_validate_missing_dependency=True,
+            )
+        except ValueError as e:
+            raise ConfigError(str(e))
 
     def get_config_name_mapping(self):
         seq = self.manifest.get_file_mapping().items()


### PR DESCRIPTION
This makes sure user cannot change the name of a job/action which is
triggered/required by other actions and have things silently fail.