### PR TITLE
tron output dir names shortened

### DIFF
--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -58,7 +58,6 @@ class TestJob(TestCase):
             requires=[],
         )
         job_config = mock.Mock(
-            name='ajob',
             node='thenodepool',
             monitoring={
                 "team": "foo",
@@ -71,6 +70,7 @@ class TestJob(TestCase):
             actions={action.name: action},
             cleanup_action=None,
         )
+        job_config.name = 'ajob'  # set this after mock creation to give it a "real" name attribute
         scheduler = 'scheduler_token'
         parent_context = 'parent_context_token'
         output_path = ["base_path"]

--- a/tests/core/jobrun_test.py
+++ b/tests/core/jobrun_test.py
@@ -72,7 +72,7 @@ class TestJobRun(TestCase):
     def test__init__(self):
         assert_equal(self.job_run.job_name, 'jobname')
         assert_equal(self.job_run.run_time, self.run_time)
-        assert str(self.job_run.output_path).endswith(self.job_run.id)
+        assert str(self.job_run.output_path).endswith(str(self.job_run.run_num))
 
     def test_for_job(self):
         run_num = 6

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -98,7 +98,10 @@ class Job(Observable, Observer):
         self.time_zone = time_zone
         self.expected_runtime = expected_runtime
         self.output_path = output_path or filehandler.OutputPath()
-        self.output_path.append(name)
+        # if the name doesn't have a period, the "namespace" and the "job-name" will
+        # be the same, we don't have to worry about a crash here
+        self.output_path.append(name.split('.')[0])  # namespace
+        self.output_path.append(name.split('.')[-1])  # job-name
         self.context = command_context.build_context(self, parent_context)
         self.run_limit = run_limit
         log.info(f'{self} created')

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -57,7 +57,7 @@ class JobRun(Observable, Observer):
         self.run_time = run_time
         self.node = node
         self.output_path = output_path or filehandler.OutputPath()
-        self.output_path.append(self.id)
+        self.output_path.append(str(self.run_num))
         self.action_runs_proxy = None
         self._action_runs = None
         self.action_graph = action_graph


### PR DESCRIPTION
This will prevent issues like DAR-755 from happening again.  In summary, instead of storing things in `/nail/tron/namespace.jobname/namespace.jobname.run_num/namespace.jobname.run_num.actionname/.stdout` (and, when we have to recover an "unknown" action, `/nail/tron/namespace.jobname/namespace.jobname.run_num/namespace.jobname.run_num.actionname/namespace.jobname.run_num.recovery-namespace.jobname.run_num.actionname/.stdout`), we instead store things in `/nail/tron/namespace/jobname/run_num/action_name/.stdout` or `/nail/tron/namespace/jobname/run_num/action_name-recovery/.stdout`.  Aside from keeping us from running into the 255-char pathname limit, this also will help organize things on our Tron masters a little more sanely.

**Testing Done**
* `make test` passes
* manual testing with `make dev`: I confirmed that when we "change over" from the old directory names to the new directory names, we can still recover jobs successfully, and I confirmed that we can still recover successfully once we're totally on the "new way"