### PR TITLE
Skip job graph validation in write_config

### DIFF
--- a/tests/config/manager_test.py
+++ b/tests/config/manager_test.py
@@ -151,6 +151,7 @@ class TestConfigManager(TestCase):
         self.manager.validate_with_fragment.assert_called_with(
             name,
             self.content,
+            should_validate_missing_dependency=False,
         )
 
     def test_write_config_new_name(self):


### PR DESCRIPTION
Tron does not natively support cross-cluster triggers right now. The temporary workaround is using `tronctl publish` to expose cross-cluster triggers. Such dependency is hard to capture and can break tron config writes at pre-write validation step if existing configuration already contains such dependency.
This PR is a short-term fix which turns off job graph validation for config writes. A longer-term solution is adding a flag to rule out certain actions from job graph validation. Eventually we will turn job graph validation back up after tron natively support cross-cluster triggers.