### PR TITLE
Pinning nodes in tronweb dependency graph to make it look sane

### DIFF
--- a/tronweb/coffee/graph.coffee
+++ b/tronweb/coffee/graph.coffee
@@ -50,7 +50,8 @@ class window.GraphView extends Backbone.View
         @node = @svg.selectAll(".node")
             .data(data)
             .enter().append("svg:g")
-            .call(@force.drag)
+            .on("dblclick", (d) -> d.fixed = false)
+            .call(@force.drag().on("dragstart", (d) -> d.fixed = true))
             .attr
                 class: @nodeClass
                 'data-title': (d) -> d.name
@@ -77,7 +78,6 @@ class window.GraphView extends Backbone.View
                 .attr("y2", (d) -> d.target.y)
 
             @node.attr("transform", (d) -> "translate(#{d.x}, #{d.y})")
-
     addNodes: (data) ->
         @force.nodes data
 
@@ -91,7 +91,6 @@ class window.GraphView extends Backbone.View
             .theta(1)
             .linkDistance(@linkDistance)
             .size([width, height])
-
     buildSvg: (height, width) ->
         @svg = d3.select(@el)
             .append("svg")


### PR DESCRIPTION
This change allows users to pin a node, move it around, and unpin the node using double-click. It does so by making the node fixed on `dragstart` event, and making it un-fixed on `dblclick`
It allows users to arrange the tronweb dependency graph to stay **static** once organized, instead of moving to a random state even when users try to organize nodes.
Manually tested by adding more nodes and dependencies in the tronfig and then arranging the tronweb dependency graph.
Note: This change however does not automatically organize the graph to a left-to-right looking DAG, that can be an additional improvement later.
