### PR TITLE
Support keyboard-interactive as an authentication method for ssh

### DIFF
--- a/tron/ssh.py
+++ b/tron/ssh.py
@@ -60,9 +60,8 @@ class SSHAuthOptions(object):
 
 class NoPasswordAuthClient(default.SSHUserAuthClient):
     """Only support passwordless auth."""
-    preferredOrder = ['publickey']
+    preferredOrder = ['publickey', 'keyboard-interactive']
     auth_password = None
-    auth_keyboard_interactive = None
 
 
 class ClientTransport(transport.SSHClientTransport):


### PR DESCRIPTION
Tron uses twisted ssh to do ssh to batch hosts for `executor: ssh` jobs. Tron currently specifies `publickey` as the only supported AuthenticationMethod via the `NoPasswordAuthClient` class definition. As such, tron is unable to ssh to hosts that have been configured to use PAM as a "second factor" beyond ssh keys for ssh authorization. 

For context, I'll give additional details here about how we're using PAM. Typically PAM is used in a way that is actually interactive with the end-user, e.g. the user has to enter a TOTP passcode or type an additional password. This is why PAM requires the `keyboard-interactive` authentication method. In our case, we actually don't require interaction with the end user. Our PAM module evaluates a set of policies to make an `allow` vs `deny` decision based on various factors with no human interaction. Additionally, we have designed this PAM module in a way that  we can configure it to operate in "dry-run" mode where it will unconditionally `allow` the request. 

Unfortunately, `sshd` does not know anything about how the PAM modules are configured (nor should it), so when the client tries to connect without supporting `keyboard-interactive`, sshd short-circuits and rejects the request entirely, thinking that "if you can't do keyboard-interactive things, you won't be able to use PAM". 

We encountered similar issues with various other automated ssh use cases (ansible, cathage, oxidized, cep-1070, deploy-stage, etc) and the fix was the same every time, include `keyboard-interactive` in the list of supported/preferred authentication methods. This is a backwards compatible change and so far hasn't introduced any issues to date, so I think this is a safe change to make. I'd prefer to just make this the new default, rather than doing the plumbing work to make this configurable.