### PR TITLE
TRON-1531: Suppress the need to prompt the user via tty

### DIFF
--- a/tron/ssh.py
+++ b/tron/ssh.py
@@ -68,7 +68,10 @@ class NoPasswordAuthClient(default.SSHUserAuthClient):
         # This works around an issue where some PAM modules that have "keyboard-interactive"
         # but don't actually require any input from the end-user
         if prompts:
-            super().getGenericAnswers(self, name, instruction, prompts)
+            return super().getGenericAnswers(self, name, instruction, prompts)
+
+        # Otherwise, just return an empty defer.succeed to satisfy the contract
+        return defer.succeed([])
 
 
 class ClientTransport(transport.SSHClientTransport):

--- a/tron/ssh.py
+++ b/tron/ssh.py
@@ -63,6 +63,13 @@ class NoPasswordAuthClient(default.SSHUserAuthClient):
     preferredOrder = ['publickey', 'keyboard-interactive']
     auth_password = None
 
+    def getGenericAnswers(self, name, instruction, prompts):
+        # We really only need to get input from the user if there is actually a prompt
+        # This works around an issue where some PAM modules that have "keyboard-interactive"
+        # but don't actually require any input from the end-user
+        if prompts:
+            super().getGenericAnswers(self, name, instruction, prompts)
+
 
 class ClientTransport(transport.SSHClientTransport):
 


### PR DESCRIPTION
if there is no actual reason to prompt the user (e.g. there is a keyboard-interactive authentication mechanism, but there is no actual input taken from the user)

Realistically, this fix should go in twisted itself (in https://github.com/twisted/twisted/blob/trunk/src/twisted/conch/client/default.py#L300), but that is more 🐰🕳️than I want to deal with right now and I'd like to see if this works first before trying to push that upstream.

I think this will work around the issue described in TRON-1531, but really the best way for me to verify that is to try deploying this on one of the tron masters in devc (or hot patching it directly). Open to suggestions for other approaches or other testing strategies. See TRON-1531 for details.