### PR TITLE
Bump requirements to pick up new task_proc version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ addict==2.2.1
 argcomplete==1.9.5
 asn1crypto==1.1.0
 attrs==19.3.0
-Automat==0.7.0
+Automat==20.2.0
 aws-sam-translator==1.15.1
 aws-xray-sdk==2.4.2
 backcall==0.1.0
@@ -23,7 +23,7 @@ docker==4.1.0
 docutils==0.15.2
 ecdsa==0.13.3
 future==0.18.1
-http-parser==0.8.3
+http-parser==0.9.0
 humanize==0.5.1
 hyperlink==19.0.0
 idna==2.8
@@ -56,7 +56,7 @@ pyasn1==0.4.7
 pycparser==2.19
 pyformance==0.4
 Pygments==2.4.2
-PyHamcrest==1.9.0
+PyHamcrest==2.0.2
 pymesos==0.3.9
 pyrsistent==0.15.4
 pysensu-yelp==0.4.1
@@ -71,11 +71,11 @@ responses==0.10.6
 rsa==4.0
 s3transfer==0.2.1
 setuptools==41.4.0
-six==1.13.0
+six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.1.8
+task-processing==0.1.9
 traitlets==4.3.3
-Twisted==19.7.0
+Twisted==20.3.0
 urllib3==1.25.6
 wcwidth==0.1.7
 websocket-client==0.56.0
@@ -83,4 +83,4 @@ Werkzeug==0.16.0
 wrapt==1.11.2
 xmltodict==0.12.0
 zipp==0.6.0
-zope.interface==4.6.0
+zope.interface==5.1.0


### PR DESCRIPTION
(COMPINFRA-333) The task_processing library handled LIKE constraints
using a "match" expression instead of a "fullmatch" expression, which
meant that "pool: stable" jobs would get scheduled on the stable_batch
pool.  This version bump fixes that behaviour.