### PR TITLE
Tron 1539 dynamo metrics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     -   id: check-yaml
     -   id: requirements-txt-fixer
     -   id: flake8
+        additional_dependencies: ['flake8==3.8.3']
         exclude: testifycompat/
         language_version: python3.6
 -   repo: https://github.com/asottile/reorder_python_imports.git

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -174,7 +174,7 @@ def backfill(args):
         args.end_date = datetime.datetime.today()
 
     if not args.id:
-        print(f"Error: must provide at least one id argument")
+        print("Error: must provide at least one id argument")
         yield False
 
     dates = get_dates_for_backfill(
@@ -208,7 +208,7 @@ def tron_version(args):
     server_version = response.content.get('version', 'unknown')
     print(f"Tron server version: {server_version}")
     if server_version != local_version:
-        print(f"Warning: client and server versions should match")
+        print("Warning: client and server versions should match")
         yield
     yield True
 

--- a/cluster_itests/steps/itest_utils.py
+++ b/cluster_itests/steps/itest_utils.py
@@ -5,5 +5,5 @@ def run(command):
     process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
     process.wait()
     returncode = process.returncode
-    output = "".join([l.decode('utf8') for l in process.stdout.readlines()])
+    output = "".join([line.decode('utf8') for line in process.stdout.readlines()])
     return returncode, output

--- a/tests/api/controller_test.py
+++ b/tests/api/controller_test.py
@@ -282,7 +282,7 @@ class TestEventsController:
         assert len(self.eventbus.publish.mock_calls) == 1
 
         self.eventbus.publish.return_value = True
-        assert self.controller.publish(event) == dict(response=f'OK')
+        assert self.controller.publish(event) == dict(response='OK')
         assert len(self.eventbus.publish.mock_calls) == 2
 
     def test_discard(self):
@@ -298,5 +298,5 @@ class TestEventsController:
         assert len(self.eventbus.discard.mock_calls) == 1
 
         self.eventbus.discard.return_value = True
-        assert self.controller.discard(event) == dict(response=f'OK')
+        assert self.controller.discard(event) == dict(response='OK')
         assert len(self.eventbus.discard.mock_calls) == 2

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -348,8 +348,8 @@ class TestActionRun:
         self.action_run.emit_triggers()
 
         assert eventbus.publish.mock_calls == [
-            mock.call(f"ns.id.action_name.shortdate.foo"),
-            mock.call(f"ns.id.action_name.foo.bar"),
+            mock.call("ns.id.action_name.shortdate.foo"),
+            mock.call("ns.id.action_name.foo.bar"),
         ]
 
     def test_success_bad_state(self):

--- a/tests/serialize/runstate/dynamodb_state_store_test.py
+++ b/tests/serialize/runstate/dynamodb_state_store_test.py
@@ -119,6 +119,7 @@ class TestDynamoDBStateStore:
         store.save(key_value_pairs)
         store._consume_save_queue()
 
+        assert store.save_errors == 0
         keys = [store.build_key("DynamoDBTest", "two"), store.build_key("DynamoDBTest2", "four")]
         vals = store.restore(keys)
         for key, value in key_value_pairs:
@@ -134,6 +135,7 @@ class TestDynamoDBStateStore:
         store.save(key_value_pairs)
         store._consume_save_queue()
 
+        assert store.save_errors == 0
         keys = [store.build_key("DynamoDBTest", "two")]
         vals = store.restore(keys)
         for key, value in key_value_pairs:
@@ -146,6 +148,7 @@ class TestDynamoDBStateStore:
         store.save(pairs)
         store._consume_save_queue()
 
+        assert store.save_errors == 0
         vals = store.restore(keys)
         for key in keys:
             assert_equal(pickle.dumps(vals[key]), large_object)
@@ -157,6 +160,7 @@ class TestDynamoDBStateStore:
         store.save(pairs)
         store._consume_save_queue()
 
+        assert store.save_errors == 0
         vals = store.restore(keys)
         for key in keys:
             assert_equal(pickle.dumps(vals[key]), small_object)
@@ -164,13 +168,13 @@ class TestDynamoDBStateStore:
     def test_delete(self, store, small_object, large_object):
         keys = [store.build_key("thing", i) for i in range(3)]
         value = pickle.loads(large_object)
-        pairs = zip(keys, (value for i in range(len(keys))))
+        pairs = list(zip(keys, (value for i in range(len(keys)))))
         store.save(pairs)
 
-        for key in pairs:
+        for key, value in pairs:
             store._delete_item(key)
 
-        for key in pairs:
+        for key, value in pairs:
             assert_equal(store._get_num_of_partitions(key), 0)
 
     def test_retry_saving(self, store, small_object, large_object):

--- a/tests/trond_test.py
+++ b/tests/trond_test.py
@@ -176,7 +176,7 @@ class TronCommandsTestCase(sandbox.SandboxTestCase):
             """
 
         def remove_line_space(s):
-            return [l.replace(' ', '') for l in s.split('\n')]
+            return [line.replace(' ', '') for line in s.split('\n')]
 
         actual = self.sandbox.tronview()[0]
         assert_equal(remove_line_space(actual), remove_line_space(expected))

--- a/tron/mesos.py
+++ b/tron/mesos.py
@@ -202,9 +202,9 @@ class MesosTask(ActionCommand):
 
     def report_resources(self, decrement=False):
         multiplier = -1 if decrement else 1
-        metrics.count(f'tron.mesos.cpus', self.task_config.cpus * multiplier)
-        metrics.count(f'tron.mesos.mem', self.task_config.mem * multiplier)
-        metrics.count(f'tron.mesos.disk', self.task_config.disk * multiplier)
+        metrics.count('tron.mesos.cpus', self.task_config.cpus * multiplier)
+        metrics.count('tron.mesos.mem', self.task_config.mem * multiplier)
+        metrics.count('tron.mesos.disk', self.task_config.disk * multiplier)
 
     def log_event_info(self, event):
         # Separate out so task still transitions even if this nice-to-have logging fails.
@@ -226,13 +226,13 @@ class MesosTask(ActionCommand):
         elif mesos_type is None:
             self.log.info(f'Non-Mesos event: {event.raw}')
             if 'Failed due to offer timeout' in str(event.raw):
-                self.log.info(f'Explanation:')
-                self.log.info(f'This error means that Tron timed out waiting for Mesos to give it the')
-                self.log.info(f'resources requested (ram, cpu, disk, pool, etc).')
-                self.log.info(f'This can happen if the cluster is low on resources, or if the resource')
-                self.log.info(f'requests are too high.')
-                self.log.info(f'Try reducing the resource request, or adding retries + retries_delay.')
-                self.log.info(f'')
+                self.log.info('Explanation:')
+                self.log.info('This error means that Tron timed out waiting for Mesos to give it the')
+                self.log.info('resources requested (ram, cpu, disk, pool, etc).')
+                self.log.info('This can happen if the cluster is low on resources, or if the resource')
+                self.log.info('requests are too high.')
+                self.log.info('Try reducing the resource request, or adding retries + retries_delay.')
+                self.log.info('')
 
         # Mesos events may have task reasons
         if mesos_type:

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -199,7 +199,7 @@ class DynamoDBStateStore(object):
                         raise e
                     log.warning(f'Got error while saving, trying again: {repr(e)}')
         timer(
-            name=f'tron.dynamodb.setitem',
+            name='tron.dynamodb.setitem',
             delta=time.time() - start,
         )
 
@@ -214,7 +214,7 @@ class DynamoDBStateStore(object):
                     }
                 )
         timer(
-            name=f'tron.dynamodb.delete',
+            name='tron.dynamodb.delete',
             delta=time.time() - start,
         )
 

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -194,6 +194,7 @@ class DynamoDBStateStore(object):
                     count += 1
                     if count > 3:
                         raise e
+                    log.warning(f'Got error while saving, trying again: {repr(e)}')
 
     def _delete_item(self, key: str) -> None:
         with self.table.batch_writer() as batch:


### PR DESCRIPTION
TRON-1539: adding some observability to help us debug.
1. Add log line for every save failure
2. Add some timing metrics so we can see if individual operations are taking longer. These show up when you curl `/api/metrics` and represent an exponentially decaying sample. We already have a cron job that periodically curls this endpoint and puts all the metrics into signalfx.
3. Fix the tests so they actually fail when setitem and delete_Item raise exceptions. _consume_save_queue catches all exceptions and just logs and increments save_errors, and the delete test wasn't calling delete_item at all before because you can only iterate through the `pairs` iterator once.

Metrics example:
```
{
  "counter": [],
  "gauge": [],
  "histogram": [],
  "meter": [
    {
      "name": "tron.site.2xx",
      "count": 1,
      "m1_rate": 0.008909745197802103,
      "m5_rate": 0.008909745216728618,
      "m15_rate": 0.008909745197802103
    },
    {
      "name": "tron.actionrun.waiting",
      "count": 2,
      "m1_rate": 0.024151459813796815,
      "m5_rate": 0.024151460022398655,
      "m15_rate": 0.024151460370068392
    },
    {
      "name": "tron.actionrun.starting",
      "count": 2,
      "m1_rate": 0.024151655692509818,
      "m5_rate": 0.024151655692509818,
      "m15_rate": 0.024151655831579966
    },
    {
      "name": "tron.actionrun.running",
      "count": 2,
      "m1_rate": 0.024233583045079894,
      "m5_rate": 0.02423358332511041,
      "m15_rate": 0.02423358346512567
    },
    {
      "name": "tron.actionrun.succeeded",
      "count": 2,
      "m1_rate": 0.024235214542663395,
      "m5_rate": 0.024235214752714562,
      "m15_rate": 0.024235215032782788
    }
  ],
  "timer": [
    {
      "name": "tron.dynamodb.delete",
      "count": 13,
      "m1_rate": 0.09710491337744767,
      "m5_rate": 0.12486026642002795,
      "m15_rate": 0.13499111491969873,
      "mean": 0.013183263631967397,
      "min": 0.0052564144134521484,
      "max": 0.03205609321594238,
      "p50": 0.012398242950439453,
      "p75": 0.013523221015930176,
      "p95": 0.03205609321594238,
      "p99": 0.03205609321594238
    },
    {
      "name": "tron.dynamodb.setitem",
      "count": 13,
      "m1_rate": 0.0971271474950808,
      "m5_rate": 0.12495925184532777,
      "m15_rate": 0.13511810617348322,
      "mean": 0.02607615177447979,
      "min": 0.021736621856689453,
      "max": 0.034305572509765625,
      "p50": 0.025242328643798828,
      "p75": 0.026988744735717773,
      "p95": 0.034305572509765625,
      "p99": 0.034305572509765625
    }
  ]
}
```