### PR TITLE
Tron 1527: save job runs separately in state store from job state

### DIFF
--- a/tests/core/job_test.py
+++ b/tests/core/job_test.py
@@ -134,7 +134,7 @@ class TestJob:
 
     def test_state_data(self):
         state_data = self.job.state_data
-        assert_equal(state_data['runs'], self.job.runs.state_data)
+        assert_equal(state_data['run_nums'], self.job.runs.get_run_nums.return_value)
         assert state_data['enabled']
 
     def test_get_job_runs_from_state(self):

--- a/tests/core/jobrun_test.py
+++ b/tests/core/jobrun_test.py
@@ -320,6 +320,7 @@ class TestJobRun(TestCase):
         self.job_run.output_path = mock.create_autospec(filehandler.OutputPath)
         self.job_run.cleanup()
 
+        self.job_run.notify.assert_called_with(jobrun.JobRun.NOTIFY_REMOVED)
         self.job_run.clear_observers.assert_called_with()
         self.job_run.output_path.delete.assert_called_with()
         assert not self.job_run.node

--- a/tests/core/jobrun_test.py
+++ b/tests/core/jobrun_test.py
@@ -679,6 +679,9 @@ class TestJobRunCollection(TestCase):
         for job_run in job_runs:
             job_run.get_action_run.assert_called_with(action_name)
 
+    def test_get_run_nums(self):
+        assert self.run_collection.get_run_nums() == [5, 4, 3, 2, 1]
+
 
 class TestJobRunStateTransitions:
     """Integration test for the state of a job run when actions change state in various ways."""

--- a/tests/serialize/runstate/shelvestore_test.py
+++ b/tests/serialize/runstate/shelvestore_test.py
@@ -52,6 +52,35 @@ class TestShelveStateStore(TestCase):
             assert_equal(stored_data[str(key.key)], value)
         stored_data.close()
 
+    def test_delete(self):
+        key_value_pairs = [
+            (
+                ShelveKey("one", "two"),
+                {
+                    'this': 'data',
+                },
+            ),
+            (
+                ShelveKey("three", "four"),
+                {
+                    'this': 'data2',
+                },
+            ),
+            # Delete first key
+            (
+                ShelveKey("one", "two"),
+                None,
+            ),
+        ]
+        self.store.save(key_value_pairs)
+        self.store.cleanup()
+
+        stored_data = Py2Shelf(self.filename)
+        assert stored_data == {
+            str(ShelveKey("three", "four").key): {'this': 'data2'},
+        }
+        stored_data.close()
+
     def test_restore(self):
         self.store.cleanup()
         keys = [ShelveKey("thing", i) for i in range(5)]

--- a/tests/serialize/runstate/statemanager_test.py
+++ b/tests/serialize/runstate/statemanager_test.py
@@ -197,6 +197,12 @@ class TestPersistentStateManager(TestCase):
             self.manager.save("something", 'name', mock.Mock())
         assert not self.store.save.mock_calls
 
+    def test_delete(self):
+        name = 'name'
+        self.manager.delete(runstate.JOB_STATE, name)
+        key = '%s%s' % (runstate.JOB_STATE, name)
+        self.store.save.assert_called_with([(key, None)])
+
     def test_cleanup(self):
         self.manager.cleanup()
         self.store.cleanup.assert_called_with()
@@ -341,6 +347,17 @@ class TestStateChangeWatcher(TestCase):
             runstate.JOB_RUN_STATE,
             mock_job_run.name,
             mock_job_run.state_data,
+        )
+
+    def test_handler_job_run_removed(self):
+        mock_job_run = mock.MagicMock(spec_set=JobRun)
+        self.watcher.handler(
+            observable=mock_job_run,
+            event=JobRun.NOTIFY_REMOVED,
+        )
+        self.watcher.state_manager.delete.assert_called_with(
+            runstate.JOB_RUN_STATE,
+            mock_job_run.name,
         )
 
 

--- a/tests/serialize/runstate/statemanager_test.py
+++ b/tests/serialize/runstate/statemanager_test.py
@@ -105,6 +105,54 @@ class TestPersistentStateManager(TestCase):
         keys = ['type%s' % name for name in names]
         assert_equal(key_to_item_map, dict(zip(keys, names)))
 
+    def test_restore(self):
+        job_names = ['one', 'two']
+        with mock.patch.object(
+            self.manager, '_restore_metadata', autospec=True,
+        ) as mock_restore_metadata, mock.patch.object(
+            self.manager, '_restore_dicts', autospec=True,
+        ) as mock_restore_dicts, mock.patch.object(
+            self.manager, '_restore_runs_for_job', autospect=True,
+        ) as mock_restore_runs:
+            mock_restore_dicts.side_effect = [
+                # _restore_dicts for JOB_STATE
+                {
+                    'one': {'key': 'val1'},
+                    'two': {'key': 'val2'},
+                },
+                # _restore_dicts for MESOS_STATE
+                {'frameworks': 'clusters'},
+            ]
+
+            restored_state = self.manager.restore(job_names)
+            mock_restore_metadata.assert_called_once_with()
+            assert mock_restore_dicts.call_args_list == [
+                mock.call(runstate.JOB_STATE, job_names),
+                mock.call(runstate.MESOS_STATE, ['frameworks']),
+            ]
+            assert len(mock_restore_runs.call_args_list) == 2
+            assert restored_state == {
+                runstate.JOB_STATE: {
+                    'one': {'key': 'val1', 'runs': mock_restore_runs.return_value},
+                    'two': {'key': 'val2', 'runs': mock_restore_runs.return_value},
+                },
+                runstate.MESOS_STATE: {'frameworks': 'clusters'},
+            }
+
+    def test_restore_runs_for_job(self):
+        job_state = {'run_nums': [2, 3], 'enabled': True}
+        with mock.patch.object(
+            self.manager, '_restore_dicts', autospec=True,
+        ) as mock_restore_dicts:
+            mock_restore_dicts.side_effect = [{'job_a.2': 'two'}, {'job_a.3': 'three'}]
+            runs = self.manager._restore_runs_for_job('job_a', job_state)
+
+            assert mock_restore_dicts.call_args_list == [
+                mock.call(runstate.JOB_RUN_STATE, ['job_a.2']),
+                mock.call(runstate.JOB_RUN_STATE, ['job_a.3']),
+            ]
+            assert runs == ['two', 'three']
+
     def test_restore_dicts(self):
         names = ['namea', 'nameb']
         autospec_method(self.manager._keys_for_items)
@@ -282,6 +330,18 @@ class TestStateChangeWatcher(TestCase):
             )
             mock_watch.assert_called_with(mock_job_run)
             assert mock_save_job.call_count == 0
+
+    def test_handler_job_run_state_change(self):
+        mock_job_run = mock.MagicMock(spec_set=JobRun)
+        self.watcher.handler(
+            observable=mock_job_run,
+            event=JobRun.NOTIFY_STATE_CHANGED,
+        )
+        self.watcher.state_manager.save.assert_called_with(
+            runstate.JOB_RUN_STATE,
+            mock_job_run.name,
+            mock_job_run.state_data,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/serialize/runstate/yamlstore_test.py
+++ b/tests/serialize/runstate/yamlstore_test.py
@@ -82,6 +82,29 @@ class TestYamlStateStore(TestCase):
             actual = yaml.load(fh)
         assert_equal(actual, expected)
 
+    def test_delete(self):
+        expected = {'state_a': {'five': 'barz'}}
+
+        key_value_pairs = [
+            (yamlstore.YamlKey('state_a', 'five'), 'barz'),
+            (yamlstore.YamlKey('state_c', 'five'), 'delete_all_c'),
+            (yamlstore.YamlKey('state_a', 'six'), 'delete_one_a'),
+        ]
+        # Save first
+        self.store.save(key_value_pairs)
+
+        # Save second
+        key_value_pairs = [
+            (yamlstore.YamlKey('state_c', 'five'), None),
+            (yamlstore.YamlKey('state_a', 'six'), None),
+        ]
+        self.store.save(key_value_pairs)
+
+        assert_equal(self.store.buffer, expected)
+        with open(self.filename, 'r') as fh:
+            actual = yaml.load(fh)
+        assert_equal(actual, expected)
+
 
 if __name__ == "__main__":
     run()

--- a/tools/migration/migrate_state_1.3.15_to_1.4.0.py
+++ b/tools/migration/migrate_state_1.3.15_to_1.4.0.py
@@ -1,0 +1,77 @@
+import argparse
+import logging
+
+from tron.config import manager
+from tron.serialize import runstate
+from tron.serialize.runstate.statemanager import PersistenceManagerFactory
+from tron.utils import chdir
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--back",
+        help="Flag to migrate back from new state back to old state",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--working-dir",
+        help="Working directory for the Tron daemon",
+        required=True,
+    )
+    parser.add_argument(
+        "--config-path",
+        help="Path in working dir with configs",
+        required=True,
+    )
+    return parser.parse_args()
+
+
+def create_job_runs_for_job(state_manager, job_name, job_state):
+    for run in job_state['runs']:
+        run_num = run['run_num']
+        state_manager.save(runstate.JOB_RUN_STATE, f'{job_name}.{run_num}', run)
+    run_nums = [run['run_num'] for run in job_state['runs']]
+    job_state['run_nums'] = run_nums
+    # Note: not removing 'runs' from job_state for safety.
+    # If Tron starts up correctly after the state migration, it will update the job state
+    # and remove 'runs'.
+    state_manager.save(runstate.JOB_STATE, job_name, job_state)
+
+
+def move_job_runs_to_job(state_manager, job_name, job_state):
+    runs = state_manager._restore_runs_for_job(job_name, job_state)
+    job_state['runs'] = runs
+    state_manager.save(runstate.JOB_STATE, job_name, job_state)
+    for run in runs:
+        state_manager.delete(runstate.JOB_RUN_STATE, f'{job_name}.{run["run_num"]}')
+
+
+def update_state(state_manager, job_names, back):
+    jobs = state_manager._restore_dicts(runstate.JOB_STATE, job_names)
+    for job_name, job_state in jobs.items():
+        if back:
+            move_job_runs_to_job(state_manager, job_name, job_state)
+        else:
+            create_job_runs_for_job(state_manager, job_name, job_state)
+
+
+def migrate_state(config_path, working_dir, back):
+    with chdir(working_dir):
+        config_manager = manager.ConfigManager(config_path)
+        config_container = config_manager.load()
+    job_names = config_container.get_job_names()
+    state_config = config_container.get_master().state_persistence
+    state_manager = PersistenceManagerFactory.from_config(state_config)
+    update_state(state_manager, job_names, back)
+    state_manager.cleanup()
+
+
+if __name__ == '__main__':
+    # INFO for boto, DEBUG for all tron-related state logs
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger('tron').setLevel(logging.DEBUG)
+
+    args = parse_args()
+    migrate_state(args.config_path, args.working_dir, args.back)

--- a/tron/core/job.py
+++ b/tron/core/job.py
@@ -189,9 +189,12 @@ class Job(Observable, Observer):
 
     @property
     def state_data(self):
-        """This data is used to serialize the state of this job."""
+        """
+        This data is used to serialize the state of this job.
+        State of job runs is serialized separately.
+        """
         return {
-            'runs': self.runs.state_data,
+            'run_nums': self.runs.get_run_nums(),
             'enabled': self.enabled,
         }
 

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -27,6 +27,10 @@ class Error(Exception):
     pass
 
 
+def get_job_run_id(job_name, run_num):
+    return '%s.%s' % (job_name, run_num)
+
+
 class JobRun(Observable, Observer):
     """A JobRun is an execution of a Job.  It has a list of ActionRuns and is
     responsible for starting ActionRuns in the correct order and managing their
@@ -70,7 +74,12 @@ class JobRun(Observable, Observer):
 
     @property
     def id(self):
-        return '%s.%s' % (self.job_name, self.run_num)
+        return get_job_run_id(self.job_name, self.run_num)
+
+    @property
+    def name(self):
+        """Property used by state manager to identify objects."""
+        return self.id
 
     @classmethod
     def for_job(cls, job, run_num, run_time, node, manual):
@@ -461,6 +470,9 @@ class JobRunCollection(object):
 
     def get_action_runs(self, action_name):
         return [job_run.get_action_run(action_name) for job_run in self.runs]
+
+    def get_run_nums(self):
+        return [r.run_num for r in self.runs]
 
     @property
     def state_data(self):

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -39,6 +39,7 @@ class JobRun(Observable, Observer):
 
     NOTIFY_DONE = 'notify_done'
     NOTIFY_STATE_CHANGED = 'notify_state_changed'
+    NOTIFY_REMOVED = 'notify_removed'
 
     context_class = command_context.JobRunContext
 
@@ -295,6 +296,7 @@ class JobRun(Observable, Observer):
     def cleanup(self):
         """Cleanup any resources used by this JobRun."""
         log.info(f'{self} removed')
+        self.notify(self.NOTIFY_REMOVED)
         self.clear_observers()
         self.action_runs.cleanup()
         self.node = None

--- a/tron/serialize/runstate/__init__.py
+++ b/tron/serialize/runstate/__init__.py
@@ -2,5 +2,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 JOB_STATE = 'job_state'
+JOB_RUN_STATE = 'job_run_state'
 MCP_STATE = 'mcp_state'
 MESOS_STATE = 'mesos_state'

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -106,7 +106,7 @@ class DynamoDBStateStore(object):
                     log.info(f"save queue size {qlen} > {MAX_SAVE_QUEUE}, sleeping 5s")
                     time.sleep(5)
                     continue
-                self.save_queue[key] = pickle.dumps(val)
+                self.save_queue[key] = val
                 break
 
     def _consume_save_queue(self):
@@ -119,7 +119,8 @@ class DynamoDBStateStore(object):
                 # Remove all previous data with the same partition key
                 # TODO: only remove excess partitions if new data has fewer
                 self._delete_item(key)
-                self[key] = val
+                if val is not None:
+                    self[key] = pickle.dumps(val)
                 # reset errors count if we can successfully save
                 saved += 1
             except Exception as e:

--- a/tron/serialize/runstate/shelvestore.py
+++ b/tron/serialize/runstate/shelvestore.py
@@ -40,6 +40,13 @@ class Py2Shelf(shelve.Shelf):
         pickle.dump(obj=value, file=f, protocol=self._protocol)
         self.dict[key.encode('utf8')] = f.getvalue()
 
+    def delete(self, key):
+        if key in self.cache:
+            del self.cache[key]
+        encoded_key = key.encode('utf8')
+        if encoded_key in self.dict:
+            del self.dict[encoded_key]
+
 
 class ShelveKey(object):
     __slots__ = ['type', 'iden']
@@ -74,7 +81,11 @@ class ShelveStateStore(object):
 
     def save(self, key_value_pairs):
         for key, state_data in key_value_pairs:
-            self.shelve[str(key.key)] = state_data
+            shelve_key = str(key.key)
+            if state_data is None:
+                self.shelve.delete(shelve_key)
+            else:
+                self.shelve[shelve_key] = state_data
         self.shelve.sync()
 
     def restore(self, keys):

--- a/tron/serialize/runstate/statemanager.py
+++ b/tron/serialize/runstate/statemanager.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 
 from tron.config import schema
 from tron.core import job
-from tron.core.jobrun import JobRun
+from tron.core import jobrun
 from tron.mesos import MesosClusterRepository
 from tron.serialize import runstate
 from tron.serialize.runstate.dynamodb_state_store import DynamoDBStateStore
@@ -145,6 +145,8 @@ class PersistentStateManager(object):
             self._restore_metadata()
 
         jobs = self._restore_dicts(runstate.JOB_STATE, job_names)
+        for job_name, job_state in jobs.items():
+            job_state['runs'] = self._restore_runs_for_job(job_name, job_state)
         frameworks = self._restore_dicts(runstate.MESOS_STATE, ['frameworks'])
 
         state = {
@@ -152,6 +154,17 @@ class PersistentStateManager(object):
             runstate.MESOS_STATE: frameworks,
         }
         return state
+
+    def _restore_runs_for_job(self, job_name, job_state):
+        run_nums = job_state['run_nums']
+        runs = []
+        for run_num in run_nums:
+            key = jobrun.get_job_run_id(job_name, run_num)
+            # If the key isn't there, the list will be empty and we will crash during start up
+            # That's fine because that means the job state is incorrect
+            run_state = list(self._restore_dicts(runstate.JOB_RUN_STATE, [key]).values())[0]
+            runs.append(run_state)
+        return runs
 
     def _restore_metadata(self):
         metadata = self._impl.restore([self.metadata_key])
@@ -261,18 +274,22 @@ class StateChangeWatcher(observer.Observer):
             self.save_frameworks(observable)
         elif isinstance(observable, job.Job):
             if event == job.Job.NOTIFY_NEW_RUN:
-                if event_data is None or not isinstance(event_data, JobRun):
+                if event_data is None or not isinstance(event_data, jobrun.JobRun):
                     log.warning(f'Notified of new run, but no run to watch. Got {event_data}')
                 else:
                     log.debug(f'Watching new run {event_data}')
                     self.watch(event_data)
             else:
                 self.save_job(observable)
-        elif isinstance(observable, JobRun):
-            pass
+        elif isinstance(observable, jobrun.JobRun):
+            self.save_job_run(observable)
 
     def save_job(self, job):
         self._save_object(runstate.JOB_STATE, job)
+
+    def save_job_run(self, job_run):
+        log.debug(f'saving {job_run.id}')
+        self._save_object(runstate.JOB_RUN_STATE, job_run)
 
     def save_frameworks(self, clusters):
         self._save_object(runstate.MESOS_STATE, clusters)

--- a/tron/serialize/runstate/yamlstore.py
+++ b/tron/serialize/runstate/yamlstore.py
@@ -40,8 +40,18 @@ class YamlStateStore(object):
 
     def save(self, key_value_pairs):
         for key, state_data in key_value_pairs:
-            self.buffer.setdefault(key.type, {})[key.iden] = state_data
+            if state_data is None:
+                self._delete_from_buffer(key)
+            else:
+                self.buffer.setdefault(key.type, {})[key.iden] = state_data
         self._write_buffer()
+
+    def _delete_from_buffer(self, key):
+        data_for_type = self.buffer.get(key.type, {})
+        if data_for_type.get(key.iden):
+            del data_for_type[key.iden]
+        if not data_for_type:  # No remaining data for this type
+            del self.buffer[key.type]
 
     def _write_buffer(self):
         with open(self.filename, 'w') as fh:


### PR DESCRIPTION
Here's the part that actually saves the job run state separately, based on the events added in https://github.com/Yelp/Tron/pull/758/files.

The diff is big because I needed to add support for delete to the state stores, otherwise old job run state would never get deleted.

This is not backwards compatible, so I wrote a script that can go back and forth. My upgrade plan is:
1) stop Tron, install new version
2) run the script
3) start Tron. if this doesn't work for whatever reason, run the script to migrate state back, then install the old version and restart.

I've tested this a bunch of times back in forth with a local dev cluster.