### PR TITLE
install clusterman-metrics from internal yelp pypi only

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
 usedevelop = true
 passenv = USER PIP_INDEX_URL
 commands =
-    -pip install clusterman-metrics  # don't fail if we can't install this
+    -pip install --index-url https://pypi.yelpcorp.com/simple clusterman-metrics  # internal yelp package, don't fail if we can't install this
     py.test -s {posargs:tests}
     pre-commit install -f --install-hooks
     pre-commit run --all-files


### PR DESCRIPTION
This package is not available externally.