### PR TITLE
Avoid saving all job runs on start up by only saving when runs are cr…

### DIFF
--- a/tron/core/job_scheduler.py
+++ b/tron/core/job_scheduler.py
@@ -5,6 +5,7 @@ from twisted.internet import reactor
 
 from tron.core import recovery
 from tron.core.job import Job
+from tron.core.jobrun import JobRun
 from tron.scheduler import scheduler_from_config
 from tron.serialize import filehandler
 from tron.utils import timeutils
@@ -55,9 +56,12 @@ class JobScheduler(Observer):
         runs_to_schedule = self.get_runs_to_schedule(next_run_time)
         if not runs_to_schedule:
             return
-        for r in runs_to_schedule:
-            self._set_callback(r)
         # Eagerly save new runs in case tron gets restarted
+        # runs_to_schedule is a generator, so we can only iterate
+        # through it once
+        for r in runs_to_schedule:
+            r.notify(JobRun.NOTIFY_STATE_CHANGED)
+            self._set_callback(r)
         self.job.notify(Job.NOTIFY_STATE_CHANGE)
 
     def disable(self):

--- a/tron/serialize/runstate/statemanager.py
+++ b/tron/serialize/runstate/statemanager.py
@@ -283,7 +283,6 @@ class StateChangeWatcher(observer.Observer):
                     log.warning(f'Notified of new run, but no run to watch. Got {event_data}')
                 else:
                     log.debug(f'Watching new run {event_data}')
-                    self.save_job_run(event_data)
                     self.watch(event_data)
             else:
                 self.save_job(observable)


### PR DESCRIPTION
…eated, not watched

When testing the migration in norcal-devc, I noticed startup was really slow because we were saving *every* job run again when we were restoring runs. This change will stop doing that.

I tested this in mesosstage by building a deb and restarting a couple times. The logs show that fewer things are being saved.