### PR TITLE
fix the bionic build by installing the right virtualenv for inscrutable reasons

### DIFF
--- a/yelp_package/bionic/Dockerfile
+++ b/yelp_package/bionic/Dockerfile
@@ -19,9 +19,10 @@ RUN apt-get -q update && \
         libssl-dev \
         libffi-dev \
         python3.6-dev \
-        python-pip \
+        python3-pip \
         python-tox \
         wget \
     && apt-get -q clean
 
+RUN pip3 install virtualenv==16.0.0
 WORKDIR /work


### PR DESCRIPTION
I tested this locally and it seemed to fix it.  I'll re-enable the Jenkins build and test it there.