### PR TITLE
Tron logging errors

### DIFF
--- a/tron/core/job_scheduler.py
+++ b/tron/core/job_scheduler.py
@@ -141,6 +141,11 @@ class JobScheduler(Observer):
             log.info(f"Cancelled {job_run} because job has been disabled.")
             return job_run.cancel()
 
+        # This is a callback on a job run that has been already cleaned up due to
+        # reconfiguration. Do nothing.
+        if not job_run.action_runs:
+            return
+
         # If the JobRun was cancelled we won't run it.  A JobRun may be
         # cancelled if the job was disabled, or manually by a user. It's
         # also possible this job was run (or is running) manually by a user.

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -207,7 +207,7 @@ class DynamoDBStateStore(object):
                         )
                         raise e
                     else:
-                        log.warning(f'Got error while saving, trying again: {repr(e)}')
+                        log.warning(f'Got error while saving {key}, trying again: {repr(e)}')
         timer(
             name='tron.dynamodb.setitem',
             delta=time.time() - start,

--- a/tron/serialize/runstate/statemanager.py
+++ b/tron/serialize/runstate/statemanager.py
@@ -204,14 +204,11 @@ class PersistentStateManager(object):
         if not key_state_pairs:
             return
 
-        keys = ','.join(str(key) for key, _ in key_state_pairs)
-        log.info("Saving state for %s" % keys)
-
         with self._timeit():
             try:
                 self._impl.save(key_state_pairs)
             except Exception as e:
-                msg = "Failed to save state for %s: %s" % (keys, e)
+                msg = f"Error while saving: {repr(e)}"
                 log.warning(msg)
                 raise PersistenceStoreError(msg)
 


### PR DESCRIPTION
2 small changes that I combined into one review.

### logging all keys saved is too long
After the state migration, the logs are full of errors like
```
Aug 12 00:22:29 tron1-uswest2aprod trond[15510]: --- Logging error ---
Aug 12 00:22:29 tron1-uswest2aprod trond[15510]: Traceback (most recent call last):
Aug 12 00:22:29 tron1-uswest2aprod trond[15510]:   File "/usr/lib/python3.6/logging/handlers.py", line 914, in emit
Aug 12 00:22:29 tron1-uswest2aprod trond[15510]:     self.socket.send(msg)
Aug 12 00:22:29 tron1-uswest2aprod trond[15510]: OSError: [Errno 90] Message too long
Aug 12 00:22:29 tron1-uswest2aprod trond[15510]: During handling of the above exception, another exception occurred:
Aug 12 00:22:29 tron1-uswest2aprod trond[15510]: Traceback (most recent call last):
Aug 12 00:22:29 tron1-uswest2aprod trond[15510]:   File "/usr/lib/python3.6/logging/handlers.py", line 918, in emit
Aug 12 00:22:29 tron1-uswest2aprod trond[15510]:     self.socket.send(msg)
Aug 12 00:22:29 tron1-uswest2aprod trond[15510]: OSError: [Errno 90] Message too long
```
from
```
Aug 12 00:22:29 tron1-uswest2aprod trond[15510]:     log.info("Saving state for %s" % keys)
```
These lines clutter up the log even if they're not too long. We already have lines that log each time a save for a key is buffered, and the number of items being saved in the dynamodb store, so I don't think we need this. If we really need to know exactly when a key is saved, I could add something to the dynamodb store in setitem for each key.

### TRON-1558
These log lines happen when a job is reconfigured and the old run is no longer relevant and gets cleaned up, but the callback still exists and gets called later. We can just skip the job run in that case.

log lines for reference:
```
Aug 11 10:00:35 tron1-uswest2aprod tron: INFO pid=29704 tid=140668762846976 tron.core.job_scheduler run_job:146 JobRun:yelp-main.x.174 in state unknown is not scheduled, scheduling a new run instead of running
Aug 11 10:00:35 tron1-uswest2aprod tron: INFO pid=29704 tid=140668762846976 tron.core.jobrun state:319 JobRun:yelp-main.x.174 has no action runs to determine state
```

