### PR TITLE
Alert for waiting jobs as long as other actions in the job have started

### DIFF
--- a/tests/bin/check_tron_jobs_test.py
+++ b/tests/bin/check_tron_jobs_test.py
@@ -745,6 +745,60 @@ class TestCheckJobs(TestCase):
         assert_equal(run['id'], 'MASTER.test.99')
         assert_equal(state, State.STUCK)
 
+    def test_job_waiting_job_exceeds_expected_runtime_already_started(self):
+        job_runs = {
+            'status':
+                'running',
+            'next_run':
+                None,
+            'expected_runtime':
+                480.0,
+            'allow_overlap':
+                True,
+            'runs': [
+                {
+                    'id':
+                        'MASTER.test.100',
+                    'state':
+                        'scheduled',
+                    'run_time':
+                        time.strftime(
+                            '%Y-%m-%d %H:%M:%S',
+                            time.localtime(time.time() + 600),
+                        ),
+                    'end_time':
+                        None,
+                    'start_time':
+                        None,
+                    'duration':
+                        '',
+                },
+                {
+                    'id':
+                        'MASTER.test.99',
+                    'state':
+                        'waiting',
+                    'run_time':
+                        time.strftime(
+                            '%Y-%m-%d %H:%M:%S',
+                            time.localtime(time.time() - 600),
+                        ),
+                    'start_time':
+                        time.strftime(
+                            '%Y-%m-%d %H:%M:%S',
+                            time.localtime(time.time() - 600),
+                        ),
+                    'end_time':
+                        None,
+                    'duration':
+                        '0:10:01.883601',
+                },
+            ],
+        }
+        run, state = check_tron_jobs.get_relevant_run_and_state(job_runs)
+        assert_equal(run['id'], 'MASTER.test.99')
+        assert_equal(state, State.STUCK)
+
     def test_job_running_action_exceeds_expected_runtime(self):
         job_runs = {
             'status':

--- a/tron/bin/check_tron_jobs.py
+++ b/tron/bin/check_tron_jobs.py
@@ -234,7 +234,8 @@ def is_job_stuck(
 ):
     next_run_time = None
     for job_run in job_runs:
-        if job_run.get('state', 'unknown') == "running":
+        states_to_check = {"running", "waiting"}
+        if job_run.get('state', 'unknown') in states_to_check:
             if is_job_run_exceeding_expected_runtime(
                 job_run, job_expected_runtime
             ):
@@ -255,13 +256,11 @@ def is_job_stuck(
 
 
 def is_job_run_exceeding_expected_runtime(job_run, job_expected_runtime):
+    states_to_check = {"running", "waiting"}
     if job_expected_runtime is not None and job_run.get(
         'state', 'unknown'
-    ) == "running":
+    ) in states_to_check:
         duration_seconds = pytimeparse.parse(job_run.get('duration', ''))
-        # TODO: duration_seconds will be None for a running job if it's root
-        # action is waiting for external dependency. Maybe fix by setting
-        # job's start_time to run_time when that happens.
         if duration_seconds and duration_seconds > job_expected_runtime:
             return True
     return False


### PR DESCRIPTION
This covers the case where the initial actions start and complete, but then the job is waiting for triggers in later actions. This is described in the ticket TRON-1542.

I don't think we should alert in the case that no actions in the job have started (the TODO). job_run start_time (and therefore duration) is based on the start time of the first action. If we assumed run_time when start_time doesn't exist yet, the following could happen:
* run_time is 1 am, expected_runtime is 3 hours
* no actions have started by 4 am: alert
* action starts at 4:15: start time is now 4:15, duration is now < 1 min, alert resolves

If we wanted to solve it, we should change the way start_time gets calculated, not this script. In the meantime, a workaround if people want to be alerted in that case is setting a trigger timeout.

Tested in dev with the following config, where the second action is always waiting because the trigger does not get emitted:
```
  testjob1:
    node: localhost
    schedule: "cron */10 * * * *"
    actions:
      first:
        command: "sleep 60"
      second:
        command: "echo 'hello world'"
        requires: [first]
        triggered_by:
          - "MASTER.testjob0.does_not_exist_{ymdhm}"
```
Before this change, the script does not alert for that job. After this change, it does, even if `first` is complete and the job run is `waiting`.
