### PR TITLE
Skip check_oom_events key from monitoring, which is only used by paasta

### DIFF
--- a/tron/bin/check_tron_jobs.py
+++ b/tron/bin/check_tron_jobs.py
@@ -397,6 +397,7 @@ def compute_check_result_for_job(client, job, url_index):
         pmap(job['monitoring']).discard(PRECIOUS_JOB_ATTR)
         .discard('check_every')
         .discard('page_for_expected_runtime')
+        .discard('check_oom_events')
     )
     kwargs = kwargs.update(sensu_kwargs)
     hide_stderr = kwargs.get('hide_stderr', False)


### PR DESCRIPTION
Tested by adding check_oom_events to a job's monitoring and running the script -  pysensu fails to send the event without this change and succeeds after.