### PR TITLE
Only reconfigure jobs in that namespace when a namespace is updated

### DIFF
--- a/tests/api/controller_test.py
+++ b/tests/api/controller_test.py
@@ -189,15 +189,15 @@ class TestConfigController:
         assert resp['hash'] == self.manager.get_hash.return_value
 
     def test_update_config(self):
-        name, content, config_hash = None, mock.Mock(), mock.Mock()
+        name, content, config_hash = 'foo_namespace', mock.Mock(), mock.Mock()
         self.manager.get_hash.return_value = config_hash
         assert not self.controller.update_config(name, content, config_hash)
         self.manager.get_hash.assert_called_with(name)
         self.manager.write_config.assert_called_with(name, content)
-        self.mcp.reconfigure.assert_called_with()
+        self.mcp.reconfigure.assert_called_with(name)
 
     def test_update_config_failure(self):
-        name, content, old_content, config_hash = None, mock.Mock(), mock.Mock(), mock.Mock()
+        name, content, old_content, config_hash = 'foo_namespace', mock.Mock(), mock.Mock(), mock.Mock()
         self.manager.get_hash.return_value = config_hash
         self.manager.write_config.side_effect = [ConfigError("It broke"), None]
         self.controller.read_config = mock.Mock(return_value={'config': old_content})
@@ -209,22 +209,23 @@ class TestConfigController:
         assert error == "It broke"
         self.manager.write_config.call_args_list = [(name, content), (name, old_content)]
         assert self.mcp.reconfigure.call_count == 1
+        self.mcp.reconfigure.assert_called_with(name)
 
     def test_update_config_hash_mismatch(self):
-        name, content, config_hash = None, mock.Mock(), mock.Mock()
+        name, content, config_hash = 'foo_namespace', mock.Mock(), mock.Mock()
         error = self.controller.update_config(name, content, config_hash)
         assert error == "Configuration has changed. Please try again."
 
     def test_delete_config(self):
-        name, content, config_hash = None, "", mock.Mock()
+        name, content, config_hash = 'foo_namespace', "", mock.Mock()
         self.manager.get_hash.return_value = config_hash
         assert not self.controller.delete_config(name, content, config_hash)
         self.manager.delete_config.assert_called_with(name)
-        self.mcp.reconfigure.assert_called_with()
+        self.mcp.reconfigure.assert_called_with(name)
         self.manager.get_hash.assert_called_with(name)
 
     def test_delete_config_failure(self):
-        name, content, config_hash = None, "", mock.Mock()
+        name, content, config_hash = 'foo_namespace', "", mock.Mock()
         self.manager.get_hash.return_value = config_hash
         self.manager.delete_config.side_effect = Exception("some error")
         error = self.controller.delete_config(name, content, config_hash)
@@ -233,12 +234,12 @@ class TestConfigController:
         assert not self.mcp.reconfigure.call_count
 
     def test_delete_config_hash_mismatch(self):
-        name, content, config_hash = None, "", mock.Mock()
+        name, content, config_hash = 'foo_namespace', "", mock.Mock()
         error = self.controller.delete_config(name, content, config_hash)
         assert error == "Configuration has changed. Please try again."
 
     def test_delete_config_content_not_empty(self):
-        name, content, config_hash = None, "content", mock.Mock()
+        name, content, config_hash = 'foo_namespace', "", mock.Mock()
         error = self.controller.delete_config(name, content, config_hash)
         assert error
 

--- a/tests/mcp_test.py
+++ b/tests/mcp_test.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 
 import mock
+import pytest
 
 from testifycompat import assert_equal
 from testifycompat import run
@@ -19,11 +20,11 @@ from tron.core.job_collection import JobCollection
 from tron.serialize.runstate import statemanager
 
 
-class TestMasterControlProgram(TestCase):
+class TestMasterControlProgram:
 
     TEST_CONFIG = 'tests/data/test_config.yaml'
 
-    @setup
+    @pytest.fixture(autouse=True)
     def setup_mcp(self):
         self.working_dir = tempfile.mkdtemp()
         self.config_path = tempfile.mkdtemp()
@@ -34,41 +35,57 @@ class TestMasterControlProgram(TestCase):
         self.mcp.state_watcher = mock.create_autospec(
             statemanager.StateChangeWatcher,
         )
-
-    @teardown
-    def teardown_mcp(self):
+        yield
         shutil.rmtree(self.config_path)
         shutil.rmtree(self.working_dir)
 
-    def test_reconfigure(self):
+    def test_reconfigure_default(self):
         autospec_method(self.mcp._load_config)
         self.mcp.state_watcher = mock.MagicMock()
         self.mcp.reconfigure()
-        self.mcp._load_config.assert_called_with(reconfigure=True)
+        self.mcp._load_config.assert_called_with(reconfigure=True, namespace_to_reconfigure=None)
 
-    def test_load_config(self):
+    def test_reconfigure_namespace(self):
+        autospec_method(self.mcp._load_config)
+        self.mcp.state_watcher = mock.MagicMock()
+        self.mcp.reconfigure(namespace='foo')
+        self.mcp._load_config.assert_called_with(reconfigure=True, namespace_to_reconfigure='foo')
+
+    @pytest.mark.parametrize('reconfigure,namespace', [
+        (False, None),
+        (True, None),
+        (True, 'foo'),
+    ])
+    def test_load_config(self, reconfigure, namespace):
         autospec_method(self.mcp.apply_config)
         self.mcp.config = mock.create_autospec(manager.ConfigManager)
-        self.mcp._load_config()
+        self.mcp._load_config(reconfigure, namespace)
         self.mcp.state_watcher.disabled.assert_called_with()
         self.mcp.apply_config.assert_called_with(
             self.mcp.config.load.return_value,
-            reconfigure=False,
+            reconfigure=reconfigure,
+            namespace_to_reconfigure=namespace,
         )
 
+    @pytest.mark.parametrize('reconfigure,namespace', [
+        (False, None),
+        (True, None),
+        (True, 'foo'),
+        (True, 'MASTER'),
+    ])
     @mock.patch('tron.mcp.MesosClusterRepository', autospec=True)
     @mock.patch('tron.mcp.node.NodePoolRepository', autospec=True)
-    def test_apply_config(self, mock_repo, mock_cluster_repo):
+    def test_apply_config(self, mock_repo, mock_cluster_repo, reconfigure, namespace):
         config_container = mock.create_autospec(config_parse.ConfigContainer)
         master_config = config_container.get_master.return_value
-        autospec_method(self.mcp.apply_collection_config)
+        autospec_method(self.mcp.jobs.update_from_config)
         autospec_method(self.mcp.build_job_scheduler_factory)
-        self.mcp.apply_config(config_container)
+        self.mcp.apply_config(config_container, reconfigure, namespace)
         self.mcp.state_watcher.update_from_config.assert_called_with(
             master_config.state_persistence,
         )
         assert_equal(self.mcp.context.base, master_config.command_context)
-        assert_equal(len(self.mcp.apply_collection_config.mock_calls), 1)
+
         mock_repo.update_from_config.assert_called_with(
             master_config.nodes,
             master_config.node_pools,
@@ -78,6 +95,18 @@ class TestMasterControlProgram(TestCase):
             master_config.mesos_options,
         )
         self.mcp.build_job_scheduler_factory(master_config, mock.Mock())
+
+        expected_namespace_to_update = None if namespace == 'MASTER' else namespace
+        self.mcp.jobs.update_from_config.assert_called_once_with(
+            config_container.get_jobs(),
+            self.mcp.build_job_scheduler_factory.return_value,
+            reconfigure,
+            expected_namespace_to_update,
+        )
+        self.mcp.state_watcher.watch_all.assert_called_once_with(
+            self.mcp.jobs.update_from_config.return_value,
+            mock.ANY,
+        )
 
     def test_update_state_watcher_config_changed(self):
         self.mcp.state_watcher.update_from_config.return_value = True

--- a/tron/api/controller.py
+++ b/tron/api/controller.py
@@ -190,14 +190,15 @@ class ConfigController(object):
 
         old_config = self.read_config(name)['config']
         try:
+            log.info(f"Reconfiguring namespace {name}")
             self.config_manager.write_config(name, content)
-            self.mcp.reconfigure()
+            self.mcp.reconfigure(namespace=name)
         except Exception as e:
-            log.error("Configuration update failed: %s" % e)
+            log.error(f"Configuration for {name} update failed: {e}")
             log.error("Reconfiguring with the previous good configuration")
             try:
                 self.config_manager.write_config(name, old_config)
-                self.mcp.reconfigure()
+                self.mcp.reconfigure(namespace=name)
             except Exception as e:
                 log.error("Could not restore old config: %s" % e)
                 return str(e)
@@ -212,8 +213,9 @@ class ConfigController(object):
             return "Configuration content is not empty, will not delete."
 
         try:
+            log.info(f"Deleting namespace {name}")
             self.config_manager.delete_config(name)
-            self.mcp.reconfigure()
+            self.mcp.reconfigure(namespace=name)
         except Exception as e:
             log.error("Deleting configuration for %s failed: %s" % (name, e))
             return str(e)

--- a/tron/core/job_collection.py
+++ b/tron/core/job_collection.py
@@ -22,7 +22,7 @@ class JobCollection:
             ],
         )
 
-    def load_from_config(self, job_configs, factory, reconfigure):
+    def update_from_config(self, job_configs, factory, reconfigure, namespace_to_reconfigure=None):
         """Apply a configuration to this collection and return a generator of
         jobs which were added.
         """
@@ -34,7 +34,13 @@ class JobCollection:
                     job_scheduler.schedule()
                 yield job_scheduler.get_job()
 
-        seq = (factory.build(config) for config in job_configs.values())
+        def reconfigure_filter(config):
+            if not reconfigure or not namespace_to_reconfigure:
+                return True
+            else:
+                return config.namespace == namespace_to_reconfigure
+
+        seq = (factory.build(config) for config in job_configs.values() if reconfigure_filter(config))
         return map_to_job_and_schedule(filter(self.add, seq))
 
     def add(self, job_scheduler):


### PR DESCRIPTION
map_to_job_and_schedule does all the updating - this change reduces the number of jobs that it gets called on.

This should make setup_tron_namespace faster (TRON-1523), and reduce API slowness overall.