### PR TITLE
Small Makefile/tox.ini updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,6 @@ DOCKER_RUN = docker run -t -v $(CURDIR):/work:rw -v $(CURDIR)/.tox-indocker:/wor
 UID:=$(shell id -u)
 GID:=$(shell id -g)
 
-ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
-	export PIP_INDEX_URL ?= https://pypi.yelpcorp.com/simple
-else
-	export PIP_INDEX_URL ?= https://pypi.python.org/simple
-endif
-
 .PHONY : all clean tests docs dev cluster_itests
 
 -usage:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 envlist = py36
+tox_pip_extensions_ext_pip_custom_platform = true
+tox_pip_extensions_ext_venv_update = true
 
 [testenv]
 basepython=python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ tox_pip_extensions_ext_pip_custom_platform = true
 tox_pip_extensions_ext_venv_update = true
 
 [testenv]
-basepython=python3.6
+basepython = /usr/bin/python3.6
 deps =
     --requirement={toxinidir}/requirements.txt
     --requirement={toxinidir}/requirements-dev.txt
@@ -58,7 +58,7 @@ commands =
     docker-compose rm --force
 
 [testenv:tron_itests_inside_container]
-basepython = python3.6
+basepython = /usr/bin/python3.6
 changedir=cluster_itests/
 deps =
     {[testenv]deps}
@@ -71,7 +71,7 @@ commands =
     behave {posargs}
 
 [testenv:trond_inside_container]
-basepython = python3.6
+basepython = /usr/bin/python3.6
 deps = {[testenv]deps}
 commands =
     trond --debug -c /work/cluster_itests/config/ -l /work/example-cluster/logging.conf -H 0.0.0.0


### PR DESCRIPTION
## Set an absolute path for basepython

without this, venv-update on a devbox will error on a rebuild of the
venv since basepython will be the python inside the venv, instead of the
canonical system one.

## Remove PIP_INDEX_URL shenanigans

We set this globally through puppet internally - we don't need to do
this anymore.

This technically isn't breaking anything, but we might as well do it as
we modernize the codebase.

## Use pip-custom-platform to pick up wheels

This will be unnecessary as soon as we roll out per-platform packade
indicies, but for now we still need p-c-p