### PR TITLE
Revert "Remove PIP_INDEX_URL shenanigans"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ DOCKER_RUN = docker run -t -v $(CURDIR):/work:rw -v $(CURDIR)/.tox-indocker:/wor
 UID:=$(shell id -u)
 GID:=$(shell id -g)
 
+ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
+	export PIP_INDEX_URL ?= https://pypi.yelpcorp.com/simple
+else
+	export PIP_INDEX_URL ?= https://pypi.python.org/simple
+endif
+
 .PHONY : all clean tests docs dev cluster_itests
 
 -usage:


### PR DESCRIPTION
This reverts commit b474d931859c68f6548e8f2daa62e352111e6131. 

Turns out I can't read and we were using this for itests as well.