### PR TITLE
Tronctl success no longer emits trigger when the transition is invalid

### DIFF
--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -337,6 +337,14 @@ class TestActionRun:
         assert self.action_run.success()
         assert self.action_run.emit_triggers.call_count == 0
 
+    def test_sucess_emits_not_invalid_transition(self):
+        self.action_run.trigger_downstreams = True
+        self.action_run.machine.check = mock.Mock(return_value=False)
+        self.action_run.emit_triggers = mock.Mock()
+
+        assert not self.action_run.success()
+        assert self.action_run.emit_triggers.call_count == 0
+
     def test_success_emits_on_true(self):
         self.action_run.machine.transition('start')
         self.action_run.machine.transition('started')

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -646,9 +646,12 @@ class ActionRun(Observable):
         ]
 
     def success(self):
-        if self.trigger_downstreams:
-            self.emit_triggers()
-        return self._done('success')
+        transitionvalid = self._done('success')
+        if transitionvalid:
+            if self.trigger_downstreams:
+                self.emit_triggers()
+
+        return transitionvalid
 
     def fail_unknown(self):
         """Failed with unknown reason."""

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -646,12 +646,12 @@ class ActionRun(Observable):
         ]
 
     def success(self):
-        transitionvalid = self._done('success')
-        if transitionvalid:
+        transition_valid = self._done('success')
+        if transition_valid:
             if self.trigger_downstreams:
                 self.emit_triggers()
 
-        return transitionvalid
+        return transition_valid
 
     def fail_unknown(self):
         """Failed with unknown reason."""


### PR DESCRIPTION
### Description
Previously, we used to emit triggers before we transitioned to the next state. However, this caused some confusion since the transition could be invalid (i.e. no next state to transition to). This change ensures that the transition is first valid before we can emit triggers.

### Tests
`make test` - PASSED