### PR TITLE
Implementation of skip-and-publish

### DIFF
--- a/bin/tronctl
+++ b/bin/tronctl
@@ -191,15 +191,15 @@ def control_objects(args: argparse.Namespace):
                 # query the API and figure out what triggers exist
                 triggers = _get_triggers_for_action(server=args.server, action_identifier=identifier)
                 if triggers is None:
+                    print("Encountered error getting triggers to publish.")
                     # tronctl allows for multiple ids to be passed in for commands, but we want to make it obvious that
                     # we failed to get the downstream triggers so that users know to take action (and don't miss the
                     # error amongst other tronctl output).
-                    print("Encountered error getting triggers to publish.")
                     yield False
                 elif not triggers:
+                    print(f"{identifier} has no triggers to publish.")
                     # TODO: should we check this up-front and refuse to skip if there are no triggers that will be
                     # published rather than carry on under the assumption that the user copy-pasted/typo'd the identifier?
-                    print(f"{identifier} has no triggers to publish.")
                     yield True
 
                 # TODO: this loop should use event_publish(), but we'd need to refactor how the CLI works and stop passing
@@ -210,10 +210,10 @@ def control_objects(args: argparse.Namespace):
                         data={"command": "publish", "event": trigger}
                     )
             else:
+                print(f"Unable to skip {identifier}.")
                 # again, tronctl allows for multiple ids to be passed in for commands, but we want to make it obvious that
                 # we failed to skip something so that users know to take action (and don't miss the error amongst other
                 # tronctl output)
-                print(f"Unable to skip {identifier}.")
                 yield False
 
         else:

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -4,12 +4,15 @@
 Part of the command line interface to the tron daemon. Provides the interface
 to controlling jobs and runs.
 """
+import argparse
 import datetime
 import logging
 import sys
 from collections import defaultdict
 from typing import Any
 from typing import Dict
+from typing import Optional
+from typing import Tuple
 from urllib.parse import urljoin
 
 import argcomplete
@@ -132,7 +135,33 @@ def event_discard(args):
         )
 
 
-def control_objects(args):
+def _get_triggers_for_action(server: str, action_identifier: str) -> Optional[Tuple[str, ...]]:
+    try:
+        namespace, job_name, run_number, action_name = action_identifier.split('.')
+    except ValueError:
+        print(f"Unable to fully decompose {action_identifier}: expected an identifier of the form (namespace).(job).(run).(action)")
+        return None
+
+    trigger_response = client.request(
+        uri=urljoin(
+            server,
+            f"/api/jobs/{namespace}.{job_name}/{run_number}/{action_name}",
+        ),
+    )
+    if trigger_response.error:
+        print(f"Unable to fetch downstream triggers for {action_identifier}: {trigger_response.error}")
+        return None
+
+    # triggers are returned by the API as comma-separated values with a space after every comma, which is
+    # not automation-friendly - thus the string-manipulation
+    triggers = trigger_response.content.get('trigger_downstreams', '').replace(" ", "").split(',')
+
+    # the API will return an empty string for actions with no triggers to emit, but splitting '' yields [''],
+    # so we want to make sure that we return an empty iterable in this case
+    return tuple(f"{namespace}.{job_name}.{action_name}.{trigger}" for trigger in triggers if trigger)
+
+
+def control_objects(args: argparse.Namespace):
     tron_client = client.Client(args.server)
     url_index = tron_client.index()
     for identifier in args.id:
@@ -160,37 +189,33 @@ def control_objects(args):
             ):
                 # a single action can have 0..N triggers to publish and these can be arbitrarily named, so we need to
                 # query the API and figure out what triggers exist
-
-                try:
-                    namespace, job_name, run_number, action_name = identifier.split('.')
-                except ValueError:
-                    print(f"Unable to fully decompose {identifier}: expected an identifier of the form (namespace).(job).(run).(action)")
+                triggers = _get_triggers_for_action(server=args.server, action_identifier=identifier)
+                if triggers is None:
+                    # tronctl allows for multiple ids to be passed in for commands, but we want to make it obvious that
+                    # we failed to get the downstream triggers so that users know to take action (and don't miss the
+                    # error amongst other tronctl output).
+                    print("Encountered error getting triggers to publish.")
                     yield False
+                elif not triggers:
+                    # TODO: should we check this up-front and refuse to skip if there are no triggers that will be
+                    # published rather than carry on under the assumption that the user copy-pasted/typo'd the identifier?
+                    print(f"{identifier} has no triggers to publish.")
+                    yield True
 
-                trigger_response = client.request(
-                    uri=urljoin(
-                        args.server,
-                        f"/api/jobs/{namespace}.{job_name}/{run_number}/{action_name}",
-                    ),
-                )
-                if trigger_response.error:
-                    print(f"Unable to fetch downstream triggers for {identifier}: {trigger_response.error}")
-                    yield False
-
-                # triggers are returned by the API as comma-separated values with a space after every comma, which is
-                # not automation-friendly - thus the string-manipulation
-                triggers = trigger_response.content.get(
-                    'trigger_downstreams',
-                ).replace(" ", "").split(',')
-
+                # TODO: this loop should use event_publish(), but we'd need to refactor how the CLI works and stop passing
+                # around the full set of args everywhere to do so
                 for trigger in triggers:
                     yield request(
                         url=urljoin(args.server, "/api/events"),
-                        data={"command": "publish", "event": f"{namespace}.{job_name}.{action_name}.{trigger}"},
+                        data={"command": "publish", "event": trigger}
                     )
             else:
-                print(f"Unable to skip {tron_id.url}")
+                # again, tronctl allows for multiple ids to be passed in for commands, but we want to make it obvious that
+                # we failed to skip something so that users know to take action (and don't miss the error amongst other
+                # tronctl output)
+                print(f"Unable to skip {identifier}.")
                 yield False
+
         else:
             data = dict(command=args.command)
             if args.command == "start" and args.run_date:

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -192,9 +192,6 @@ def control_objects(args: argparse.Namespace):
                 triggers = _get_triggers_for_action(server=args.server, action_identifier=identifier)
                 if triggers is None:
                     print("Encountered error getting triggers to publish.")
-                    # tronctl allows for multiple ids to be passed in for commands, but we want to make it obvious that
-                    # we failed to get the downstream triggers so that users know to take action (and don't miss the
-                    # error amongst other tronctl output).
                     yield False
                 elif not triggers:
                     print(f"{identifier} has no triggers to publish.")
@@ -211,9 +208,6 @@ def control_objects(args: argparse.Namespace):
                     )
             else:
                 print(f"Unable to skip {identifier}.")
-                # again, tronctl allows for multiple ids to be passed in for commands, but we want to make it obvious that
-                # we failed to skip something so that users know to take action (and don't miss the error amongst other
-                # tronctl output)
                 yield False
 
         else:

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -8,6 +8,8 @@ import datetime
 import logging
 import sys
 from collections import defaultdict
+from typing import Any
+from typing import Dict
 from urllib.parse import urljoin
 
 import argcomplete
@@ -32,6 +34,7 @@ COMMAND_HELP = (
     ('fail', 'Mark an UNKNOWN job or action as failed. Does not publish action triggers.'),
     ('success', 'Mark an UNKNOWN job or action as having succeeded. Will publish action triggers.'),
     ('skip', 'Skip a failed action, unblocks dependent actions. Does *not* publish action triggers.'),
+    ('skip-and-publish', 'Skip a failed action, unblocks dependent actions. *Does* publish action triggers.'),
     ('stop', 'Stop the action run (SIGTERM)'),
     ('kill', 'Force kill the action run (SIGKILL)'),
     ('move', 'Rename a job'),
@@ -104,11 +107,11 @@ def parse_cli():
     return args
 
 
-def request(url, data, headers=None, method=None):
+def request(url: str, data: Dict[str, Any], headers=None, method=None) -> bool:
     response = client.request(url, data=data, headers=headers, method=method)
     if response.error:
         print(f'Error: {response.content}')
-        return
+        return False
     print(response.content.get('result', 'OK'))
     return True
 
@@ -147,12 +150,54 @@ def control_objects(args):
             )
             raise SystemExit(f"Error: {e}{suggestions}")
 
-        data = dict(command=args.command)
-        if args.command == "start" and args.run_date:
-            data['run_time'] = str(args.run_date)
-        if args.command == "retry":
-            data['use_latest_command'] = int(args.use_latest_command)
-        yield request(urljoin(args.server, tron_id.url), data)
+        if args.command == "skip-and-publish":
+            # this command is more of a pseudo-command - skip and publish are handled in two different resources
+            # and changing the API would be painful, so instead we call skip + publish separately from the client
+            # (i.e., this file) to implement this functionality
+            if request(
+                url=urljoin(args.server, tron_id.url),
+                data={"command": "skip"}
+            ):
+                # a single action can have 0..N triggers to publish and these can be arbitrarily named, so we need to
+                # query the API and figure out what triggers exist
+
+                try:
+                    namespace, job_name, run_number, action_name = identifier.split('.')
+                except ValueError:
+                    print(f"Unable to fully decompose {identifier}: expected an identifier of the form (namespace).(job).(run).(action)")
+                    yield False
+
+                trigger_response = client.request(
+                    uri=urljoin(
+                        args.server,
+                        f"/api/jobs/{namespace}.{job_name}/{run_number}/{action_name}",
+                    ),
+                )
+                if trigger_response.error:
+                    print(f"Unable to fetch downstream triggers for {identifier}: {trigger_response.error}")
+                    yield False
+
+                # triggers are returned by the API as comma-separated values with a space after every comma, which is
+                # not automation-friendly - thus the string-manipulation
+                triggers = trigger_response.content.get(
+                    'trigger_downstreams',
+                ).replace(" ", "").split(',')
+
+                for trigger in triggers:
+                    yield request(
+                        url=urljoin(args.server, "/api/events"),
+                        data={"command": "publish", "event": f"{namespace}.{job_name}.{action_name}.{trigger}"},
+                    )
+            else:
+                print(f"Unable to skip {tron_id.url}")
+                yield False
+        else:
+            data = dict(command=args.command)
+            if args.command == "start" and args.run_date:
+                data['run_time'] = str(args.run_date)
+            if args.command == "retry":
+                data['use_latest_command'] = int(args.use_latest_command)
+            yield request(urljoin(args.server, tron_id.url), data)
 
 
 def move(args):

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -153,8 +153,8 @@ def _get_triggers_for_action(server: str, action_identifier: str) -> Optional[Tu
         return None
 
     # triggers are returned by the API as comma-separated values with a space after every comma, which is
-    # not automation-friendly - thus the string-manipulation
-    triggers = trigger_response.content.get('trigger_downstreams', '').replace(" ", "").split(',')
+    # not automation-friendly - thus the non-standard multi-character split
+    triggers = trigger_response.content.get('trigger_downstreams', '').split(', ')
 
     # the API will return an empty string for actions with no triggers to emit, but splitting '' yields [''],
     # so we want to make sure that we return an empty iterable in this case

--- a/tests/api/controller_test.py
+++ b/tests/api/controller_test.py
@@ -5,6 +5,7 @@ from tron import mcp
 from tron.api import controller
 from tron.api.controller import ConfigController
 from tron.api.controller import EventsController
+from tron.api.controller import InvalidCommandForActionState
 from tron.api.controller import JobCollectionController
 from tron.api.controller import UnknownCommandError
 from tron.config import ConfigError
@@ -86,9 +87,8 @@ class TestActionRunController:
 
     def test_handle_command_mapped_command_failed(self):
         self.action_run.cancel.return_value = False
-        result = self.controller.handle_command('cancel')
-        self.action_run.cancel.assert_called_with()
-        assert "Failed to cancel" in result
+        with pytest.raises(InvalidCommandForActionState):
+            self.controller.handle_command('cancel')
 
     def test_handle_termination_not_implemented(self):
         self.action_run.stop.side_effect = NotImplementedError

--- a/tron/api/controller.py
+++ b/tron/api/controller.py
@@ -13,6 +13,20 @@ class UnknownCommandError(Exception):
     """Exception raised when a controller received an unknown command."""
 
 
+class InvalidCommandForActionState(Exception):
+    """
+    Exception raised when a controller attempts a command on an action in a state
+    that does not support that command (e.g., skipping a successful run).
+    """
+
+    def __init__(self, command: str, action_name: str, action_state: str) -> None:
+        self.command = command
+        self.action_name = action_name
+        self.action_state = action_state
+        self.message = f"Failed to {command} on {action_name}. State is {action_state}."
+        super().__init__()
+
+
 class JobCollectionController(object):
     def __init__(self, job_collection):
         self.job_collection = job_collection
@@ -72,8 +86,7 @@ class ActionRunController(object):
             msg = "%s now in state %s"
             return msg % (self.action_run, self.action_run.state)
 
-        msg = "Failed to %s on %s. State is %s."
-        return msg % (command, self.action_run, self.action_run.state)
+        raise InvalidCommandForActionState(command=command, action_name=self.action_run.name, action_state=self.action_run.state)
 
     def handle_termination(self, command):
         try:

--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -79,6 +79,11 @@ def handle_command(request, api_controller, obj, **kwargs):
         return respond(
             request=request, response={'error': error_msg}, code=http.NOT_IMPLEMENTED
         )
+    except controller.InvalidCommandForActionState as e:
+        log.warning(e.message)
+        return respond(
+            request=request, response={"error": e.message}, code=http.CONFLICT,
+        )
     except Exception as e:
         log.exception('%r while executing command %s for %s', e, command, obj)
         trace = traceback.format_exc()


### PR DESCRIPTION
Skipping an action that has downstream triggers is error-prone as its easy to forget that you have triggers to emit and what triggers to emit. You prob need to go check your tronfig definitions to see what triggers exist and converting the trigger name to a trigger command can be a little tricky (with date magic).

To solve this, we add a new tronctl command that will skip an action and then publish all triggers for that action

Testing: mostly manual, there are no tronctl tests. `make test itest_bionic` pass, though!