### PR TITLE
Add initial k8s config + global k8s toggle + job opt-out

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -163,6 +163,7 @@ def make_job(**kwargs):
     kwargs.setdefault('allow_overlap', False)
     kwargs.setdefault('time_zone', None)
     kwargs.setdefault('expected_runtime', datetime.timedelta(0, 3600))
+    kwargs.setdefault('use_k8s', True)
     return schema.ConfigJob(**kwargs)
 
 

--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -163,7 +163,7 @@ def make_job(**kwargs):
     kwargs.setdefault('allow_overlap', False)
     kwargs.setdefault('time_zone', None)
     kwargs.setdefault('expected_runtime', datetime.timedelta(0, 3600))
-    kwargs.setdefault('use_k8s', True)
+    kwargs.setdefault('use_k8s', False)
     return schema.ConfigJob(**kwargs)
 
 

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -560,7 +560,7 @@ class ValidateJob(Validator):
         'monitoring': {},
         'time_zone': None,
         'expected_runtime': datetime.timedelta(hours=24),
-        'use_k8s': True,
+        'use_k8s': False,
     }
 
     validators = {

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -185,7 +185,7 @@ def valid_master_address(value, config_context):
 
 
 def valid_k8s_master_address(value: str, config_context: ConfigContext) -> str:
-    """Validates and normalizes Mesos master address.
+    """Validates and normalizes Kubernetes master address.
 
     Must be HTTP or not include a scheme, and only include
     a host, without any path components.

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -35,6 +35,7 @@ from tron.config.schema import ConfigAction
 from tron.config.schema import ConfigCleanupAction
 from tron.config.schema import ConfigConstraint
 from tron.config.schema import ConfigJob
+from tron.config.schema import ConfigKubernetes
 from tron.config.schema import ConfigMesos
 from tron.config.schema import ConfigParameter
 from tron.config.schema import ConfigSSHOptions
@@ -178,6 +179,41 @@ def valid_master_address(value, config_context):
 
     if not netloc:
         msg = f"Mesos master address is missing host, got {value}"
+        raise ConfigError(msg)
+
+    return f'{scheme}://{netloc}'
+
+
+def valid_k8s_master_address(value: str, config_context: ConfigContext) -> str:
+    """Validates and normalizes Mesos master address.
+
+    Must be HTTP or not include a scheme, and only include
+    a host, without any path components.
+    """
+    valid_string(value, config_context)
+
+    # Parse with HTTP as default, only HTTPS allowed.
+    scheme, netloc, path, params, query, fragment = urlparse(url=value, scheme='https')
+    if scheme != 'http':
+        msg = f"Only HTTPS supported for Kubernetes master address, got {value}"
+        raise ConfigError(msg)
+
+    if params or query or fragment:
+        msg = f"Kubernetes master address may not contain path components, got {value}"
+        raise ConfigError(msg)
+
+    # Only one of netloc or path allowed, and no / except trailing ones.
+    path = path.rstrip('/')
+    if (netloc and path) or '/' in path:
+        msg = f"Kubernetes master address may not contain path components, got {value}"
+        raise ConfigError(msg)
+
+    # netloc is empty if there's no scheme, so we fallback to path.
+    if not netloc and path:
+        netloc = path
+
+    if not netloc:
+        msg = f"Kubernetes master address is missing host, got {value}"
         raise ConfigError(msg)
 
     return f'{scheme}://{netloc}'
@@ -524,6 +560,7 @@ class ValidateJob(Validator):
         'monitoring': {},
         'time_zone': None,
         'expected_runtime': datetime.timedelta(hours=24),
+        'use_k8s': True,
     }
 
     validators = {
@@ -541,6 +578,7 @@ class ValidateJob(Validator):
         'monitoring': valid_dict,
         'time_zone': valid_time_zone,
         'expected_runtime': config_utils.valid_time_delta,
+        'use_k8s': valid_bool,
     }
 
     def cast(self, in_dict, config_context):
@@ -673,6 +711,23 @@ class ValidateMesos(Validator):
 valid_mesos_options = ValidateMesos()
 
 
+class ValidateKubernetes(Validator):
+    config_class = ConfigKubernetes
+    optional = True
+    defaults = {
+        'master_address': None,
+        'enabled': False,
+    }
+
+    validators = {
+        'master_address': valid_k8s_master_address,
+        'enabled': valid_bool,
+    }
+
+
+valid_kubernetes_options = ValidateKubernetes()
+
+
 def validate_jobs(config, config_context):
     """Validate jobs"""
     valid_jobs = build_dict_name_validator(valid_job, allow_empty=True)
@@ -728,6 +783,7 @@ class ValidateConfig(Validator):
         'nodes': nodes,
         'node_pools': node_pools,
         'mesos_options': valid_mesos_options,
+        'k8s_options': valid_kubernetes_options,
         'eventbus_enabled': valid_bool,
     }
     optional = False

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -48,6 +48,7 @@ TronConfig = config_object_factory(
         'node_pools',  # dict of ConfigNodePool
         'jobs',  # dict of ConfigJob
         'mesos_options',  # ConfigMesos
+        'k8s_options',  # ConfigKubernetes
         'eventbus_enabled',  # bool or None
     ],
 )
@@ -114,6 +115,14 @@ ConfigMesos = config_object_factory(
     ],
 )
 
+ConfigKubernetes = config_object_factory(
+    name='ConfigKubernetes',
+    optional=[
+        'master_address',
+        'enabled',
+    ],
+)
+
 ConfigJob = config_object_factory(
     name='ConfigJob',
     required=[
@@ -134,6 +143,8 @@ ConfigJob = config_object_factory(
         'max_runtime',  # datetime.Timedelta
         'time_zone',  # pytz time zone
         'expected_runtime',  # datetime.Timedelta
+        # TODO: cleanup once we're fully off of Mesos and all non-SSH jobs *only* use k8s
+        'use_k8s'  # bool
     ],
 )
 

--- a/tron/config/tronfig_schema.json
+++ b/tron/config/tronfig_schema.json
@@ -128,6 +128,10 @@
       "items": {
         "type": "object",
         "properties": {
+          "use_k8s": {
+            "type": "boolean",
+            "default": true
+          },
           "name": {
             "type": "string"
           },

--- a/tron/config/tronfig_schema.json
+++ b/tron/config/tronfig_schema.json
@@ -130,7 +130,7 @@
         "properties": {
           "use_k8s": {
             "type": "boolean",
-            "default": true
+            "default": false
           },
           "name": {
             "type": "string"


### PR DESCRIPTION
We'll be adding two toggles to control Tron's usage of k8s:
* a global killswitch (`k8s_options["enabled"]`) for when we want to go
  back to Mesos for an entire cluster (and, in the future, for when we
  want to quickly stop all Tronjobs).
* a per-job opt-out (`use_k8s`) for any jobs that encounter issues with
   k8s or that we want to migrate at a specific time.

Since I was adding a k8s config section to the Tron master config, I
also went ahead and added a way to configure what the k8s API address
should be (i.e., the "master" address).