### PR TITLE
Add kubernetes as a valid ExecutorType

### DIFF
--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -237,7 +237,7 @@ StatePersistenceTypes = Enum(
     'StatePersistenceTypes', dict(shelve='shelve', yaml='yaml', dynamodb='dynamodb')
 )
 
-ExecutorTypes = Enum('ExecutorTypes', dict(ssh='ssh', mesos='mesos'))
+ExecutorTypes = Enum('ExecutorTypes', dict(ssh='ssh', mesos='mesos', kubernetes='kubernetes'))
 
 ActionRunnerTypes = Enum('ActionRunnerTypes', dict(none='none', subprocess='subprocess'))
 


### PR DESCRIPTION
I somehow forget to include this in the PR that added support for k8s
toggles.