### PR TITLE
install js dependencies in tox for use in pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.6
-      # we have a pre-commit hook that runs eslint over our FE files, but our
-      # current setup means that the necessary binaries won't be installed
-      # automatically, so we manually invoke yarn to install things
-      - run: yarn install && yarn --cwd tronweb2 install
       # GHA won't setup tox for us and we use tox-pip-extensions for venv-update
       - run: pip install tox==3.2 tox-pip-extensions==1.3.0
         # there are no pre-built wheels for bsddb3, so we need to install

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,15 @@ deps =
     --requirement={toxinidir}/requirements-dev.txt
 usedevelop = true
 passenv = USER PIP_INDEX_URL
+whitelist_externals=
+    yarn
 commands =
     -pip install --index-url https://pypi.yelpcorp.com/simple clusterman-metrics  # internal yelp package, don't fail if we can't install this
+    # we have a pre-commit hook that runs eslint over our FE files, but our
+    # current setup means that the necessary binaries won't be installed
+    # automatically, so we manually invoke yarn to install things
+    yarn install
+    yarn --cwd tronweb2 install
     py.test -s {posargs:tests}
     pre-commit install -f --install-hooks
     pre-commit run --all-files


### PR DESCRIPTION
This will make it so that JS-based pre-commit hooks will work regardless
of how you invoke our tox testenv.