### PR TITLE
Add check-requirements and mypy to our tox tests

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+python_version = 3.6
+
+show_column_numbers = True
+show_error_context = True
+
+warn_incomplete_stub = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unreachable = True
+warn_unused_ignores = True

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -1,7 +1,7 @@
 flake8
 mock
+mypy
 pre-commit
 pylint
 pytest
 requirements-tools
-yapf

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,9 +9,10 @@ importlib-resources==1.0.2
 isort==4.3.18
 lazy-object-proxy==1.3.1
 mccabe==0.6.1
+mypy==0.812
+mypy-extensions==0.4.3
 nodeenv==1.3.3
 packaging==19.2
-pathlib2==2.3.2
 pluggy==0.13.0
 pre-commit==1.21.0
 py==1.8.0
@@ -23,5 +24,5 @@ pytest==5.2.1
 requirements-tools==1.2.1
 toml==0.10.0
 typed-ast==1.4.0
+typing-extensions==3.10.0.0
 virtualenv==16.7.5
-yapf==0.27.0

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,10 @@ commands =
     py.test -s {posargs:tests}
     pre-commit install -f --install-hooks
     pre-commit run --all-files
+    # tron has been around for a while, so we'll need to slowly add types or make an effort
+    # to get it mypy-clean in one shot - until then, let's only check files that we've added types to
+    mypy --pretty tron/kubernetes.py
+    check-requirements
 
 [flake8]
 ignore = E501,E265,E241,E704,E251,W504,E231,W503,E203

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -1,8 +1,8 @@
 import logging
 from logging import Logger
 
-from task_processing.interfaces.event import Event
-from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
+from task_processing.interfaces.event import Event  # type: ignore  # TODO: mypy isn't finding hints
+from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig  # type: ignore  # TODO: mypy isn't finding hints
 
 import tron.metrics as metrics
 from tron.actioncommand import ActionCommand
@@ -55,7 +55,7 @@ class KubernetesTask(ActionCommand):
 
         This will generally be of the form {pod_name}.{unique_suffix}
         """
-        return self.task_config.pod_name
+        return self.task_config.pod_name  # type: ignore  # TODO: mypy isn't seeing that this is typed in task_proc
 
     def get_config(self) -> KubernetesTaskConfig:
         """


### PR DESCRIPTION
* we have requirements-tools installed, but aren't automatically running
  it
* we're starting to add types to new code, so let's have mypy
  automatically check it instead of relying on our editor setups to run
  it for us :p