### PR TITLE
Store kubeconfig path in tron settings, not k8s master address

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -91,6 +91,10 @@ def make_mesos_options():
     )
 
 
+def make_k8s_options():
+    return schema.ConfigKubernetes(enabled=False,)
+
+
 def make_action(**kwargs):
     kwargs.setdefault("name", "action"),
     kwargs.setdefault("command", "command")
@@ -217,6 +221,7 @@ def make_tron_config(
     node_pools=None,
     jobs=None,
     mesos_options=None,
+    k8s_options=None,
 ):
     return schema.TronConfig(
         action_runner=action_runner or {},
@@ -229,6 +234,7 @@ def make_tron_config(
         node_pools=node_pools or make_node_pools(),
         jobs=jobs or make_master_jobs(),
         mesos_options=mesos_options or make_mesos_options(),
+        k8s_options=k8s_options or make_k8s_options(),
     )
 
 
@@ -319,6 +325,7 @@ class ConfigTestCase(TestCase):
         assert test_config.time_zone == expected.time_zone
         assert test_config.nodes == expected.nodes
         assert test_config.node_pools == expected.node_pools
+        assert test_config.k8s_options == expected.k8s_options
         for key in ["0", "1", "2", "_actions_dict", "4", "_mesos"]:
             job_name = f"MASTER.test_job{key}"
             assert job_name in test_config.jobs, f"{job_name} in test_config.jobs"

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -628,12 +628,12 @@ class ValidateKubernetes(Validator):
     config_class = ConfigKubernetes
     optional = True
     defaults = {
-        "master_address": None,
+        "kubeconfig_path": None,
         "enabled": False,
     }
 
     validators = {
-        "master_address": valid_k8s_master_address,
+        "kubeconfig_path": valid_string,
         "enabled": valid_bool,
     }
 
@@ -677,6 +677,7 @@ class ValidateConfig(Validator):
         "node_pools": {},
         "jobs": (),
         "mesos_options": ConfigMesos(**ValidateMesos.defaults),
+        "k8s_options": ConfigKubernetes(**ValidateKubernetes.defaults),
         "eventbus_enabled": None,
     }
     node_pools = build_dict_name_validator(valid_node_pool, allow_empty=True)

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -93,7 +93,7 @@ ConfigMesos = config_object_factory(
     ],
 )
 
-ConfigKubernetes = config_object_factory(name="ConfigKubernetes", optional=["master_address", "enabled",],)
+ConfigKubernetes = config_object_factory(name="ConfigKubernetes", optional=["kubeconfig_path", "enabled",],)
 
 ConfigJob = config_object_factory(
     name="ConfigJob",


### PR DESCRIPTION
kubeconfig files already contain the master address, so no need to
duplicate that here. additionally, we'll need to know what kubeconfig to
use, so lets replace master_address with kubeconfig_path