### PR TITLE
Enable submitting a task to k8s using task_proc

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,5 +24,4 @@ pytest==5.2.1
 requirements-tools==1.2.1
 toml==0.10.0
 typed-ast==1.4.0
-typing-extensions==3.10.0.0
 virtualenv==16.7.5

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -20,7 +20,7 @@ pytimeparse
 pytz
 PyYAML>=5.1
 requests
-task_processing[mesos_executor]
+task_processing[mesos_executor,k8s]
 Twisted>=19.7.0
 urllib3>=1.24.2
 Werkzeug>=0.15.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.1.16
+task-processing==0.1.17
 traitlets==4.3.3
 Twisted==20.3.0
 typing-extensions==3.10.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ boto==2.49.0
 boto3==1.9.249
 botocore==1.12.249
 bsddb3==6.2.6
+cachetools==4.2.1
 certifi==2019.11.28
 cffi==1.12.3
 cfn-lint==0.24.4
@@ -23,6 +24,7 @@ docker==4.1.0
 docutils==0.15.2
 ecdsa==0.13.3
 future==0.18.1
+google-auth==1.23.0
 http-parser==0.9.0
 humanize==0.5.1
 hyperlink==19.0.0
@@ -40,11 +42,13 @@ jsonpatch==1.24
 jsonpickle==1.2
 jsonpointer==2.0
 jsonschema==3.1.1
+kubernetes==17.17.0
 lockfile==0.12.2
 MarkupSafe==1.1.1
 mock==3.0.5
 more-itertools==8.0.2
 moto==1.3.13
+oauthlib==3.1.0
 parso==0.5.1
 pexpect==4.7.0
 pickleshare==0.7.5
@@ -53,6 +57,7 @@ psutil==5.6.6
 ptyprocess==0.6.0
 py-bcrypt==0.4
 pyasn1==0.4.7
+pyasn1-modules==0.2.8
 pycparser==2.19
 pyformance==0.4
 Pygments==2.4.2
@@ -67,15 +72,17 @@ pytimeparse==1.1.8
 pytz==2019.3
 PyYAML==5.4.1
 requests==2.22.0
+requests-oauthlib==1.2.0
 responses==0.10.6
 rsa==4.0
 s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.1.12
+task-processing==0.1.16
 traitlets==4.3.3
 Twisted==20.3.0
+typing-extensions==3.10.0.0
 urllib3==1.25.6
 wcwidth==0.1.7
 websocket-client==0.56.0

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -17,7 +17,9 @@ def mock_kubernetes_task():
     ):
         yield KubernetesTask(
             action_run_id="mock_service.mock_job.1.mock_action",
-            task_config=KubernetesTaskConfig(name="mock--service-mock-job-mock--action", uuid="123456",),
+            task_config=KubernetesTaskConfig(
+                name="mock--service-mock-job-mock--action", uuid="123456", image="some_image", command="echo test"
+            ),
         )
 
 
@@ -25,7 +27,10 @@ def mock_kubernetes_task():
 def mock_kubernetes_cluster():
     with mock.patch("tron.kubernetes.PyDeferredQueue", autospec=True,), mock.patch(
         "tron.kubernetes.TaskProcessor", autospec=True,
-    ):
+    ), mock.patch("tron.kubernetes.Subscription", autospec=True,) as mock_runner:
+        mock_runner.return_value.configure_mock(
+            stopping=False, TASK_CONFIG_INTERFACE=mock.Mock(spec=KubernetesTaskConfig)
+        )
         yield KubernetesCluster("kube-cluster-a:1234")
 
 
@@ -33,6 +38,8 @@ def mock_kubernetes_cluster():
 def mock_disabled_kubernetes_cluster():
     with mock.patch("tron.kubernetes.PyDeferredQueue", autospec=True,), mock.patch(
         "tron.kubernetes.TaskProcessor", autospec=True,
+    ), mock.patch(
+        "tron.kubernetes.Subscription", autospec=True,
     ):
         yield KubernetesCluster("kube-cluster-a:1234", enabled=False)
 
@@ -96,7 +103,17 @@ def test_create_task_disabled():
     cluster = KubernetesCluster("kube-cluster-a:1234", enabled=False)
     mock_serializer = mock.MagicMock()
 
-    task = cluster.create_task(action_run_id="action_a", serializer=mock_serializer,)
+    task = cluster.create_task(
+        action_run_id="action_a",
+        serializer=mock_serializer,
+        command="ls",
+        cpus=1,
+        mem=1024,
+        disk=None,
+        docker_image="docker-paasta.yelpcorp.com:443/bionic_yelp",
+        env={},
+        volumes=[],
+    )
 
     assert task is None
 
@@ -104,7 +121,17 @@ def test_create_task_disabled():
 def test_create_task(mock_kubernetes_cluster):
     mock_serializer = mock.MagicMock()
 
-    task = mock_kubernetes_cluster.create_task(action_run_id="action_a", serializer=mock_serializer,)
+    task = mock_kubernetes_cluster.create_task(
+        action_run_id="action_a",
+        serializer=mock_serializer,
+        command="ls",
+        cpus=1,
+        mem=1024,
+        disk=None,
+        docker_image="docker-paasta.yelpcorp.com:443/bionic_yelp",
+        env={},
+        volumes=[],
+    )
 
     assert task is not None
 
@@ -112,7 +139,18 @@ def test_create_task(mock_kubernetes_cluster):
 def test_create_task_with_task_id(mock_kubernetes_cluster):
     mock_serializer = mock.MagicMock()
 
-    task = mock_kubernetes_cluster.create_task(action_run_id="action_a", serializer=mock_serializer, task_id="yay.1234")
+    task = mock_kubernetes_cluster.create_task(
+        action_run_id="action_a",
+        serializer=mock_serializer,
+        task_id="yay.1234",
+        command="ls",
+        cpus=1,
+        mem=1024,
+        disk=None,
+        docker_image="docker-paasta.yelpcorp.com:443/bionic_yelp",
+        env={},
+        volumes=[],
+    )
 
     mock_kubernetes_cluster.runner.TASK_CONFIG_INTERFACE().set_pod_name.assert_called_once_with("yay.1234")
     assert task is not None
@@ -123,7 +161,18 @@ def test_create_task_with_invalid_task_id(mock_kubernetes_cluster):
 
     with mock.patch.object(mock_kubernetes_cluster, "runner") as mock_runner:
         mock_runner.TASK_CONFIG_INTERFACE.return_value.set_pod_name = mock.MagicMock(side_effect=ValueError)
-        task = mock_kubernetes_cluster.create_task(action_run_id="action_a", serializer=mock_serializer, task_id="boo")
+        task = mock_kubernetes_cluster.create_task(
+            action_run_id="action_a",
+            serializer=mock_serializer,
+            task_id="boo",
+            command="ls",
+            cpus=1,
+            mem=1024,
+            disk=None,
+            docker_image="docker-paasta.yelpcorp.com:443/bionic_yelp",
+            env={},
+            volumes=[],
+        )
 
     assert task is None
 
@@ -209,7 +258,12 @@ def test_set_enabled_disable(mock_kubernetes_cluster):
 
 def test_configure_default_volumes():
     # default_volume validation is done at config time, we just need to validate we are setting it
-    mock_kubernetes_cluster = KubernetesCluster("kube-cluster-a:1234", default_volumes=[])
+    with mock.patch("tron.kubernetes.PyDeferredQueue", autospec=True,), mock.patch(
+        "tron.kubernetes.TaskProcessor", autospec=True,
+    ), mock.patch(
+        "tron.kubernetes.Subscription", autospec=True,
+    ):
+        mock_kubernetes_cluster = KubernetesCluster("kube-cluster-a:1234", default_volumes=[])
     assert mock_kubernetes_cluster.default_volumes == []
     expected_volumes = [
         {"container_path": "/tmp", "host_path": "/host/tmp", "mode": "RO",},

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -270,3 +270,19 @@ def test_configure_default_volumes():
     ]
     mock_kubernetes_cluster.configure_tasks(default_volumes=expected_volumes)
     assert mock_kubernetes_cluster.default_volumes == expected_volumes
+
+
+def test_submit_disabled(mock_disabled_kubernetes_cluster, mock_kubernetes_task):
+    with mock.patch.object(mock_kubernetes_task, "exited", autospec=True) as mock_exited:
+        mock_disabled_kubernetes_cluster.submit(mock_kubernetes_task)
+
+    assert mock_kubernetes_task.get_kubernetes_id() not in mock_disabled_kubernetes_cluster.tasks
+    mock_exited.assert_called_once_with(1)
+
+
+def test_submit(mock_kubernetes_cluster, mock_kubernetes_task):
+    mock_kubernetes_cluster.submit(mock_kubernetes_task)
+
+    assert mock_kubernetes_task.get_kubernetes_id() in mock_kubernetes_cluster.tasks
+    assert mock_kubernetes_cluster.tasks[mock_kubernetes_task.get_kubernetes_id()] == mock_kubernetes_task
+    mock_kubernetes_cluster.runner.run.assert_called_once_with(mock_kubernetes_task.get_config())

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -21,6 +21,7 @@ class ActionCommandConfig:
     disk: float = None
     constraints: set = field(default_factory=set)
     docker_image: str = None
+    # XXX: we can get rid of docker_parameters once we're off of Mesos
     docker_parameters: set = field(default_factory=set)
     env: dict = field(default_factory=dict)
     extra_volumes: set = field(default_factory=set)

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -204,6 +204,8 @@ class ActionRun(Observable):
         EXIT_STOP_KILL: "Stopped or killed",
         EXIT_TRIGGER_TIMEOUT: "Timed out waiting for trigger",
         EXIT_MESOS_DISABLED: "Mesos disabled",
+        EXIT_KUBERNETES_DISABLED: "Kubernetes disabled",
+        EXIT_KUBERNETES_NOT_CONFIGURED: "Kubernetes enabled, but not configured",
     }
 
     # This is a list of "alternate locations" that we can look for stdout/stderr in

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -1,14 +1,16 @@
 import logging
 from logging import Logger
+from typing import cast
+from typing import Collection
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import TYPE_CHECKING
 
-from task_processing.interfaces.event import Event  # type: ignore  # need to add task_proc type hints
-from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig  # type: ignore
-from task_processing.runners.subscription import Subscription  # type: ignore
-from task_processing.task_processor import TaskProcessor  # type: ignore
+from task_processing.interfaces.event import Event
+from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
+from task_processing.runners.subscription import Subscription
+from task_processing.task_processor import TaskProcessor
 from twisted.internet.defer import Deferred  # type: ignore  # need to upgrade twisted
 from twisted.internet.defer import logError
 
@@ -16,17 +18,30 @@ import tron.metrics as metrics
 from tron.actioncommand import ActionCommand
 from tron.config.schema import ConfigKubernetes
 from tron.config.schema import ConfigVolume
+from tron.serialize.filehandler import OutputStreamSerializer
 from tron.utils.queue import PyDeferredQueue
 
 if TYPE_CHECKING:
     from tron.serialize.runstate.statemanager import StateChangeWatcher
 
 DEFAULT_POD_LAUNCH_TIMEOUT_S = 300  # arbitrary number, same as Mesos offer timeout of yore
+DEFAULT_DISK_LIMIT = 1024.0  # arbitrary, same as what was chosen for Mesos-based Tronjobs
 
 KUBERNETES_TASK_LOG_FORMAT = "%(asctime)s %(name)s %(levelname)s %(message)s"
 KUBERNETES_TASK_OUTPUT_LOGGER = "tron.kubernetes.task_output"
 
 log = logging.getLogger(__name__)
+
+
+def combine_volumes(defaults: Collection[ConfigVolume], overrides: Collection[ConfigVolume],) -> List[ConfigVolume]:
+    """Helper to reconcile lists of volume mounts.
+
+    If any volumes have the same container path, the one in overrides wins.
+    """
+    result = {mount.container_path: mount for mount in defaults}
+    for mount in overrides:
+        result[mount.container_path] = mount
+    return list(result.values())
 
 
 class KubernetesTask(ActionCommand):
@@ -64,7 +79,7 @@ class KubernetesTask(ActionCommand):
         # TODO(TRON-1612): these should eventually be Prometheus metrics
         multiplier = -1 if decrement else 1
         metrics.count("tron.mesos.cpus", self.task_config.cpus * multiplier)
-        metrics.count("tron.mesos.mem", self.task_config.mem * multiplier)
+        metrics.count("tron.mesos.mem", self.task_config.memory * multiplier)
         metrics.count("tron.mesos.disk", self.task_config.disk * multiplier)
 
     def get_kubernetes_id(self) -> str:
@@ -73,7 +88,7 @@ class KubernetesTask(ActionCommand):
 
         This will generally be of the form {pod_name}.{unique_suffix}
         """
-        return self.task_config.pod_name  # type: ignore  # TODO: mypy isn't seeing that this is typed in task_proc
+        return self.task_config.pod_name
 
     def get_config(self) -> KubernetesTaskConfig:
         """
@@ -171,11 +186,11 @@ class KubernetesCluster:
 
         # TODO: once we start implementing more things in the executor, we'll need to actually pass
         # down some config
-        executor = self.processor.executor_from_config(provider="kubernetes", provider_config={})
+        executor = self.processor.executor_from_config(
+            provider="kubernetes", provider_config={"namespace": "tron", "kubeconfig_path": self.kubeconfig_path,},
+        )
 
-        # TODO: we should return a Subscription here: but this will crash until we've actually implemented
-        # get_event_queue() in our task_proc plugin
-        return executor
+        return Subscription(executor, queue)
 
     def handle_next_event(self, _=None) -> None:
         """
@@ -235,7 +250,7 @@ class KubernetesCluster:
 
         task = self.tasks[task_id]
         task.handle_event(event)
-        if task.is_done:
+        if task.is_done and event.task_id is not None:
             del self.tasks[event.task_id]
 
     def kill(self, task_id: str) -> bool:
@@ -280,7 +295,19 @@ class KubernetesCluster:
     def configure_tasks(self, default_volumes: Optional[List[ConfigVolume]]):
         self.default_volumes = default_volumes
 
-    def create_task(self, action_run_id: str, serializer, task_id: Optional[str] = None) -> Optional[KubernetesTask]:
+    def create_task(
+        self,
+        action_run_id: str,
+        serializer: OutputStreamSerializer,
+        command: str,
+        cpus: Optional[float],
+        mem: Optional[float],
+        disk: Optional[float],
+        docker_image: str,
+        env: Dict[str, str],
+        volumes: Collection[ConfigVolume],
+        task_id: Optional[str] = None,
+    ) -> Optional[KubernetesTask]:
         """
         Given the execution parameters for a task, create a KubernetesTask that encapsulate those parameters.
 
@@ -292,9 +319,26 @@ class KubernetesCluster:
             )
             return None
 
-        # TODO: fill out required fields once they're ready
-        task_config = self.runner.TASK_CONFIG_INTERFACE()
+        task_config = cast(
+            KubernetesTaskConfig,
+            self.runner.TASK_CONFIG_INTERFACE(
+                name=action_run_id,
+                command=command,
+                image=docker_image,
+                cpus=cpus,
+                memory=mem,
+                disk=DEFAULT_DISK_LIMIT if disk is None else disk,
+                environment=env,
+                volumes=[
+                    volume._asdict()
+                    for volume in combine_volumes(defaults=self.default_volumes or [], overrides=volumes)
+                ],
+            ),
+        )
 
+        # this should only ever be non-null when we're recovering from a Tron restart
+        # and are recreating the previous state - when actually creating a new task
+        # we'll always let task_processing come up with a Pod name for us
         if task_id is not None:
             try:
                 task_config = task_config.set_pod_name(task_id)
@@ -302,13 +346,51 @@ class KubernetesCluster:
                 log.error(f"Invalid {task_id} for {action_run_id}")
                 return None
 
-        return KubernetesTask(action_run_id=action_run_id, task_config=task_config, serializer=serializer)
+        return KubernetesTask(action_run_id=action_run_id, task_config=task_config, serializer=serializer,)
+
+    def _check_connection(self) -> None:
+        """
+        Helper to ensure that the task_processing plugin is in a running state and event handling
+        is correctly setup in case we've disabled k8s at some point during operation.
+        """
+        if self.runner is None or self.runner.stopping:
+            log.info("k8s plugin never created or stopped, restarting.")
+            self.connect()
+        # re-add callbacks just in case they're missing
+        elif self.deferred is None or self.deferred.called:
+            self.handle_next_event()
 
     def submit(self, task: KubernetesTask) -> None:
         """
         Given a KubernetesTask, submit it to the configured Kubernetes cluster in order to attempt to run it.
         """
-        pass
+        # Submitting a task while k8s usage is disabled should fail the task so that
+        # users know that they have to take action and re-run whatever was scheduled
+        # during the time this killswitch is active
+        if not self.enabled:
+            task.log.info("Not starting task, Kubernetes usage is disabled.")
+            task.exited(1)
+            return
+
+        # it's possible that we're the first task submission following k8s going from
+        # disabled -> enabled, so make sure everything is correctly setup
+        self._check_connection()
+        assert self.runner is not None, "Unable to correctly setup k8s runner!"
+
+        # store the task to be launched before actually launching it so that there's
+        # no race conditions later on with processing an event for that Pod before
+        # Tron know that that Pod is for a task it cares about
+        self.tasks[task.get_kubernetes_id()] = task
+
+        # XXX: if spark-on-k8s ends up running through task_processing, we'll need to revist
+        # reimplementing the clusterman resource reporting that MesosCluster::submit() used to do
+        if not self.runner.run(task.get_config()):
+            log.warning(f"Unable to submit task {task.get_kubernetes_id()} to configured k8s cluster.")
+            task.exited(1)
+        log.info(f"Submitted task {task.get_kubernetes_id()} to configured k8s cluster.")
+
+        # update internal resource usage tracker (this isn't connected at all to clusterman)
+        task.report_resources()
 
     def recover(self, task: KubernetesTask) -> None:
         """
@@ -338,8 +420,9 @@ class KubernetesClusterRepository:
     @classmethod
     def get_cluster(cls, kubeconfig_path: Optional[str] = None) -> Optional[KubernetesCluster]:
         if kubeconfig_path is None:
+            if cls.kubeconfig_path is None:
+                return None
             kubeconfig_path = cls.kubeconfig_path
-            return None
 
         if kubeconfig_path not in cls.clusters:
             cluster = KubernetesCluster(


### PR DESCRIPTION
We aren't yet reading any of the events that task_proc is bubbling back
up to us, but that'll come next.

With this, we should be giving task_proc all the information it needs to
actually create a usable Pod.