### PR TITLE
TRON-1625: Add handling for default volumes config at the cluster level

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -92,7 +92,7 @@ def make_mesos_options():
 
 
 def make_k8s_options():
-    return schema.ConfigKubernetes(enabled=False,)
+    return schema.ConfigKubernetes(enabled=False, default_volumes=())
 
 
 def make_action(**kwargs):
@@ -1021,6 +1021,20 @@ class TestValidateVolume(TestCase):
         # After we fix the error, expect error to go away.
         mesos_options["default_volumes"][1]["mode"] = "RW"
         assert config_parse.valid_mesos_options.validate(mesos_options, self.context,)
+
+    def test_k8s_default_volumes(self):
+        k8s_options = {"kubeconfig_path": "some_path"}
+        k8s_options["default_volumes"] = [
+            {"container_path": "/nail/srv", "host_path": "/tmp", "mode": "RO",},
+            {"container_path": "/nail/srv", "host_path": "/tmp", "mode": "invalid",},
+        ]
+
+        with pytest.raises(ConfigError):
+            config_parse.valid_kubernetes_options.validate(k8s_options, self.context)
+
+        # After we fix the error, expect error to go away.
+        k8s_options["default_volumes"][1]["mode"] = "RW"
+        assert config_parse.valid_kubernetes_options.validate(k8s_options, self.context,)
 
 
 class TestValidMasterAddress:

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -205,3 +205,14 @@ def test_set_enabled_disable(mock_kubernetes_cluster):
     mock_kubernetes_cluster.runner.stop.assert_called_once()
     assert mock_kubernetes_cluster.deferred is None
     assert mock_kubernetes_cluster.tasks == {}
+
+
+def test_configure_default_volumes():
+    # default_volume validation is done at config time, we just need to validate we are setting it
+    mock_kubernetes_cluster = KubernetesCluster("kube-cluster-a:1234", default_volumes=[])
+    assert mock_kubernetes_cluster.default_volumes == []
+    expected_volumes = [
+        {"container_path": "/tmp", "host_path": "/host/tmp", "mode": "RO",},
+    ]
+    mock_kubernetes_cluster.configure_tasks(default_volumes=expected_volumes)
+    assert mock_kubernetes_cluster.default_volumes == expected_volumes

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -630,11 +630,13 @@ class ValidateKubernetes(Validator):
     defaults = {
         "kubeconfig_path": None,
         "enabled": False,
+        "default_volumes": (),
     }
 
     validators = {
         "kubeconfig_path": valid_string,
         "enabled": valid_bool,
+        "default_volumes": build_list_of_type_validator(valid_volume, allow_empty=True),
     }
 
 

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -93,7 +93,9 @@ ConfigMesos = config_object_factory(
     ],
 )
 
-ConfigKubernetes = config_object_factory(name="ConfigKubernetes", optional=["kubeconfig_path", "enabled",],)
+ConfigKubernetes = config_object_factory(
+    name="ConfigKubernetes", optional=["kubeconfig_path", "enabled", "default_volumes",],
+)
 
 ConfigJob = config_object_factory(
     name="ConfigJob",


### PR DESCRIPTION
This mirrors how we handle default volumes on the mesos side, keeping it as an attribute in `KubernetesClusters` and applying the same to all clusters within a `KubernetesClusterRepository`.  Since we'll just be using the exact same source config for default_volumes, we're copying the config schema & validation logic as well.

Because we have not yet started implementing `create_task` to apply parameters to tasks, I haven't added that to this PR, but this should let us start handling a `default_volumes` key in our master config under `k8s_options`.

The tests are somewhat sparse here (just duplicating existing tests) since we don't *do* much based on this config, we just store it or set a default. Let me know if you think there should be more cases we want to test. 

