### PR TITLE
Fix kubernetes configuration tests to use correct default_volumes class

### DIFF
--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -6,6 +6,7 @@ import pytest
 from task_processing.interfaces.event import Event
 from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
 
+from tron.config.schema import ConfigVolume
 from tron.kubernetes import KubernetesCluster
 from tron.kubernetes import KubernetesTask
 
@@ -212,7 +213,7 @@ def test_configure_default_volumes():
     mock_kubernetes_cluster = KubernetesCluster("kube-cluster-a:1234", default_volumes=[])
     assert mock_kubernetes_cluster.default_volumes == []
     expected_volumes = [
-        {"container_path": "/tmp", "host_path": "/host/tmp", "mode": "RO",},
+        ConfigVolume(container_path="/tmp", host_path="/host/tmp", mode="RO",),
     ]
     mock_kubernetes_cluster.configure_tasks(default_volumes=expected_volumes)
     assert mock_kubernetes_cluster.default_volumes == expected_volumes


### PR DESCRIPTION
In #819 , I added default_volume support to our `k8s_options`.  However, in the test, I specified our test list of `default_volumes` as a list of `dict` rather than the expected `ConfigVolume`.

This fixes the test so this does not mislead anyone in the future.