### PR TITLE
TRON-1637: Add support for secret_env key on action configs

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -675,6 +675,7 @@ class TestValidateJobs(TestCase):
                             docker_image="my_container:latest",
                             docker_parameters=[dict(key="label", value="labelA"), dict(key="label", value="labelB"),],
                             env=dict(USER="batch"),
+                            secret_env=dict(MY_SECRET=dict(secret="k8s-secret-name", key="secret_key")),
                             extra_volumes=[dict(container_path="/tmp", host_path="/home/tmp", mode="RO",),],
                         ),
                         dict(
@@ -709,6 +710,7 @@ class TestValidateJobs(TestCase):
                             schema.ConfigParameter(key="label", value="labelB",),
                         ),
                         env={"USER": "batch"},
+                        secret_env={"MY_SECRET": schema.ConfigSecretSource(secret="k8s-secret-name", key="secret_key")},
                         extra_volumes=(
                             schema.ConfigVolume(
                                 container_path="/tmp", host_path="/home/tmp", mode=schema.VolumeModes.RO.value,

--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -207,6 +207,29 @@ def make_master_jobs():
             cleanup_action=None,
             expected_runtime=datetime.timedelta(1),
         ),
+        "MASTER.test_job_k8s": make_job(
+            name="MASTER.test_job_k8s",
+            node="NodePool",
+            schedule=schedule_parse.ConfigDailyScheduler(
+                original="00:00:00 ", hour=0, minute=0, second=0, days=set(), jitter=None,
+            ),
+            actions={
+                "action_k8s": make_action(
+                    name="action_k8s",
+                    command="test_command_k8s",
+                    executor=schema.ExecutorTypes.kubernetes.value,
+                    cpus=0.1,
+                    mem=100,
+                    disk=600,
+                    docker_image="container:latest",
+                    secret_env=dict(
+                        TEST_SECRET=schema.ConfigSecretSource(secret="tron-secret-test-secret--1", key="secret_1")
+                    ),
+                ),
+            },
+            cleanup_action=None,
+            expected_runtime=datetime.timedelta(1),
+        ),
     }
 
 
@@ -302,6 +325,23 @@ class ConfigTestCase(TestCase):
                         mem=100,
                         disk=600,
                         docker_image="container:latest",
+                    ),
+                ],
+            ),
+            dict(
+                name="test_job_k8s",
+                node="NodePool",
+                schedule="daily",
+                actions=[
+                    dict(
+                        name="action_k8s",
+                        executor="kubernetes",
+                        command="test_command_k8s",
+                        cpus=0.1,
+                        mem=100,
+                        disk=600,
+                        docker_image="container:latest",
+                        secret_env=dict(TEST_SECRET=dict(secret="tron-secret-test-secret--1", key="secret_1")),
                     ),
                 ],
             ),
@@ -578,6 +618,31 @@ class TestJobConfig(TestCase):
         assert_in(expected_msg, str(exception))
 
 
+class TestValidSecretSource(TestCase):
+    def test_missing_secret_name(self):
+        secret_env = dict(key="no_secret_name")
+
+        with pytest.raises(ConfigError) as missing_exc:
+            config_parse.valid_secret_source(secret_env, NullConfigContext)
+
+        assert "missing options: secret" in str(missing_exc.value)
+
+    def test_validate_job_extra_secret_env(self):
+        secret_env = dict(secret="tron-secret-k8s-name-no--secret--name", key="no_secret_name", extra_key="unknown",)
+        with pytest.raises(ConfigError) as missing_exc:
+            config_parse.valid_secret_source(secret_env, NullConfigContext)
+
+        assert "Unknown keys in SecretSource : extra_key" in str(missing_exc.value)
+
+    def test_valid_job_secret_env_success(self):
+        secret_env = dict(secret="tron-secret-k8s-name-no--secret--name", key="no_secret_name",)
+
+        expected_env = schema.ConfigSecretSource(**secret_env)
+
+        built_env = config_parse.valid_secret_source(secret_env, NullConfigContext)
+        assert built_env == expected_env
+
+
 class TestNodeConfig(TestCase):
     def test_validate_node_pool(self):
         config_node_pool = valid_node_pool(dict(name="theName", nodes=["node1", "node2"]),)
@@ -675,7 +740,6 @@ class TestValidateJobs(TestCase):
                             docker_image="my_container:latest",
                             docker_parameters=[dict(key="label", value="labelA"), dict(key="label", value="labelB"),],
                             env=dict(USER="batch"),
-                            secret_env=dict(MY_SECRET=dict(secret="k8s-secret-name", key="secret_key")),
                             extra_volumes=[dict(container_path="/tmp", host_path="/home/tmp", mode="RO",),],
                         ),
                         dict(
@@ -710,7 +774,6 @@ class TestValidateJobs(TestCase):
                             schema.ConfigParameter(key="label", value="labelB",),
                         ),
                         env={"USER": "batch"},
-                        secret_env={"MY_SECRET": schema.ConfigSecretSource(secret="k8s-secret-name", key="secret_key")},
                         extra_volumes=(
                             schema.ConfigVolume(
                                 container_path="/tmp", host_path="/home/tmp", mode=schema.VolumeModes.RO.value,
@@ -871,6 +934,7 @@ class TestConfigContainer(TestCase):
             "test_job2",
             "test_job4",
             "test_job_mesos",
+            "test_job_k8s",
         ]
         assert_equal(set(job_names), set(expected))
 
@@ -882,6 +946,7 @@ class TestConfigContainer(TestCase):
             "test_job2",
             "test_job4",
             "test_job_mesos",
+            "test_job_k8s",
         ]
         assert_equal(set(expected), set(self.container.get_jobs().keys()))
 

--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -223,7 +223,7 @@ def make_master_jobs():
                     disk=600,
                     docker_image="container:latest",
                     secret_env=dict(
-                        TEST_SECRET=schema.ConfigSecretSource(secret="tron-secret-test-secret--1", key="secret_1")
+                        TEST_SECRET=schema.ConfigSecretSource(secret_name="tron-secret-test-secret--1", key="secret_1")
                     ),
                 ),
             },
@@ -341,7 +341,7 @@ class ConfigTestCase(TestCase):
                         mem=100,
                         disk=600,
                         docker_image="container:latest",
-                        secret_env=dict(TEST_SECRET=dict(secret="tron-secret-test-secret--1", key="secret_1")),
+                        secret_env=dict(TEST_SECRET=dict(secret_name="tron-secret-test-secret--1", key="secret_1")),
                     ),
                 ],
             ),
@@ -628,14 +628,16 @@ class TestValidSecretSource(TestCase):
         assert "missing options: secret" in str(missing_exc.value)
 
     def test_validate_job_extra_secret_env(self):
-        secret_env = dict(secret="tron-secret-k8s-name-no--secret--name", key="no_secret_name", extra_key="unknown",)
+        secret_env = dict(
+            secret_name="tron-secret-k8s-name-no--secret--name", key="no_secret_name", extra_key="unknown",
+        )
         with pytest.raises(ConfigError) as missing_exc:
             config_parse.valid_secret_source(secret_env, NullConfigContext)
 
         assert "Unknown keys in SecretSource : extra_key" in str(missing_exc.value)
 
     def test_valid_job_secret_env_success(self):
-        secret_env = dict(secret="tron-secret-k8s-name-no--secret--name", key="no_secret_name",)
+        secret_env = dict(secret_name="tron-secret-k8s-name-no--secret--name", key="no_secret_name",)
 
         expected_env = schema.ConfigSecretSource(**secret_env)
 

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -254,8 +254,8 @@ valid_volume = ValidateVolume()
 class ValidateSecretSource(Validator):
     config_class = ConfigSecretSource
     validators = {
-        "secret": valid_string,
-        "key": valid_string,
+        "secret_name": valid_string,  # name of Kubernetes Secret
+        "key": valid_string,  # key name in Secret data
     }
 
 

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -17,6 +17,7 @@ from tron.config import config_utils
 from tron.config import ConfigError
 from tron.config import schema
 from tron.config.config_utils import build_dict_name_validator
+from tron.config.config_utils import build_dict_value_validator
 from tron.config.config_utils import build_list_of_type_validator
 from tron.config.config_utils import ConfigContext
 from tron.config.config_utils import PartialConfigContext
@@ -38,6 +39,7 @@ from tron.config.schema import ConfigJob
 from tron.config.schema import ConfigKubernetes
 from tron.config.schema import ConfigMesos
 from tron.config.schema import ConfigParameter
+from tron.config.schema import ConfigSecretSource
 from tron.config.schema import ConfigSSHOptions
 from tron.config.schema import ConfigState
 from tron.config.schema import ConfigVolume
@@ -249,6 +251,17 @@ class ValidateVolume(Validator):
 valid_volume = ValidateVolume()
 
 
+class ValidateSecretSource(Validator):
+    config_class = ConfigSecretSource
+    validators = {
+        "secret": valid_string,
+        "key": valid_string,
+    }
+
+
+valid_secret_source = ValidateSecretSource()
+
+
 class ValidateSSHOptions(Validator):
     """Validate SSH options."""
 
@@ -387,6 +400,7 @@ class ValidateAction(Validator):
         "docker_image": None,
         "docker_parameters": None,
         "env": None,
+        "secret_env": None,
         "extra_volumes": None,
         "trigger_downstreams": None,
         "triggered_by": None,
@@ -410,6 +424,7 @@ class ValidateAction(Validator):
         "docker_image": valid_string,
         "docker_parameters": build_list_of_type_validator(valid_docker_parameter, allow_empty=True,),
         "env": valid_dict,
+        "secret_env": build_dict_value_validator(valid_secret_source),
         "extra_volumes": build_list_of_type_validator(valid_volume, allow_empty=True),
         "trigger_downstreams": valid_trigger_downstreams,
         "triggered_by": build_list_of_type_validator(valid_string, allow_empty=True),

--- a/tron/config/config_utils.py
+++ b/tron/config/config_utils.py
@@ -202,11 +202,13 @@ def build_dict_value_validator(item_validator, allow_empty=False):
     """Build a validator which validates values of a dict, and returns a dict"""
 
     def validator(value, config_context):
-        msg = "Duplicate name %%s at %s" % config_context.path
-        name_dict = UniqueNameDict(msg)
+        if not isinstance(value, dict):
+            msg = "Require a dict of type %s at %s"
+            raise ConfigError(msg % (item_validator.type_name, config_context.path))
+        result_dict = dict()
         for k, v in value.items():
-            name_dict[k] = item_validator(v, config_context)
-        return name_dict
+            result_dict[k] = item_validator(v, config_context)
+        return result_dict
 
     return validator
 

--- a/tron/config/config_utils.py
+++ b/tron/config/config_utils.py
@@ -181,7 +181,8 @@ def build_list_of_type_validator(item_validator, allow_empty=False):
 
 
 def build_dict_name_validator(item_validator, allow_empty=False):
-    """Build a validator which validates a list or dict, and returns a dict."""
+    """Build a validator which validates a list or dict, and returns a dict.
+       Item validator must expect a "name" key, mapped to the key of the dict item"""
     valid = build_list_of_type_validator(item_validator, allow_empty)
 
     def validator(value, config_context):
@@ -192,6 +193,19 @@ def build_dict_name_validator(item_validator, allow_empty=False):
         name_dict = UniqueNameDict(msg)
         for item in valid(value, config_context):
             name_dict[item.name] = item
+        return name_dict
+
+    return validator
+
+
+def build_dict_value_validator(item_validator, allow_empty=False):
+    """Build a validator which validates values of a dict, and returns a dict"""
+
+    def validator(value, config_context):
+        msg = "Duplicate name %%s at %s" % config_context.path
+        name_dict = UniqueNameDict(msg)
+        for k, v in value.items():
+            name_dict[k] = item_validator(v, config_context)
         return name_dict
 
     return validator

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -165,6 +165,7 @@ ConfigCleanupAction = config_object_factory(
         "docker_image",  # str
         "docker_parameters",  # List of ConfigParameter
         "env",  # dict
+        "secret_env",  # dict of str, ConfigSecretSource
         "extra_volumes",  # List of ConfigVolume
         "trigger_downstreams",  # None, bool or dict
         "triggered_by",  # list or None

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -138,6 +138,7 @@ ConfigAction = config_object_factory(
         "docker_image",  # str
         "docker_parameters",  # List of ConfigParameter
         "env",  # dict
+        "secret_env",  # dict of str, ConfigSecretSource
         "extra_volumes",  # List of ConfigVolume
         "expected_runtime",  # datetime.Timedelta
         "trigger_downstreams",  # None, bool or dict
@@ -179,6 +180,8 @@ ConfigConstraint = config_object_factory(
 ConfigVolume = config_object_factory(
     name="ConfigVolume", required=["container_path", "host_path", "mode",], optional=[],
 )
+
+ConfigSecretSource = config_object_factory(name="ConfigSecretSource", required=["secret", "key"], optional=[],)
 
 ConfigParameter = config_object_factory(name="ConfigParameter", required=["key", "value",], optional=[],)
 

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -182,7 +182,7 @@ ConfigVolume = config_object_factory(
     name="ConfigVolume", required=["container_path", "host_path", "mode",], optional=[],
 )
 
-ConfigSecretSource = config_object_factory(name="ConfigSecretSource", required=["secret", "key"], optional=[],)
+ConfigSecretSource = config_object_factory(name="ConfigSecretSource", required=["secret_name", "key"], optional=[],)
 
 ConfigParameter = config_object_factory(name="ConfigParameter", required=["key", "value",], optional=[],)
 


### PR DESCRIPTION
*Note*: This PR Is based off of #818. I will update when that is merged. 

With k8s jobs, we will be configuring environment variables from Kubernetes Secret resources.  To do this, we need to know the secret resources' names and keys.

This adds a new `secret_env` key to `TronActionConfig`, which will map an envvar to a `ConfigSecretSource`, whose keys (`secret`, `key`)  map to the required values of a Kubernetes [SecretKeySelector](https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core) (`name`, `key`).

This required adding a new dict validator to verify values of a dict passed an expected validator. The existing `build_dict_name_validator` presumed the type being validated had a `name` field, which is not the case for our `ConfigSecretSource`.