### PR TITLE
TRON-1627: Pass secret_env to taskproc from kubernetes

### DIFF
--- a/tests/core/action_test.py
+++ b/tests/core/action_test.py
@@ -3,6 +3,7 @@ import pytest
 from tron.config.schema import ConfigAction
 from tron.config.schema import ConfigConstraint
 from tron.config.schema import ConfigParameter
+from tron.config.schema import ConfigSecretSource
 from tron.config.schema import ConfigVolume
 from tron.core.action import Action
 
@@ -22,6 +23,7 @@ class TestAction:
             docker_image="fake-docker.com:400/image",
             docker_parameters=[ConfigParameter(key="test", value=123,),],
             env={"TESTING": "true"},
+            secret_env={"TEST_SECRET": ConfigSecretSource(secret_name="tron-secret-svc-sec--A", key="sec_A")},
             extra_volumes=[ConfigVolume(host_path="/tmp", container_path="/nail/tmp", mode="RO",),],
             trigger_downstreams=True,
             triggered_by=["foo.bar"],
@@ -42,6 +44,7 @@ class TestAction:
         assert command_config.docker_image == config.docker_image
         assert command_config.docker_parameters == {("test", 123)}
         assert command_config.env == config.env
+        assert command_config.secret_env == config.secret_env
         assert command_config.extra_volumes == {("/nail/tmp", "/tmp", "RO")}
 
     def test_from_config_none_values(self):
@@ -55,4 +58,5 @@ class TestAction:
         assert command_config.docker_image is None
         assert command_config.docker_parameters == set()
         assert command_config.env == {}
+        assert command_config.secret_env == {}
         assert command_config.extra_volumes == set()

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -24,6 +24,7 @@ class ActionCommandConfig:
     # XXX: we can get rid of docker_parameters once we're off of Mesos
     docker_parameters: set = field(default_factory=set)
     env: dict = field(default_factory=dict)
+    secret_env: dict = field(default_factory=dict)
     extra_volumes: set = field(default_factory=set)
 
     @property
@@ -72,6 +73,7 @@ class Action:
             docker_parameters=set(config.docker_parameters or []),
             extra_volumes=set(config.extra_volumes or []),
             env=config.env or {},
+            secret_env=config.secret_env or {},
         )
         kwargs = dict(
             name=config.name,

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -1034,6 +1034,7 @@ class KubernetesActionRun(ActionRun, Observer):
             disk=attempt.command_config.disk,
             docker_image=attempt.command_config.docker_image,
             env=build_environment(original_env=attempt.command_config.env, run_id=self.id),
+            secret_env=attempt.command_config.secret_env,
             serializer=filehandler.OutputStreamSerializer(self.output_path),
             volumes=attempt.command_config.extra_volumes,
         )

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -17,6 +17,7 @@ from twisted.internet.defer import logError
 import tron.metrics as metrics
 from tron.actioncommand import ActionCommand
 from tron.config.schema import ConfigKubernetes
+from tron.config.schema import ConfigSecretSource
 from tron.config.schema import ConfigVolume
 from tron.serialize.filehandler import OutputStreamSerializer
 from tron.utils.queue import PyDeferredQueue
@@ -305,6 +306,7 @@ class KubernetesCluster:
         disk: Optional[float],
         docker_image: str,
         env: Dict[str, str],
+        secret_env: Dict[str, ConfigSecretSource],
         volumes: Collection[ConfigVolume],
         task_id: Optional[str] = None,
     ) -> Optional[KubernetesTask]:
@@ -329,6 +331,7 @@ class KubernetesCluster:
                 memory=mem,
                 disk=DEFAULT_DISK_LIMIT if disk is None else disk,
                 environment=env,
+                secret_environment={k: v._asdict() for k, v in secret_env.items()},
                 volumes=[
                     volume._asdict()
                     for volume in combine_volumes(defaults=self.default_volumes or [], overrides=volumes)


### PR DESCRIPTION
Once tronfig supports secret_env with #821, this change will use that config to relay to task_proc `KubernetesTaskConfig`'s `secret_environment`, which was added in https://github.com/Yelp/task_processing/pull/170

This continues the same pattern of converting from `Config*` classes to native dicts when we relay to `KubernetesTaskConfig` in `KubernetesCluster.create_task`, as we had been doing with `volumes` from #818
