### PR TITLE
TRON-1611 Handle KubernetesTask State Machine Transitions

### DIFF
--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -108,11 +108,11 @@ def test_handle_event_running(mock_kubernetes_task):
     assert mock_kubernetes_task.state == mock_kubernetes_task.RUNNING
 
 
-def test_handle_event_exit_on_succeeded(mock_kubernetes_task):
+def test_handle_event_exit_on_finished(mock_kubernetes_task):
     mock_kubernetes_task.started()
     mock_kubernetes_task.handle_event(
         mock_event_factory(
-            task_id=mock_kubernetes_task.get_kubernetes_id(), platform_type="succeeded", terminal=True, success=True
+            task_id=mock_kubernetes_task.get_kubernetes_id(), platform_type="finished", terminal=True, success=True
         )
     )
     assert mock_kubernetes_task.state == mock_kubernetes_task.COMPLETE
@@ -123,7 +123,7 @@ def test_handle_event_exit_on_failed(mock_kubernetes_task):
     mock_kubernetes_task.started()
     mock_kubernetes_task.handle_event(
         mock_event_factory(
-            task_id=mock_kubernetes_task.get_kubernetes_id(), platform_type="failed", terminal=True, success=False
+            task_id=mock_kubernetes_task.get_kubernetes_id(), platform_type="FAILED", terminal=True, success=False
         )
     )
 

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -131,16 +131,13 @@ def test_handle_event_exit_on_failed(mock_kubernetes_task):
     assert mock_kubernetes_task.is_done
 
 
-def test_handle_event_unknown(mock_kubernetes_task):
+def test_handle_event_lost(mock_kubernetes_task):
     mock_kubernetes_task.started()
     mock_kubernetes_task.handle_event(
-        mock_event_factory(
-            task_id=mock_kubernetes_task.get_kubernetes_id(), platform_type="unknown", terminal=True, success=False
-        )
+        mock_event_factory(task_id=mock_kubernetes_task.get_kubernetes_id(), platform_type="lost",)
     )
 
     assert mock_kubernetes_task.is_unknown
-    assert mock_kubernetes_task.is_done
 
 
 def test_create_task_disabled():

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -129,8 +129,10 @@ class KubernetesTask(ActionCommand):
             self.exited(0)
         elif k8s_type == "FAILED":
             self.exited(1)
-        elif k8s_type == "unknown":
-            self.log.warning("Kubernetes does not know anything about this task, it is UNKOWN")
+        elif k8s_type == "lost":
+            # Using 'lost' instead of 'unknown' for now until we are sure that before reconcile() is called,
+            # the tasks inside task_metadata map are all UNKNOWN
+            self.log.warning("Kubernetes does not know anything about this task, it is LOST")
             self.log.warning(
                 "This can happen for any number of reasons, and Tron can't know if the task ran or not at all!"
             )

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -123,13 +123,11 @@ class KubernetesTask(ActionCommand):
         except Exception:
             self.log.exception(f"Unable to log event info for id={event_id}.")
 
-        if k8s_type == "pending":
-            pass
-        elif k8s_type == "running":
+        if k8s_type == "running":
             self.started()
-        elif k8s_type == "succeeded":
+        elif k8s_type == "finished":
             self.exited(0)
-        elif k8s_type == "failed":
+        elif k8s_type == "FAILED":
             self.exited(1)
         elif k8s_type == "unknown":
             self.log.warning("Kubernetes does not know anything about this task, it is UNKOWN")

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -109,6 +109,42 @@ class KubernetesTask(ActionCommand):
             self.log.exception(f"Unable to log event info for id={event_id}.")
 
         # TODO(TRON-1611): actually transition to different states
+        if k8s_type == "pending":
+            pass
+        elif k8s_type == "running":
+            self.started()
+        elif k8s_type == "succeeded":
+            self.exited(0)
+        elif k8s_type == "failed":
+            self.exited(1)
+        elif k8s_type == "unknown":
+            self.log.warning("Kubernetes does not know anything about this task, it is UNKOWN")
+            self.log.warning(
+                "This can happen for any number of reasons, and Tron can't know if the task ran or not at all!"
+            )
+            self.log.warning("If you want Tron to RUN it (again) anyway, retry it with:")
+            self.log.warning(f"    tronctl retry {self.id}")
+            self.log.warning("If you want Tron to NOT run it and consider it as a success, skip it with:")
+            self.log.warning(f"    tronctl skip {self.id}")
+            self.log.warning("If you want Tron to NOT run it and consider it as a failure, fail it with:")
+            self.log.warning(f"    tronctl fail {self.id}")
+            self.exited(None)
+        elif k8s_type is None:
+            pass
+        else:
+            self.log.info(f"Did not handle unknown kubernetes event type: {event}",)
+
+        if event.terminal:
+            self.log.info("This Kubernetes event was terminal, ending this action")
+            self.report_resources(decrement=True)
+
+            exit_code = int(not getattr(event, "success", False))
+            # Returns False if we've already exited normally above
+            unexpected_error = self.exited(exit_code)
+            if unexpected_error:
+                self.log.error("Unexpected failure, exiting")
+
+            self.done()
 
 
 class KubernetesCluster:

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -123,7 +123,6 @@ class KubernetesTask(ActionCommand):
         except Exception:
             self.log.exception(f"Unable to log event info for id={event_id}.")
 
-        # TODO(TRON-1611): actually transition to different states
         if k8s_type == "pending":
             pass
         elif k8s_type == "running":


### PR DESCRIPTION
### Description
Tron now checks to see which state machine it will transition to with every new pod event. Pod events are based on the pod lifecycle phases.

### Test
`make test - PASSED`

