### PR TITLE
Install yelp-meteorite when building yelp env

### DIFF
--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,0 +1,1 @@
+yelp-meteorite==2.1.1  # used by task-processing to emit metrics


### PR DESCRIPTION
### Description
Currently, we aren't installing yelp-meteorite, which means that task-processing isn't emitting any metrics. I copied paasta's approach and made it so that when we're inside Yelp, it'll build with yelp-meteorite.

### Testing
new: `make yelpy`
`make deb_bionic` - i saw the diff apply from `extra_requirements_yelp.txt` >> `requirements.txt`, which made the build install yelp-meteorite

### Notes
I won't release this until next week