### PR TITLE
Use un-typo'd failed platform_type for k8s events

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.1.17
+task-processing==0.1.18
 traitlets==4.3.3
 Twisted==20.3.0
 typing-extensions==3.10.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.1.18
+task-processing==0.1.19
 traitlets==4.3.3
 Twisted==20.3.0
 typing-extensions==3.10.0.0

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -125,7 +125,7 @@ def test_handle_event_exit_on_failed(mock_kubernetes_task):
     mock_kubernetes_task.started()
     mock_kubernetes_task.handle_event(
         mock_event_factory(
-            task_id=mock_kubernetes_task.get_kubernetes_id(), platform_type="FAILED", terminal=True, success=False
+            task_id=mock_kubernetes_task.get_kubernetes_id(), platform_type="failed", terminal=True, success=False
         )
     )
 

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -128,7 +128,7 @@ class KubernetesTask(ActionCommand):
             self.started()
         elif k8s_type == "finished":
             self.exited(0)
-        elif k8s_type == "FAILED":
+        elif k8s_type == "failed":
             self.exited(1)
         elif k8s_type == "lost":
             # Using 'lost' instead of 'unknown' for now until we are sure that before reconcile() is called,
@@ -144,8 +144,6 @@ class KubernetesTask(ActionCommand):
             self.log.warning("If you want Tron to NOT run it and consider it as a failure, fail it with:")
             self.log.warning(f"    tronctl fail {self.id}")
             self.exited(None)
-        elif k8s_type is None:
-            pass
         else:
             self.log.info(f"Did not handle unknown kubernetes event type: {event}",)
 


### PR DESCRIPTION
see https://github.com/Yelp/task_processing/pull/173 :p