### PR TITLE
Make copy of k8s tasks while iterating to stop them

### DIFF
--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -309,7 +309,8 @@ class KubernetesCluster:
         self.queue = PyDeferredQueue()
 
         if fail_tasks:
-            for key, task in self.tasks.items():
+            # NOTE: we're turning this into a list on purpose: otherwise we're modifying the dict we're iterating over
+            for key, task in list(self.tasks.items()):
                 # set the task status to unknown
                 task.exited(exit_status=None)
                 del self.tasks[key]


### PR DESCRIPTION
I incorrectly "fixed" some code when porting from Mesos -> Kubernetes
and introduced a bug