### PR TITLE
Actually kill k8s Pods on KubernetesActionRun::kill()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.1.19
+task-processing==0.1.21
 traitlets==4.3.3
 Twisted==20.3.0
 typing-extensions==3.10.0.0

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -1664,3 +1664,37 @@ class TestKubernetesActionRun:
         assert mock_k8s_action_run.is_unknown
         assert mock_get_cluster.return_value.recover.call_count == 0
         assert mock_k8s_action_run.end_time is not None
+
+    @mock.patch("tron.core.actionrun.KubernetesClusterRepository", autospec=True)
+    def test_kill_task_k8s(self, mock_cluster_repo, mock_k8s_action_run):
+        mock_get_cluster = mock_cluster_repo.get_cluster
+        last_attempt = mock_k8s_action_run.create_attempt()
+        last_attempt.kubernetes_task_id = "fake_task_id"
+        mock_k8s_action_run.machine.state = ActionRun.RUNNING
+
+        mock_k8s_action_run.kill()
+        mock_get_cluster.return_value.kill.assert_called_once_with(last_attempt.kubernetes_task_id)
+
+    @mock.patch("tron.core.actionrun.KubernetesClusterRepository", autospec=True)
+    def test_kill_task_no_task_id_k8s(self, mock_cluster_repo, mock_k8s_action_run):
+        mock_k8s_action_run.machine.state = ActionRun.RUNNING
+        mock_k8s_action_run.create_attempt()
+        error_message = mock_k8s_action_run.kill()
+        assert error_message == "Error: Can't find task id for the action."
+
+    @mock.patch("tron.core.actionrun.KubernetesClusterRepository", autospec=True)
+    def test_stop_task_k8s(self, mock_cluster_repo, mock_k8s_action_run):
+        mock_get_cluster = mock_cluster_repo.get_cluster
+        last_attempt = mock_k8s_action_run.create_attempt()
+        last_attempt.kubernetes_task_id = "fake_task_id"
+        mock_k8s_action_run.machine.state = ActionRun.RUNNING
+
+        mock_k8s_action_run.stop()
+        mock_get_cluster.return_value.kill.assert_called_once_with(last_attempt.kubernetes_task_id)
+
+    @mock.patch("tron.core.actionrun.KubernetesClusterRepository", autospec=True)
+    def test_stop_task_no_task_id_k8s(self, mock_cluster_repo, mock_k8s_action_run):
+        mock_k8s_action_run.machine.state = ActionRun.RUNNING
+        mock_k8s_action_run.create_attempt()
+        error_message = mock_k8s_action_run.stop()
+        assert error_message == "Error: Can't find task id for the action."


### PR DESCRIPTION
We had left this method stubbed out until we implemented kill()
in task_processing, but now we can actually finish implemention here.