### PR TITLE
Implement reconciling & task recovery for Kubernetes

### DIFF
--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -1609,6 +1609,7 @@ class TestKubernetesActionRun:
                 secret_env=mock_k8s_action_run.command_config.secret_env,
                 serializer=serializer,
                 volumes=mock_k8s_action_run.command_config.extra_volumes,
+                task_id=last_attempt.kubernetes_task_id,
             ), mock_get_cluster.return_value.create_task.calls
             task = mock_get_cluster.return_value.create_task.return_value
             mock_get_cluster.return_value.recover.assert_called_once_with(task)

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -376,8 +376,9 @@ def test_submit(mock_kubernetes_cluster, mock_kubernetes_task):
 
 
 def test_recover(mock_kubernetes_cluster, mock_kubernetes_task):
-    mock_kubernetes_cluster.recover(mock_kubernetes_task)
+    with mock.patch.object(mock_kubernetes_task, "started", autospec=True) as mock_started:
+        mock_kubernetes_cluster.recover(mock_kubernetes_task)
 
     assert mock_kubernetes_task.get_kubernetes_id() in mock_kubernetes_cluster.tasks
     mock_kubernetes_cluster.runner.reconcile.assert_called_once_with(mock_kubernetes_task.get_config())
-    assert mock_kubernetes_task.started.call_count == 1
+    assert mock_started.call_count == 1

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -373,3 +373,11 @@ def test_submit(mock_kubernetes_cluster, mock_kubernetes_task):
     assert mock_kubernetes_task.get_kubernetes_id() in mock_kubernetes_cluster.tasks
     assert mock_kubernetes_cluster.tasks[mock_kubernetes_task.get_kubernetes_id()] == mock_kubernetes_task
     mock_kubernetes_cluster.runner.run.assert_called_once_with(mock_kubernetes_task.get_config())
+
+
+def test_recover(mock_kubernetes_cluster, mock_kubernetes_task):
+    mock_kubernetes_cluster.recover(mock_kubernetes_task)
+
+    assert mock_kubernetes_task.get_kubernetes_id() in mock_kubernetes_cluster.tasks
+    mock_kubernetes_cluster.runner.reconcile.assert_called_once_with(mock_kubernetes_task.get_config())
+    assert mock_kubernetes_task.started.call_count == 1

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -1053,7 +1053,7 @@ class KubernetesActionRun(ActionRun, Observer):
     def recover(self) -> Optional[KubernetesTask]:
         """
         Called on Tron restart per previously running ActionRun to attempt to restart Tron's tracking
-        of this run.
+        of this run. See tron.core.recovery
 
         If we're able to successfully recover, a KubernetesTask representing what is currently being run
         will be returned - otherwise, None.

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -1058,7 +1058,53 @@ class KubernetesActionRun(ActionRun, Observer):
         If we're able to successfully recover, a KubernetesTask representing what is currently being run
         will be returned - otherwise, None.
         """
-        pass
+        k8s_cluster = KubernetesClusterRepository.get_cluster()
+        if not k8s_cluster:
+            self.fail(self.EXIT_KUBERNETES_NOT_CONFIGURED)
+            return None
+
+        # We cannot recover if we can't transition to running
+        if not self.machine.check("running"):
+            log.error(f"{self} unable to transition from {self.machine.state}" "to running for recovery",)
+            return
+
+        if not self.attempts or self.attempts[-1].kubernetes_task_id is None:
+            log.error(f"{self} no task ID, cannot recover")
+            self.fail_unknown()
+            return
+
+        last_attempt = self.attempts[-1]
+
+        log.info(f"{self} recovering Kubernetes run")
+
+        task = k8s_cluster.create_task(
+            action_run_id=self.id,
+            command=last_attempt.rendered_command,
+            cpus=last_attempt.command_config.cpus,
+            mem=last_attempt.command_config.mem,
+            disk=last_attempt.command_config.disk,
+            docker_image=last_attempt.command_config.docker_image,
+            env=build_environment(original_env=last_attempt.command_config.env, run_id=self.id),
+            secret_env=last_attempt.command_config.secret_env,
+            serializer=filehandler.OutputStreamSerializer(self.output_path),
+            volumes=last_attempt.command_config.extra_volumes,
+        )
+        if not task:
+            log.warning(
+                f"{self} cannot recover, Kubernetes is disabled or "
+                f"invalid task ID {last_attempt.kubernetes_task_id!r}",
+            )
+            self.fail_unknown()
+            return
+
+        self.watch(task)
+        k8s_cluster.recover(task)
+
+        # Reset status
+        self.clear_end_state()
+        self.transition_and_notify("running")
+
+        return task
 
     def stop(self) -> Optional[str]:
         """

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -1065,7 +1065,7 @@ class KubernetesActionRun(ActionRun, Observer):
 
         # We cannot recover if we can't transition to running
         if not self.machine.check("running"):
-            log.error(f"{self} unable to transition from {self.machine.state}" "to running for recovery",)
+            log.error(f"{self} unable to transition from {self.machine.state} to running for recovery")
             return
 
         if not self.attempts or self.attempts[-1].kubernetes_task_id is None:

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -1088,6 +1088,7 @@ class KubernetesActionRun(ActionRun, Observer):
             secret_env=last_attempt.command_config.secret_env,
             serializer=filehandler.OutputStreamSerializer(self.output_path),
             volumes=last_attempt.command_config.extra_volumes,
+            task_id=last_attempt.kubernetes_task_id,
         )
         if not task:
             log.warning(

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -1,6 +1,7 @@
 import logging
 
 from tron.core.actionrun import ActionRun
+from tron.core.actionrun import KubernetesActionRun
 from tron.core.actionrun import MesosActionRun
 from tron.core.actionrun import SSHActionRun
 
@@ -10,6 +11,7 @@ log = logging.getLogger(__name__)
 def filter_action_runs_needing_recovery(action_runs):
     ssh_runs = []
     mesos_runs = []
+    kubernetes_runs = []
     for action_run in action_runs:
         if isinstance(action_run, SSHActionRun):
             if action_run.state == ActionRun.UNKNOWN:
@@ -17,7 +19,10 @@ def filter_action_runs_needing_recovery(action_runs):
         elif isinstance(action_run, MesosActionRun):
             if action_run.state == ActionRun.UNKNOWN and action_run.end_time is None:
                 mesos_runs.append(action_run)
-    return ssh_runs, mesos_runs
+        elif isinstance(action_run, KubernetesActionRun):
+            if action_run.state == ActionRun.UNKNOWN and action_run.end_time is None:
+                kubernetes_runs.append(action_run)
+    return ssh_runs, mesos_runs, kubernetes_runs
 
 
 def launch_recovery_actionruns_for_job_runs(job_runs, master_action_runner):
@@ -26,9 +31,13 @@ def launch_recovery_actionruns_for_job_runs(job_runs, master_action_runner):
             log.info(f"Skipping recovery of {run} with no action runs (may have been cleaned up)")
             continue
 
-        ssh_runs, mesos_runs = filter_action_runs_needing_recovery(run._action_runs)
+        # Why do we do this separately if we just need to call recover()
+        ssh_runs, mesos_runs, kubernetes_runs = filter_action_runs_needing_recovery(run._action_runs)
         for action_run in ssh_runs:
             action_run.recover()
 
         for action_run in mesos_runs:
+            action_run.recover()
+
+        for action_run in kubernetes_runs:
             action_run.recover()

--- a/tron/core/recovery.py
+++ b/tron/core/recovery.py
@@ -31,7 +31,7 @@ def launch_recovery_actionruns_for_job_runs(job_runs, master_action_runner):
             log.info(f"Skipping recovery of {run} with no action runs (may have been cleaned up)")
             continue
 
-        # Why do we do this separately if we just need to call recover()
+        # TODO: Why do we do this separately if we just need to call recover()
         ssh_runs, mesos_runs, kubernetes_runs = filter_action_runs_needing_recovery(run._action_runs)
         for action_run in ssh_runs:
             action_run.recover()

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -217,8 +217,6 @@ class KubernetesCluster:
             log.info("Reusing previously created runner.")
             return self.runner
 
-        # TODO: once we start implementing more things in the executor, we'll need to actually pass
-        # down some config
         executor = self.processor.executor_from_config(
             provider="kubernetes",
             provider_config={
@@ -446,13 +444,14 @@ class KubernetesCluster:
             return
 
         self._check_connection()
+        assert self.runner is not None, "Unable to correctly setup k8s runner!"
 
-        # pod name
+        # the task/kubernetes id is really just the pod name
         task_id = task.get_kubernetes_id()
         self.tasks[task_id] = task
         task.log.info("TRON RESTARTED! Starting recovery procedure by reconciling state for this task from Kubernetes")
         task.started()
-        self.runner.reconcile(task.get_config())  # type: ignore  # we need to add type annotation to task_proc
+        self.runner.reconcile(task.get_config())
         task.report_resources()
 
 

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -221,7 +221,12 @@ class KubernetesCluster:
         # TODO: once we start implementing more things in the executor, we'll need to actually pass
         # down some config
         executor = self.processor.executor_from_config(
-            provider="kubernetes", provider_config={"namespace": "tron", "kubeconfig_path": self.kubeconfig_path,},
+            provider="kubernetes",
+            provider_config={
+                "namespace": "tron",
+                "kubeconfig_path": self.kubeconfig_path,
+                "task_configs": [task.get_config() for task in self.tasks.values()],
+            },
         )
 
         return Subscription(executor, queue)
@@ -433,7 +438,23 @@ class KubernetesCluster:
         """
         Given an instance of a KubernetesTask, attempt to reconcile the current state of the task from Kubernetes.
         """
-        pass
+        if not task:
+            return
+
+        if not self.enabled:
+            task.log.info("Could not recover task, Kubernetes usage is disabled.")
+            task.exited(None)
+            return
+
+        self._check_connection()
+
+        # pod name
+        task_id = task.get_kubernetes_id()
+        self.tasks[task_id] = task
+        task.log.info("TRON RESTARTED! Starting recovery procedure by reconciling state for this task from Kubernetes")
+        task.started()
+        self.runner.reconcile(task.get_config())  # type: ignore  # we need to add type annotation to task_proc
+        task.report_resources()
 
 
 class KubernetesClusterRepository:

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -47,8 +47,7 @@ def combine_volumes(defaults: Collection[ConfigVolume], overrides: Collection[Co
 
 class KubernetesTask(ActionCommand):
     def __init__(self, action_run_id: str, task_config: KubernetesTaskConfig, serializer=None):
-        # TODO(TASKPROC-238): use the actual task command once that exists
-        super().__init__(id=action_run_id, command="ls", serializer=serializer)
+        super().__init__(id=action_run_id, command=task_config.command, serializer=serializer)
 
         self.task_config = task_config
 


### PR DESCRIPTION
With https://github.com/Yelp/task_processing/pull/175 our KubernetesPodExecutor will support `reconcile(KubernetesTaskConfig)`.

When tron is starting up, it will attempt to [recover all jobs](https://github.com/Yelp/Tron/blob/master/tron/mcp.py#L141) [from saved state](https://github.com/Yelp/Tron/blob/master/tron/core/job_scheduler.py#L27-L45) and call [action_run.recover() for each still-running action_run](https://github.com/Yelp/Tron/blob/master/tron/core/recovery.py#L23-L34).

This implements KubernetesActionRun.recover to be handled during that startup process^, which in turn calls KubernetesCluster.recover, which will call KubernetesPodExecutor.reconcile().

The implementation is nearly identical to the mesos version and is tested in the same way.  The only exception is that because our kubernetes_task_id's are pod names, we also pass that along when recreating the task so we can track the correct pod's current status in reconcile(). 

An additional fix included in this PR is relaying our KubernetesTask command to ActionCommand's command (there was a TODO left undone after supporting `command` in `KubernetesTaskConfig`).