### PR TITLE
TRON-1658: Fix issue restoring KubernetesActionRuns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.1.21
+task-processing==0.1.22
 traitlets==4.3.3
 Twisted==20.3.0
 typing-extensions==3.10.0.0

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -215,6 +215,17 @@ class TestActionRunFactory:
         assert not action_run.is_cleanup
         assert action_run.__class__ == MesosActionRun
 
+    def test_action_run_from_state_kubernetes(self, state_data):
+        state_data["executor"] = ExecutorTypes.kubernetes.value
+        action_run = ActionRunFactory.action_run_from_state(self.job_run, state_data,)
+
+        assert action_run.job_run_id == state_data["job_run_id"]
+        action_name = state_data["action_name"]
+        assert action_run.command_config == self.action_graph.action_map[action_name].command_config
+
+        assert not action_run.is_cleanup
+        assert action_run.__class__ == KubernetesActionRun
+
 
 class TestActionRun:
     @pytest.fixture(autouse=True)

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -1620,6 +1620,8 @@ class TestKubernetesActionRun:
                 secret_env=mock_k8s_action_run.command_config.secret_env,
                 serializer=serializer,
                 volumes=mock_k8s_action_run.command_config.extra_volumes,
+                cap_add=mock_k8s_action_run.command_config.cap_add,
+                cap_drop=mock_k8s_action_run.command_config.cap_drop,
                 task_id=last_attempt.kubernetes_task_id,
             ), mock_get_cluster.return_value.create_task.calls
             task = mock_get_cluster.return_value.create_task.return_value

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -1092,6 +1092,8 @@ class KubernetesActionRun(ActionRun, Observer):
             secret_env=last_attempt.command_config.secret_env,
             serializer=filehandler.OutputStreamSerializer(self.output_path),
             volumes=last_attempt.command_config.extra_volumes,
+            cap_add=last_attempt.command_config.cap_add,
+            cap_drop=last_attempt.command_config.cap_drop,
             task_id=last_attempt.kubernetes_task_id,
         )
         if not task:

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -110,6 +110,8 @@ class ActionRunFactory:
 
         if state_data.get("executor") == ExecutorTypes.mesos.value:
             return MesosActionRun.from_state(**args)
+        if state_data.get("executor") == ExecutorTypes.kubernetes.value:
+            return KubernetesActionRun.from_state(**args)
         return SSHActionRun.from_state(**args)
 
 


### PR DESCRIPTION
in #829 we implemented recover() for KubernetesActionRuns and depended on job_collection.recover_state to eventually call this; however I missed handling KubernetesActionRuns when restoring an action run from state, so these jobs were recreated as SSHActionRuns erroneously.

In addition, #827 was also merged and added cap_add/cap_drop as required params to `create_task`, so these also need to be added when we recreate the task in `recover()`.

This fixes the issue and works well on our playground instance, and still-running pods are correctly updated to state `running` as expected. 