### PR TITLE
Support node selectors/affinity for k8s tasks

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -9,3 +9,6 @@ warn_redundant_casts = True
 warn_return_any = True
 warn_unreachable = True
 warn_unused_ignores = True
+
+[mypy-clusterman_metrics.*]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.1.22
+task-processing==0.1.24
 traitlets==4.3.3
 Twisted==20.3.0
 typing-extensions==3.10.0.0

--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -29,6 +29,7 @@ from tron.config.config_parse import valid_output_stream_dir
 from tron.config.config_parse import validate_fragment
 from tron.config.config_utils import NullConfigContext
 from tron.config.schedule_parse import ConfigDailyScheduler
+from tron.config.schema import ConfigNodeAffinity
 from tron.config.schema import MASTER_NAMESPACE
 
 BASE_CONFIG = dict(
@@ -227,6 +228,8 @@ def make_master_jobs():
                     secret_env=dict(
                         TEST_SECRET=schema.ConfigSecretSource(secret_name="tron-secret-test-secret--1", key="secret_1")
                     ),
+                    node_selectors={"yelp.com/pool": "default"},
+                    node_affinities=(ConfigNodeAffinity(key="instance_type", operator="In", value=("a1.1xlarge",),),),
                 ),
             },
             cleanup_action=None,
@@ -346,6 +349,8 @@ class ConfigTestCase(TestCase):
                         secret_env=dict(TEST_SECRET=dict(secret_name="tron-secret-test-secret--1", key="secret_1")),
                         cap_add=["KILL"],
                         cap_drop=["CHOWN", "KILL"],
+                        node_selectors={"yelp.com/pool": "default"},
+                        node_affinities=[{"key": "instance_type", "operator": "In", "value": ["a1.1xlarge"]}],
                     ),
                 ],
             ),

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -1623,6 +1623,8 @@ class TestKubernetesActionRun:
                 cap_add=mock_k8s_action_run.command_config.cap_add,
                 cap_drop=mock_k8s_action_run.command_config.cap_drop,
                 task_id=last_attempt.kubernetes_task_id,
+                node_selectors=mock_k8s_action_run.command_config.node_selectors,
+                node_affinities=mock_k8s_action_run.command_config.node_affinities,
             ), mock_get_cluster.return_value.create_task.calls
             task = mock_get_cluster.return_value.create_task.return_value
             mock_get_cluster.return_value.recover.assert_called_once_with(task)

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -159,6 +159,8 @@ def test_create_task_disabled():
         volumes=[],
         cap_add=[],
         cap_drop=[],
+        node_selectors={"yelp.com/pool": "default"},
+        node_affinities=[],
     )
 
     assert task is None
@@ -180,6 +182,8 @@ def test_create_task(mock_kubernetes_cluster):
         volumes=[],
         cap_add=[],
         cap_drop=[],
+        node_selectors={"yelp.com/pool": "default"},
+        node_affinities=[],
     )
 
     assert task is not None
@@ -202,6 +206,8 @@ def test_create_task_with_task_id(mock_kubernetes_cluster):
         volumes=[],
         cap_add=[],
         cap_drop=[],
+        node_selectors={"yelp.com/pool": "default"},
+        node_affinities=[],
     )
 
     mock_kubernetes_cluster.runner.TASK_CONFIG_INTERFACE().set_pod_name.assert_called_once_with("yay.1234")
@@ -227,6 +233,8 @@ def test_create_task_with_invalid_task_id(mock_kubernetes_cluster):
             volumes=[],
             cap_add=[],
             cap_drop=[],
+            node_selectors={"yelp.com/pool": "default"},
+            node_affinities=[],
         )
 
     assert task is None
@@ -254,6 +262,8 @@ def test_create_task_with_config(mock_kubernetes_cluster):
         "volumes": [v._asdict() for v in default_volumes + config_volumes],
         "cap_add": ["KILL"],
         "cap_drop": ["KILL", "CHOWN"],
+        "node_selectors": {"yelp.com/pool": "default"},
+        "node_affinities": [],
     }
 
     task = mock_kubernetes_cluster.create_task(
@@ -270,6 +280,8 @@ def test_create_task_with_config(mock_kubernetes_cluster):
         volumes=config_volumes,
         cap_add=["KILL"],
         cap_drop=["KILL", "CHOWN"],
+        node_selectors={"yelp.com/pool": "default"},
+        node_affinities=[],
     )
 
     assert task is not None

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -147,6 +147,8 @@ ConfigAction = config_object_factory(
         "triggered_by",  # list or None
         "on_upstream_rerun",  # ActionOnRerun or None
         "trigger_timeout",  # datetime.deltatime or None
+        "node_selectors",
+        "node_affinities",
     ],
 )
 
@@ -175,6 +177,8 @@ ConfigCleanupAction = config_object_factory(
         "triggered_by",  # list or None
         "on_upstream_rerun",  # ActionOnRerun or None
         "trigger_timeout",  # datetime.deltatime or None
+        "node_selectors",
+        "node_affinities",
     ],
 )
 
@@ -187,6 +191,10 @@ ConfigVolume = config_object_factory(
 )
 
 ConfigSecretSource = config_object_factory(name="ConfigSecretSource", required=["secret_name", "key"], optional=[],)
+
+ConfigNodeAffinity = config_object_factory(
+    name="ConfigNodeAffinity", required=["key", "operator", "value"], optional=[],
+)
 
 ConfigParameter = config_object_factory(name="ConfigParameter", required=["key", "value",], optional=[],)
 

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -8,6 +8,7 @@ from dataclasses import fields
 
 from tron import node
 from tron.config.schema import CLEANUP_ACTION_NAME
+from tron.config.schema import ConfigNodeAffinity
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +30,8 @@ class ActionCommandConfig:
     env: dict = field(default_factory=dict)
     secret_env: dict = field(default_factory=dict)
     extra_volumes: set = field(default_factory=set)
+    node_selectors: dict = field(default_factory=dict)
+    node_affinities: List[ConfigNodeAffinity] = field(default_factory=list)
 
     @property
     def state_data(self):
@@ -79,6 +82,8 @@ class Action:
             secret_env=config.secret_env or {},
             cap_add=config.cap_add or [],
             cap_drop=config.cap_drop or [],
+            node_selectors=config.node_selectors or {},
+            node_affinities=config.node_affinities or [],
         )
         kwargs = dict(
             name=config.name,

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -1106,6 +1106,8 @@ class KubernetesActionRun(ActionRun, Observer):
             cap_add=last_attempt.command_config.cap_add,
             cap_drop=last_attempt.command_config.cap_drop,
             task_id=last_attempt.kubernetes_task_id,
+            node_selectors=last_attempt.command_config.node_selectors,
+            node_affinities=last_attempt.command_config.node_affinities,
         )
         if not task:
             log.warning(

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from dataclasses import dataclass
 from dataclasses import fields
+from pyrsistent import InvariantException
 from twisted.internet import reactor
 
 from tron import command_context
@@ -199,6 +200,7 @@ class ActionRun(Observable):
     EXIT_MESOS_DISABLED = -5
     EXIT_KUBERNETES_DISABLED = -6
     EXIT_KUBERNETES_NOT_CONFIGURED = -7
+    EXIT_KUBERNETES_TASK_INVALID = -8
 
     EXIT_REASONS = {
         EXIT_INVALID_COMMAND: "Invalid command",
@@ -208,6 +210,7 @@ class ActionRun(Observable):
         EXIT_MESOS_DISABLED: "Mesos disabled",
         EXIT_KUBERNETES_DISABLED: "Kubernetes disabled",
         EXIT_KUBERNETES_NOT_CONFIGURED: "Kubernetes enabled, but not configured",
+        EXIT_KUBERNETES_TASK_INVALID: "Kubernetes task was not valid",
     }
 
     # This is a list of "alternate locations" that we can look for stdout/stderr in
@@ -1028,20 +1031,28 @@ class KubernetesActionRun(ActionRun, Observer):
             self.fail(self.EXIT_KUBERNETES_NOT_CONFIGURED)
             return None
 
-        task = k8s_cluster.create_task(
-            action_run_id=self.id,
-            command=attempt.rendered_command,
-            cpus=attempt.command_config.cpus,
-            mem=attempt.command_config.mem,
-            disk=attempt.command_config.disk,
-            docker_image=attempt.command_config.docker_image,
-            env=build_environment(original_env=attempt.command_config.env, run_id=self.id),
-            secret_env=attempt.command_config.secret_env,
-            serializer=filehandler.OutputStreamSerializer(self.output_path),
-            volumes=attempt.command_config.extra_volumes,
-            cap_add=attempt.command_config.cap_add,
-            cap_drop=attempt.command_config.cap_drop,
-        )
+        try:
+            task = k8s_cluster.create_task(
+                action_run_id=self.id,
+                command=attempt.rendered_command,
+                cpus=attempt.command_config.cpus,
+                mem=attempt.command_config.mem,
+                disk=attempt.command_config.disk,
+                docker_image=attempt.command_config.docker_image,
+                env=build_environment(original_env=attempt.command_config.env, run_id=self.id),
+                secret_env=attempt.command_config.secret_env,
+                serializer=filehandler.OutputStreamSerializer(self.output_path),
+                volumes=attempt.command_config.extra_volumes,
+                cap_add=attempt.command_config.cap_add,
+                cap_drop=attempt.command_config.cap_drop,
+                node_selectors=attempt.command_config.node_selectors,
+                node_affinities=attempt.command_config.node_affinities,
+            )
+        except InvariantException:
+            log.exception(f"Unable to create task for ActionRun {self.id}")
+            self.fail(self.EXIT_KUBERNETES_TASK_INVALID)
+            return None
+
         if not task:
             # generally, if we didn't get a task back that means that k8s usage is disabled
             self.fail(self.EXIT_KUBERNETES_DISABLED)

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -17,6 +17,7 @@ from twisted.internet.defer import logError
 import tron.metrics as metrics
 from tron.actioncommand import ActionCommand
 from tron.config.schema import ConfigKubernetes
+from tron.config.schema import ConfigNodeAffinity
 from tron.config.schema import ConfigSecretSource
 from tron.config.schema import ConfigVolume
 from tron.serialize.filehandler import OutputStreamSerializer
@@ -349,6 +350,8 @@ class KubernetesCluster:
         volumes: Collection[ConfigVolume],
         cap_add: Collection[str],
         cap_drop: Collection[str],
+        node_selectors: Dict[str, str],
+        node_affinities: ConfigNodeAffinity,
         task_id: Optional[str] = None,
     ) -> Optional[KubernetesTask]:
         """
@@ -379,6 +382,8 @@ class KubernetesCluster:
                     volume._asdict()
                     for volume in combine_volumes(defaults=self.default_volumes or [], overrides=volumes)
                 ],
+                node_selectors=node_selectors,
+                node_affinities=[affinity._asdict() for affinity in node_affinities],
             ),
         )
 


### PR DESCRIPTION
We need node selector support for our "pool" concept and node
affinities will give us parity with the concept we had in Mesos of
"extra_constraints".

This additionally adds some error handling when things fail any
invariants for a KubernetesTaskConfig - previously, an
InvariantException meant that we would never realize that a
KubernetesTaskConfig was invalid and that the ActionRun would never
work.