### PR TITLE
Show duration in ActionRun history table

### DIFF
--- a/tronweb/coffee/actionrun.coffee
+++ b/tronweb/coffee/actionrun.coffee
@@ -71,6 +71,7 @@ class module.ActionRunHistoryListEntryView extends ClickableListEntry
         <td><%= modules.actionrun.formatExit(exit_status) %></td>
         <td><%= dateFromNow(start_time, "None") %></td>
         <td><%= dateFromNow(end_time, "") %></td>
+        <td><%= duration %></td>
     """
 
     render: ->


### PR DESCRIPTION
This was missed when this view was initially created and is helpful for
users to determine how run times for a given action are changing over
time at a glance.