### PR TITLE
Support passing Pod labels to task_processing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.1.24
+task-processing==0.1.25
 traitlets==4.3.3
 Twisted==20.3.0
 typing-extensions==3.10.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.1.25
+task-processing==0.1.26
 traitlets==4.3.3
 Twisted==20.3.0
 typing-extensions==3.10.0.0

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -1625,6 +1625,7 @@ class TestKubernetesActionRun:
                 task_id=last_attempt.kubernetes_task_id,
                 node_selectors=mock_k8s_action_run.command_config.node_selectors,
                 node_affinities=mock_k8s_action_run.command_config.node_affinities,
+                pod_labels=mock_k8s_action_run.command_config.labels,
             ), mock_get_cluster.return_value.create_task.calls
             task = mock_get_cluster.return_value.create_task.return_value
             mock_get_cluster.return_value.recover.assert_called_once_with(task)

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -161,6 +161,7 @@ def test_create_task_disabled():
         cap_drop=[],
         node_selectors={"yelp.com/pool": "default"},
         node_affinities=[],
+        pod_labels={},
     )
 
     assert task is None
@@ -184,6 +185,7 @@ def test_create_task(mock_kubernetes_cluster):
         cap_drop=[],
         node_selectors={"yelp.com/pool": "default"},
         node_affinities=[],
+        pod_labels={},
     )
 
     assert task is not None
@@ -208,6 +210,7 @@ def test_create_task_with_task_id(mock_kubernetes_cluster):
         cap_drop=[],
         node_selectors={"yelp.com/pool": "default"},
         node_affinities=[],
+        pod_labels={},
     )
 
     mock_kubernetes_cluster.runner.TASK_CONFIG_INTERFACE().set_pod_name.assert_called_once_with("yay.1234")
@@ -235,6 +238,7 @@ def test_create_task_with_invalid_task_id(mock_kubernetes_cluster):
             cap_drop=[],
             node_selectors={"yelp.com/pool": "default"},
             node_affinities=[],
+            pod_labels={},
         )
 
     assert task is None
@@ -264,6 +268,7 @@ def test_create_task_with_config(mock_kubernetes_cluster):
         "cap_drop": ["KILL", "CHOWN"],
         "node_selectors": {"yelp.com/pool": "default"},
         "node_affinities": [],
+        "labels": {},
     }
 
     task = mock_kubernetes_cluster.create_task(
@@ -282,6 +287,7 @@ def test_create_task_with_config(mock_kubernetes_cluster):
         cap_drop=["KILL", "CHOWN"],
         node_selectors={"yelp.com/pool": "default"},
         node_affinities=[],
+        pod_labels={},
     )
 
     assert task is not None

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -444,6 +444,7 @@ class ValidateAction(Validator):
         "trigger_timeout": None,
         "node_selectors": None,
         "node_affinities": None,
+        "labels": None,
     }
     requires = build_list_of_type_validator(valid_action_name, allow_empty=True,)
     validators = {
@@ -472,6 +473,7 @@ class ValidateAction(Validator):
         "trigger_timeout": config_utils.valid_time_delta,
         "node_selectors:": valid_dict,
         "node_affinities": build_list_of_type_validator(valid_node_affinity, allow_empty=True),
+        "labels:": valid_dict,
     }
 
     def post_validation(self, action, config_context):
@@ -514,6 +516,7 @@ class ValidateCleanupAction(Validator):
         "trigger_timeout": None,
         "node_selectors": None,
         "node_affinities": None,
+        "labels": None,
     }
     validators = {
         "name": valid_cleanup_action_name,
@@ -539,6 +542,7 @@ class ValidateCleanupAction(Validator):
         "trigger_timeout": config_utils.valid_time_delta,
         "node_selectors:": valid_dict,
         "node_affinities": build_list_of_type_validator(valid_node_affinity, allow_empty=True),
+        "labels": valid_dict,
     }
 
     def post_validation(self, action, config_context):

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -147,8 +147,9 @@ ConfigAction = config_object_factory(
         "triggered_by",  # list or None
         "on_upstream_rerun",  # ActionOnRerun or None
         "trigger_timeout",  # datetime.deltatime or None
-        "node_selectors",
-        "node_affinities",
+        "node_selectors",  # Dict of str, str
+        "node_affinities",  # List of ConfigNodeAffinity
+        "labels",  # Dict of str, str
     ],
 )
 
@@ -177,8 +178,9 @@ ConfigCleanupAction = config_object_factory(
         "triggered_by",  # list or None
         "on_upstream_rerun",  # ActionOnRerun or None
         "trigger_timeout",  # datetime.deltatime or None
-        "node_selectors",
-        "node_affinities",
+        "node_selectors",  # Dict of str, str
+        "node_affinities",  # List of ConfigNodeAffinity
+        "labels",  # Dict of str, str
     ],
 )
 

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -32,6 +32,7 @@ class ActionCommandConfig:
     extra_volumes: set = field(default_factory=set)
     node_selectors: dict = field(default_factory=dict)
     node_affinities: List[ConfigNodeAffinity] = field(default_factory=list)
+    labels: dict = field(default_factory=dict)
 
     @property
     def state_data(self):
@@ -84,6 +85,7 @@ class Action:
             cap_drop=config.cap_drop or [],
             node_selectors=config.node_selectors or {},
             node_affinities=config.node_affinities or [],
+            labels=config.labels or {},
         )
         kwargs = dict(
             name=config.name,

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -1058,6 +1058,7 @@ class KubernetesActionRun(ActionRun, Observer):
                 cap_drop=attempt.command_config.cap_drop,
                 node_selectors=attempt.command_config.node_selectors,
                 node_affinities=attempt.command_config.node_affinities,
+                pod_labels=attempt.command_config.labels,
             )
         except InvariantException:
             log.exception(f"Unable to create task for ActionRun {self.id}")
@@ -1119,6 +1120,7 @@ class KubernetesActionRun(ActionRun, Observer):
             task_id=last_attempt.kubernetes_task_id,
             node_selectors=last_attempt.command_config.node_selectors,
             node_affinities=last_attempt.command_config.node_affinities,
+            pod_labels=last_attempt.command_config.labels,
         )
         if not task:
             log.warning(

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -352,6 +352,7 @@ class KubernetesCluster:
         cap_drop: Collection[str],
         node_selectors: Dict[str, str],
         node_affinities: ConfigNodeAffinity,
+        pod_labels: Dict[str, str],
         task_id: Optional[str] = None,
     ) -> Optional[KubernetesTask]:
         """
@@ -384,6 +385,7 @@ class KubernetesCluster:
                 ],
                 node_selectors=node_selectors,
                 node_affinities=[affinity._asdict() for affinity in node_affinities],
+                labels=pod_labels,
             ),
         )
 


### PR DESCRIPTION
We'll need this to set labels required by the PaaSTA Workload Contract
(which is needed to ensure that internal tooling will work as expected
with our Pods)