### PR TITLE
Filter per-instance Tronjob logs by cluster

### DIFF
--- a/tests/utils/scribereader_test.py
+++ b/tests/utils/scribereader_test.py
@@ -23,7 +23,9 @@ def test_read_log_stream_for_action_run_min_date_and_max_date_today():
         "tron.utils.scribereader.scribereader.get_stream_reader", autospec=True,
     ) as mock_stream_reader, mock.patch(
         "tron.utils.scribereader.scribereader.get_stream_tailer", autospec=True,
-    ) as mock_stream_tailer:
+    ) as mock_stream_tailer, mock.patch(
+        "tron.utils.scribereader.get_superregion", autospec=True, return_value="fake",
+    ):
         # in this case, we shouldn't even try to check the reader, so lets set an exception
         # to make sure we didn't try
         mock_stream_reader.return_value.__enter__.side_effect = Exception
@@ -34,24 +36,31 @@ def test_read_log_stream_for_action_run_min_date_and_max_date_today():
                 "tron_run_number": 1234,
                 "component": "stdout",
                 "message": "line 1",
-                "timestamp": "2021-01-02T18:10:09.169421619Z"
+                "timestamp": "2021-01-02T18:10:09.169421619Z",
+                "cluster": "fake"
             }""",
                 """{
                 "tron_run_number": 1234,
                 "component": "stdout",
                 "message": "line 2",
-                "timestamp": "2021-01-02T18:11:09.169421619Z"
+                "timestamp": "2021-01-02T18:11:09.169421619Z",
+                "cluster": "fake"
             }""",
                 """{
                 "tron_run_number": 1234,
                 "component": "stderr",
                 "message": "line 3",
-                "timestamp": "2021-01-02T18:12:09.169421619Z"
+                "timestamp": "2021-01-02T18:12:09.169421619Z",
+                "cluster": "fake"
             }""",
             ]
         )
         output = read_log_stream_for_action_run(
-            action_run_id="namespace.job.1234.action", component="stdout", min_date=min_date, max_date=max_date,
+            action_run_id="namespace.job.1234.action",
+            component="stdout",
+            min_date=min_date,
+            max_date=max_date,
+            paasta_cluster="fake",
         )
 
     mock_stream_reader.assert_not_called()
@@ -73,7 +82,9 @@ def test_read_log_stream_for_action_run_min_date_and_max_date_different_days():
         "tron.utils.scribereader.scribereader.get_stream_reader", autospec=True,
     ) as mock_stream_reader, mock.patch(
         "tron.utils.scribereader.scribereader.get_stream_tailer", autospec=True,
-    ) as mock_stream_tailer:
+    ) as mock_stream_tailer, mock.patch(
+        "tron.utils.scribereader.get_superregion", autospec=True, return_value="fake",
+    ):
         # we should check the reader for data from a previous day
         mock_stream_reader.return_value.__enter__.return_value = iter(
             [
@@ -81,7 +92,8 @@ def test_read_log_stream_for_action_run_min_date_and_max_date_different_days():
                 "tron_run_number": 1234,
                 "component": "stdout",
                 "message": "line 0",
-                "timestamp": "2021-01-02T18:10:09.169421619Z"
+                "timestamp": "2021-01-02T18:10:09.169421619Z",
+                "cluster": "fake"
             }""",
             ]
         )
@@ -92,24 +104,38 @@ def test_read_log_stream_for_action_run_min_date_and_max_date_different_days():
                 "tron_run_number": 1234,
                 "component": "stdout",
                 "message": "line 1",
-                "timestamp": "2021-01-02T18:10:09.169421619Z"
+                "timestamp": "2021-01-02T18:10:09.169421619Z",
+                "cluster": "fake"
             }""",
                 """{
                 "tron_run_number": 1234,
                 "component": "stdout",
                 "message": "line 2",
-                "timestamp": "2021-01-02T18:11:09.169421619Z"
+                "timestamp": "2021-01-02T18:11:09.169421619Z",
+                "cluster": "fake"
             }""",
                 """{
                 "tron_run_number": 1234,
                 "component": "stderr",
                 "message": "line 3",
-                "timestamp": "2021-01-02T18:12:09.169421619Z"
+                "timestamp": "2021-01-02T18:12:09.169421619Z",
+                "cluster": "fake"
+            }""",
+                """{
+                "tron_run_number": 1234,
+                "component": "stdout",
+                "message": "line 4",
+                "timestamp": "2021-01-02T18:12:09.169421619Z",
+                "cluster": "bad_fake"
             }""",
             ]
         )
         output = read_log_stream_for_action_run(
-            action_run_id="namespace.job.1234.action", component="stdout", min_date=min_date, max_date=max_date,
+            action_run_id="namespace.job.1234.action",
+            component="stdout",
+            min_date=min_date,
+            max_date=max_date,
+            paasta_cluster="fake",
         )
 
     mock_stream_reader.assert_called_once_with(
@@ -137,7 +163,9 @@ def test_read_log_stream_for_action_run_min_date_and_max_date_in_past():
         "tron.utils.scribereader.scribereader.get_stream_reader", autospec=True,
     ) as mock_stream_reader, mock.patch(
         "tron.utils.scribereader.scribereader.get_stream_tailer", autospec=True,
-    ) as mock_stream_tailer:
+    ) as mock_stream_tailer, mock.patch(
+        "tron.utils.scribereader.get_superregion", autospec=True, return_value="fake",
+    ):
         # all the data we want is from the past, so we should only check the reader
         mock_stream_reader.return_value.__enter__.return_value = iter(
             [
@@ -145,14 +173,19 @@ def test_read_log_stream_for_action_run_min_date_and_max_date_in_past():
                 "tron_run_number": 1234,
                 "component": "stdout",
                 "message": "line 0",
-                "timestamp": "2021-01-02T18:10:09.169421619Z"
+                "timestamp": "2021-01-02T18:10:09.169421619Z",
+                "cluster": "fake"
             }""",
             ]
         )
         # so lets make sure we don't call the tailer
         mock_stream_tailer.return_value.__iter__.side_effect = Exception
         output = read_log_stream_for_action_run(
-            action_run_id="namespace.job.1234.action", component="stdout", min_date=min_date, max_date=max_date,
+            action_run_id="namespace.job.1234.action",
+            component="stdout",
+            min_date=min_date,
+            max_date=max_date,
+            paasta_cluster="fake",
         )
 
     mock_stream_reader.assert_called_once_with(


### PR DESCRIPTION
It's possible that a tronjob in pnw-dev and norcal-devc could log to the
same stream (e.g., they have the same {namespace}.{job}.{action}
identifier and therefore will both log to
stream_paasta_app_output_{namespace}_{job}__{action}).

Currently, if this were to be the case and these jobs ran on the same
days with similar run numbers, we would mix the output from these two
runs when looking at the Tron UI for either of these.

Every task has a PAASTA_CLUSTER environment variable, so we can look at
the environment that we started a task with in order to filter the log
streams for these actions since these streams contain the cluster name
of where the logged message came from.

Therefore, we use this to ensure that we only display the correct log
messages to users instead of potentially mixing the output from jobs
with the same name that log to the same stream from different clusters.