### PR TITLE
Add a flush() method to our FileHandleWrapper class

### DIFF
--- a/tron/serialize/filehandler.py
+++ b/tron/serialize/filehandler.py
@@ -27,6 +27,10 @@ class NullFileHandle:
         pass
 
     @classmethod
+    def flush(cls):
+        pass
+
+    @classmethod
     def close(cls):
         pass
 
@@ -71,6 +75,14 @@ class FileHandleWrapper:
                 self.last_accessed = time.time()
                 self._fh.write(maybe_encode(content))
                 self.manager.update(self)
+
+    def flush(self) -> None:
+        with self._fh_lock:
+            if self._fh is not None:
+                try:
+                    self._fh.flush()
+                except OSError:
+                    log.exception("Failed to flush %s", self.name)
 
     def __enter__(self):
         return self


### PR DESCRIPTION
https://docs.python.org/3/library/logging.handlers.html#streamhandler
mentions that any stream passed to a logging.StreamHandler should also
support a flush() method. Without this, we don't get any "meta" output
for k8s Tronjobs until the ActionRun has completed and the file has been
closed.