### PR TITLE
Handle exceptions when creating a kubernetes executor

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,6 +24,6 @@ pyparsing==2.4.2
 pytest==6.2.2
 pytest-asyncio==0.14.0
 requirements-tools==1.2.1
-toml==0.10.0
+toml==0.10.2
 typed-ast==1.4.0
 virtualenv==16.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ hyperlink==19.0.0
 idna==2.8
 importlib-metadata==1.3.0
 incremental==17.5.0
-ipdb==0.12.2
+ipdb==0.13.2
 ipython==7.8.0
 ipython-genutils==0.2.0
 jedi==0.15.1

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -221,16 +221,20 @@ class KubernetesCluster:
             log.info("Reusing previously created runner.")
             return self.runner
 
-        executor = self.processor.executor_from_config(
-            provider="kubernetes",
-            provider_config={
-                "namespace": "tron",
-                "kubeconfig_path": self.kubeconfig_path,
-                "task_configs": [task.get_config() for task in self.tasks.values()],
-            },
-        )
+        try:
+            executor = self.processor.executor_from_config(
+                provider="kubernetes",
+                provider_config={
+                    "namespace": "tron",
+                    "kubeconfig_path": self.kubeconfig_path,
+                    "task_configs": [task.get_config() for task in self.tasks.values()],
+                },
+            )
 
-        return Subscription(executor, queue)
+            return Subscription(executor, queue)
+        except Exception:
+            log.exception("Unhandled exception while attempting to instantiate k8s task_proc plugin")
+            return None
 
     def handle_next_event(self, _=None) -> None:
         """


### PR DESCRIPTION
It's possible to run Tron somewhere with incorrect config (e.g., when
doing local development or on a "real" Tron master that hasn't fully
run Puppet).

Without this change, this situation could result in Tronjobs that are
stuck in a "Starting" stage forever (at least, until you do something
like restart Tron and force a state reconciliation).