### PR TITLE
Upgrade scribereader so that we can read logs in corpdev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,6 +24,6 @@ pyparsing==2.4.2
 pytest==6.2.2
 pytest-asyncio==0.14.0
 requirements-tools==1.2.1
-toml==0.10.0
+toml==0.10.2
 typed-ast==1.4.0
 virtualenv==16.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ hyperlink==19.0.0
 idna==2.8
 importlib-metadata==1.3.0
 incremental==17.5.0
-ipdb==0.12.2
+ipdb==0.13.2
 ipython==7.8.0
 ipython-genutils==0.2.0
 jedi==0.15.1

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -221,16 +221,20 @@ class KubernetesCluster:
             log.info("Reusing previously created runner.")
             return self.runner
 
-        executor = self.processor.executor_from_config(
-            provider="kubernetes",
-            provider_config={
-                "namespace": "tron",
-                "kubeconfig_path": self.kubeconfig_path,
-                "task_configs": [task.get_config() for task in self.tasks.values()],
-            },
-        )
+        try:
+            executor = self.processor.executor_from_config(
+                provider="kubernetes",
+                provider_config={
+                    "namespace": "tron",
+                    "kubeconfig_path": self.kubeconfig_path,
+                    "task_configs": [task.get_config() for task in self.tasks.values()],
+                },
+            )
 
-        return Subscription(executor, queue)
+            return Subscription(executor, queue)
+        except Exception:
+            log.exception("Unhandled exception while attempting to instantiate k8s task_proc plugin")
+            return None
 
     def handle_next_event(self, _=None) -> None:
         """

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,5 +1,5 @@
 clusterman-metrics==2.2.1  # used by tron for pre-scaling for Spark runs
-scribereader==0.13.1  # used by tron to get tronjob logs
+scribereader==0.14.0  # used by tron to get tronjob logs
 yelp-clog==5.2.3  # scribereader dependency
 yelp-logging==4.17.0  # scribereader dependency
 yelp-meteorite==2.1.1  # used by task-processing to emit metrics, clusterman-metrics dependency


### PR DESCRIPTION
We duplicate the ecosystems that we can point scribereader at in the
package and that list was missing corpdev

This causes a KeyError when trying to get the tailer host:port tuple for
tron in corpdev