### PR TITLE
Allow passing Pod annotations to task_processing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.1.26
+task-processing==0.2.0
 traitlets==4.3.3
 Twisted==20.3.0
 typing-extensions==3.10.0.0

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -1626,6 +1626,7 @@ class TestKubernetesActionRun:
                 node_selectors=mock_k8s_action_run.command_config.node_selectors,
                 node_affinities=mock_k8s_action_run.command_config.node_affinities,
                 pod_labels=mock_k8s_action_run.command_config.labels,
+                pod_annotations=mock_k8s_action_run.command_config.annotations,
             ), mock_get_cluster.return_value.create_task.calls
             task = mock_get_cluster.return_value.create_task.return_value
             mock_get_cluster.return_value.recover.assert_called_once_with(task)

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -162,6 +162,7 @@ def test_create_task_disabled():
         node_selectors={"yelp.com/pool": "default"},
         node_affinities=[],
         pod_labels={},
+        pod_annotations={},
     )
 
     assert task is None
@@ -186,6 +187,7 @@ def test_create_task(mock_kubernetes_cluster):
         node_selectors={"yelp.com/pool": "default"},
         node_affinities=[],
         pod_labels={},
+        pod_annotations={},
     )
 
     assert task is not None
@@ -211,6 +213,7 @@ def test_create_task_with_task_id(mock_kubernetes_cluster):
         node_selectors={"yelp.com/pool": "default"},
         node_affinities=[],
         pod_labels={},
+        pod_annotations={},
     )
 
     mock_kubernetes_cluster.runner.TASK_CONFIG_INTERFACE().set_pod_name.assert_called_once_with("yay.1234")
@@ -239,6 +242,7 @@ def test_create_task_with_invalid_task_id(mock_kubernetes_cluster):
             node_selectors={"yelp.com/pool": "default"},
             node_affinities=[],
             pod_labels={},
+            pod_annotations={},
         )
 
     assert task is None
@@ -269,6 +273,7 @@ def test_create_task_with_config(mock_kubernetes_cluster):
         "node_selectors": {"yelp.com/pool": "default"},
         "node_affinities": [],
         "labels": {},
+        "annotations": {},
     }
 
     task = mock_kubernetes_cluster.create_task(
@@ -288,6 +293,7 @@ def test_create_task_with_config(mock_kubernetes_cluster):
         node_selectors={"yelp.com/pool": "default"},
         node_affinities=[],
         pod_labels={},
+        pod_annotations={},
     )
 
     assert task is not None

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -445,6 +445,7 @@ class ValidateAction(Validator):
         "node_selectors": None,
         "node_affinities": None,
         "labels": None,
+        "annotations": None,
     }
     requires = build_list_of_type_validator(valid_action_name, allow_empty=True,)
     validators = {
@@ -474,6 +475,7 @@ class ValidateAction(Validator):
         "node_selectors:": valid_dict,
         "node_affinities": build_list_of_type_validator(valid_node_affinity, allow_empty=True),
         "labels:": valid_dict,
+        "annotations": valid_dict,
     }
 
     def post_validation(self, action, config_context):
@@ -517,6 +519,7 @@ class ValidateCleanupAction(Validator):
         "node_selectors": None,
         "node_affinities": None,
         "labels": None,
+        "annotations": None,
     }
     validators = {
         "name": valid_cleanup_action_name,
@@ -543,6 +546,7 @@ class ValidateCleanupAction(Validator):
         "node_selectors:": valid_dict,
         "node_affinities": build_list_of_type_validator(valid_node_affinity, allow_empty=True),
         "labels": valid_dict,
+        "annotations": valid_dict,
     }
 
     def post_validation(self, action, config_context):

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -150,6 +150,7 @@ ConfigAction = config_object_factory(
         "node_selectors",  # Dict of str, str
         "node_affinities",  # List of ConfigNodeAffinity
         "labels",  # Dict of str, str
+        "annotations",  # Dict of str, str
     ],
 )
 
@@ -181,6 +182,7 @@ ConfigCleanupAction = config_object_factory(
         "node_selectors",  # Dict of str, str
         "node_affinities",  # List of ConfigNodeAffinity
         "labels",  # Dict of str, str
+        "annotations",  # Dict of str, str
     ],
 )
 

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -33,6 +33,7 @@ class ActionCommandConfig:
     node_selectors: dict = field(default_factory=dict)
     node_affinities: List[ConfigNodeAffinity] = field(default_factory=list)
     labels: dict = field(default_factory=dict)
+    annotations: dict = field(default_factory=dict)
 
     @property
     def state_data(self):
@@ -86,6 +87,7 @@ class Action:
             node_selectors=config.node_selectors or {},
             node_affinities=config.node_affinities or [],
             labels=config.labels or {},
+            annotations=config.annotations or {},
         )
         kwargs = dict(
             name=config.name,

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -1059,6 +1059,7 @@ class KubernetesActionRun(ActionRun, Observer):
                 node_selectors=attempt.command_config.node_selectors,
                 node_affinities=attempt.command_config.node_affinities,
                 pod_labels=attempt.command_config.labels,
+                pod_annotations=attempt.command_config.annotations,
             )
         except InvariantException:
             log.exception(f"Unable to create task for ActionRun {self.id}")
@@ -1121,6 +1122,7 @@ class KubernetesActionRun(ActionRun, Observer):
             node_selectors=last_attempt.command_config.node_selectors,
             node_affinities=last_attempt.command_config.node_affinities,
             pod_labels=last_attempt.command_config.labels,
+            pod_annotations=last_attempt.command_config.annotations,
         )
         if not task:
             log.warning(

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -357,6 +357,7 @@ class KubernetesCluster:
         node_selectors: Dict[str, str],
         node_affinities: ConfigNodeAffinity,
         pod_labels: Dict[str, str],
+        pod_annotations: Dict[str, str],
         task_id: Optional[str] = None,
     ) -> Optional[KubernetesTask]:
         """
@@ -390,6 +391,7 @@ class KubernetesCluster:
                 node_selectors=node_selectors,
                 node_affinities=[affinity._asdict() for affinity in node_affinities],
                 labels=pod_labels,
+                annotations=pod_annotations,
             ),
         )
 


### PR DESCRIPTION
We'll need this to toggle certain behaviors (e.g., disable
Pods getting routable IPs internally).