### PR TITLE
Add Service Account support for k8s jobs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.2.0
+task-processing==0.3.0
 traitlets==4.3.3
 Twisted==20.3.0
 typing-extensions==3.10.0.0

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -163,6 +163,7 @@ def test_create_task_disabled():
         node_affinities=[],
         pod_labels={},
         pod_annotations={},
+        service_account_name=None,
     )
 
     assert task is None
@@ -188,6 +189,7 @@ def test_create_task(mock_kubernetes_cluster):
         node_affinities=[],
         pod_labels={},
         pod_annotations={},
+        service_account_name=None,
     )
 
     assert task is not None
@@ -214,6 +216,7 @@ def test_create_task_with_task_id(mock_kubernetes_cluster):
         node_affinities=[],
         pod_labels={},
         pod_annotations={},
+        service_account_name=None,
     )
 
     mock_kubernetes_cluster.runner.TASK_CONFIG_INTERFACE().set_pod_name.assert_called_once_with("yay.1234")
@@ -243,6 +246,7 @@ def test_create_task_with_invalid_task_id(mock_kubernetes_cluster):
             node_affinities=[],
             pod_labels={},
             pod_annotations={},
+            service_account_name=None,
         )
 
     assert task is None
@@ -274,6 +278,7 @@ def test_create_task_with_config(mock_kubernetes_cluster):
         "node_affinities": [],
         "labels": {},
         "annotations": {},
+        "service_account_name": None,
     }
 
     task = mock_kubernetes_cluster.create_task(
@@ -294,6 +299,7 @@ def test_create_task_with_config(mock_kubernetes_cluster):
         node_affinities=[],
         pod_labels={},
         pod_annotations={},
+        service_account_name=None,
     )
 
     assert task is not None

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -446,6 +446,7 @@ class ValidateAction(Validator):
         "node_affinities": None,
         "labels": None,
         "annotations": None,
+        "service_account_name": None,
     }
     requires = build_list_of_type_validator(valid_action_name, allow_empty=True,)
     validators = {
@@ -476,6 +477,7 @@ class ValidateAction(Validator):
         "node_affinities": build_list_of_type_validator(valid_node_affinity, allow_empty=True),
         "labels:": valid_dict,
         "annotations": valid_dict,
+        "service_account_name": valid_string,
     }
 
     def post_validation(self, action, config_context):
@@ -520,6 +522,7 @@ class ValidateCleanupAction(Validator):
         "node_affinities": None,
         "labels": None,
         "annotations": None,
+        "service_account_name": None,
     }
     validators = {
         "name": valid_cleanup_action_name,
@@ -547,6 +550,7 @@ class ValidateCleanupAction(Validator):
         "node_affinities": build_list_of_type_validator(valid_node_affinity, allow_empty=True),
         "labels": valid_dict,
         "annotations": valid_dict,
+        "service_account_name": valid_string,
     }
 
     def post_validation(self, action, config_context):

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -151,6 +151,7 @@ ConfigAction = config_object_factory(
         "node_affinities",  # List of ConfigNodeAffinity
         "labels",  # Dict of str, str
         "annotations",  # Dict of str, str
+        "service_account_name",  # str
     ],
 )
 
@@ -183,6 +184,7 @@ ConfigCleanupAction = config_object_factory(
         "node_affinities",  # List of ConfigNodeAffinity
         "labels",  # Dict of str, str
         "annotations",  # Dict of str, str
+        "service_account_name",  # str
     ],
 )
 

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 from typing import List
+from typing import Optional
 
 from dataclasses import dataclass
 from dataclasses import field
@@ -34,6 +35,7 @@ class ActionCommandConfig:
     node_affinities: List[ConfigNodeAffinity] = field(default_factory=list)
     labels: dict = field(default_factory=dict)
     annotations: dict = field(default_factory=dict)
+    service_account_name: Optional[str] = None
 
     @property
     def state_data(self):
@@ -88,6 +90,7 @@ class Action:
             node_affinities=config.node_affinities or [],
             labels=config.labels or {},
             annotations=config.annotations or {},
+            service_account_name=config.service_account_name or None,
         )
         kwargs = dict(
             name=config.name,

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -1060,6 +1060,7 @@ class KubernetesActionRun(ActionRun, Observer):
                 node_affinities=attempt.command_config.node_affinities,
                 pod_labels=attempt.command_config.labels,
                 pod_annotations=attempt.command_config.annotations,
+                service_account_name=attempt.command_config.service_account_name,
             )
         except InvariantException:
             log.exception(f"Unable to create task for ActionRun {self.id}")

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -358,6 +358,7 @@ class KubernetesCluster:
         node_affinities: ConfigNodeAffinity,
         pod_labels: Dict[str, str],
         pod_annotations: Dict[str, str],
+        service_account_name: Optional[str],
         task_id: Optional[str] = None,
     ) -> Optional[KubernetesTask]:
         """
@@ -392,6 +393,7 @@ class KubernetesCluster:
                 node_affinities=[affinity._asdict() for affinity in node_affinities],
                 labels=pod_labels,
                 annotations=pod_annotations,
+                service_account_name=service_account_name,
             ),
         )
 


### PR DESCRIPTION
We'll use this for Pod Identity - there's a webhook that will inject
a secret token + some environment variables if a Pod has a Service
Account set up.

paasta-tools will be in charge of creating the Service Account that
we'll use if it doesn't exist (as well as setting up the annotations on
that Service Account).

NOTE: tests will fail until https://github.com/Yelp/task_processing/pull/186 is merged/released, but I tested this locally with a manually built task_proc wheel (both automated tests and actually running a Pod)