### PR TITLE
Pass service_account_name in create_task() during recovery

### DIFF
--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -1627,6 +1627,7 @@ class TestKubernetesActionRun:
                 node_affinities=mock_k8s_action_run.command_config.node_affinities,
                 pod_labels=mock_k8s_action_run.command_config.labels,
                 pod_annotations=mock_k8s_action_run.command_config.annotations,
+                service_account_name=mock_k8s_action_run.command_config.service_account_name,
             ), mock_get_cluster.return_value.create_task.calls
             task = mock_get_cluster.return_value.create_task.return_value
             mock_get_cluster.return_value.recover.assert_called_once_with(task)

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -1124,6 +1124,7 @@ class KubernetesActionRun(ActionRun, Observer):
             node_affinities=last_attempt.command_config.node_affinities,
             pod_labels=last_attempt.command_config.labels,
             pod_annotations=last_attempt.command_config.annotations,
+            service_account_name=last_attempt.command_config.service_account_name,
         )
         if not task:
             log.warning(


### PR DESCRIPTION
I missed this create_task callsite in the initial PR - without this,
we'll fail to recover state when Tron restarts.