### PR TITLE
Silence yelp_clog.StreamTailer logs + k8s event guard

### DIFF
--- a/dev/logging.conf
+++ b/dev/logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=root, twisted, tron, tron.serialize.runstate.statemanager, tron.api.www.access, task_processing, tron.mesos.task_output, pymesos
+keys=root, twisted, tron, tron.serialize.runstate.statemanager, tron.api.www.access, task_processing, tron.mesos.task_output, pymesos, yelp_lib.clog.StreamTailer
 
 [handlers]
 keys=stdoutHandler, accessHandler, nullHandler
@@ -63,6 +63,12 @@ args=()
 class=logging.NullHandler
 level=DEBUG
 args=()
+
+[logger_yelp_lib.clog.StreamTailer]
+level=CRITICAL
+handlers=nullHandler
+qualname=yelp_lib.clog.StreamTailer
+propagate=0
 
 [handler_accessHandler]
 class=logging.StreamHandler

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -104,7 +104,10 @@ class KubernetesTask(ActionCommand):
         Helper to log nice-to-have information (may fail).
         """
         k8s_type = getattr(event, "platform_type", None)
-        if k8s_type == "running":
+        # when Tron restarts, we'll get a number of events with an unfilled raw attribute
+        # these are safe to skip since we'll already have printed out the hostname of the
+        # box running the task corresponding to this event
+        if k8s_type == "running" and event.raw:
             hostname = event.raw.get("spec", {}).get("nodeName", "UNKNOWN")
             self.log.info(f"Running on hostname: {hostname}")
 

--- a/tron/logging.conf
+++ b/tron/logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=root, twisted, tron, tron.serialize, task_processing, tron.mesos.task_output, pymesos
+keys=root, twisted, tron, tron.serialize, task_processing, tron.mesos.task_output, pymesos, yelp_lib.clog.StreamTailer
 
 [handlers]
 keys=timedRotatingFileHandler, syslogHandler, nullHandler
@@ -45,6 +45,12 @@ propagate=0
 level=INFO
 handlers=nullHandler
 qualname=tron.mesos.task_output
+propagate=0
+
+[logger_yelp_lib.clog.StreamTailer]
+level=CRITICAL
+handlers=nullHandler
+qualname=yelp_lib.clog.StreamTailer
 propagate=0
 
 [handler_timedRotatingFileHandler]


### PR DESCRIPTION
This should cleanup any non-fatal exceptions that we see in Tron logs.

The logger changes silence yelp_clog complaining about being unable to setup signal handlers
and the kubernetes.py silences a somewhat rare traceback when we get task_proc events that somehow have no raw attribute (which happens when we recover jobs on a restart)