### PR TITLE
Accept executor: spark

### DIFF
--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -447,6 +447,7 @@ class ValidateAction(Validator):
         "labels": None,
         "annotations": None,
         "service_account_name": None,
+        "spark_driver_service_account_name": None,
     }
     requires = build_list_of_type_validator(valid_action_name, allow_empty=True,)
     validators = {
@@ -478,6 +479,7 @@ class ValidateAction(Validator):
         "labels:": valid_dict,
         "annotations": valid_dict,
         "service_account_name": valid_string,
+        "spark_driver_service_account_name": valid_string,
     }
 
     def post_validation(self, action, config_context):
@@ -523,6 +525,7 @@ class ValidateCleanupAction(Validator):
         "labels": None,
         "annotations": None,
         "service_account_name": None,
+        "spark_driver_service_account_name": None,
     }
     validators = {
         "name": valid_cleanup_action_name,
@@ -551,6 +554,7 @@ class ValidateCleanupAction(Validator):
         "labels": valid_dict,
         "annotations": valid_dict,
         "service_account_name": valid_string,
+        "spark_driver_service_account_name": valid_string,
     }
 
     def post_validation(self, action, config_context):

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -152,6 +152,7 @@ ConfigAction = config_object_factory(
         "labels",  # Dict of str, str
         "annotations",  # Dict of str, str
         "service_account_name",  # str
+        "spark_driver_service_account_name",  # str
     ],
 )
 
@@ -185,6 +186,7 @@ ConfigCleanupAction = config_object_factory(
         "labels",  # Dict of str, str
         "annotations",  # Dict of str, str
         "service_account_name",  # str
+        "spark_driver_service_account_name",  # str
     ],
 )
 

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -206,7 +206,7 @@ ConfigParameter = config_object_factory(name="ConfigParameter", required=["key",
 
 StatePersistenceTypes = Enum("StatePersistenceTypes", dict(shelve="shelve", yaml="yaml", dynamodb="dynamodb"),)
 
-ExecutorTypes = Enum("ExecutorTypes", dict(ssh="ssh", mesos="mesos", kubernetes="kubernetes"))
+ExecutorTypes = Enum("ExecutorTypes", dict(ssh="ssh", mesos="mesos", kubernetes="kubernetes", spark="spark"))
 
 ActionRunnerTypes = Enum("ActionRunnerTypes", dict(none="none", subprocess="subprocess"))
 


### PR DESCRIPTION
For the upcoming work with Spark drivers on Kubernetes, we'll be
bubbling up the fact the `executor: spark` config from soaconfigs rather
than normalizing it to `kubernetes` (or `mesos` as we did for the
initial attempt at "paasta-native" spark drivers).

For now, this will do nothing - but it will allow us to start building
out stuff in paasta/soaconfigs without failing validation