### PR TITLE
Always restart trond if it goes down

### DIFF
--- a/debian/tron.service
+++ b/debian/tron.service
@@ -7,7 +7,7 @@ User=tron
 EnvironmentFile=/etc/default/tron
 ExecStart=/usr/bin/trond --lock-file=${LOCKFILE:-$PIDFILE} --working-dir=${WORKINGDIR} --host ${LISTEN_HOST} --port ${LISTEN_PORT} ${DAEMON_OPTS}
 TimeoutStopSec=20
-Restart=on-failure
+Restart=always
 LimitNOFILE=10000
 
 [Install]


### PR DESCRIPTION
### Description
Tron somehow went down with exit 0 and therefore didn't come back up. I couldn't find any obvious reasons for how it could exit 0. The only way that Tron should be able is through a sigwait inside a `while True`, and in that case, it would only exit non-zero. At least this PR will make it always restart.

### Testing
`systemd-analyze verify tron.service`