### PR TITLE
Bump pysensu-yelp to pull in issuetype support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ Pygments==2.4.2
 PyHamcrest==2.0.2
 pymesos==0.3.9
 pyrsistent==0.15.4
-pysensu-yelp==0.4.1
+pysensu-yelp==0.4.4
 PyStaticConfiguration==0.10.4
 python-dateutil==2.8.1
 python-jose==3.0.1


### PR DESCRIPTION
https://github.com/Yelp/pysensu-yelp/pull/30 was released in
pysensu-yelp==0.4.4 and allows users to set the issuetype for a ticket
(so that sensu-created tickets aren't always of type `Bug` (the default))