### PR TITLE
Tag state updates with executor (if available)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ whitelist_externals =
     /bin/mkdir
 commands =
     # TODO: upgrade behave if they ever take this reasonable PR
-    pip install git+git://github.com/Yelp/behave@1.2.5-issue_533-fork
+    pip install git+https://github.com/Yelp/behave@1.2.5-issue_533-fork
     behave {posargs}
 
 [testenv:trond_inside_container]

--- a/tron/core/actiongraph.py
+++ b/tron/core/actiongraph.py
@@ -1,6 +1,8 @@
 import logging
 from collections import namedtuple
+from typing import Mapping
 
+from tron.core.action import Action
 from tron.utils.timeutils import delta_total_seconds
 
 log = logging.getLogger(__name__)
@@ -10,7 +12,7 @@ Trigger = namedtuple("Trigger", ["name", "command"])
 class ActionGraph:
     """A directed graph of actions and their requirements for a specific job."""
 
-    def __init__(self, action_map, required_actions, required_triggers):
+    def __init__(self, action_map: Mapping[str, Action], required_actions, required_triggers):
         self.action_map = action_map
         self.required_actions = required_actions
         self.required_triggers = required_triggers


### PR DESCRIPTION
Core ML would like to be able to use this log for dashboarding purposes,
but there's currently no trivial way to partition actions by type with
the information in the log (without doing some funky joins on other
data)