### PR TITLE
Create KubernetesActionRuns for executor: spark

### DIFF
--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -447,7 +447,6 @@ class ValidateAction(Validator):
         "labels": None,
         "annotations": None,
         "service_account_name": None,
-        "spark_driver_service_account_name": None,
     }
     requires = build_list_of_type_validator(valid_action_name, allow_empty=True,)
     validators = {
@@ -479,7 +478,6 @@ class ValidateAction(Validator):
         "labels:": valid_dict,
         "annotations": valid_dict,
         "service_account_name": valid_string,
-        "spark_driver_service_account_name": valid_string,
     }
 
     def post_validation(self, action, config_context):
@@ -525,7 +523,6 @@ class ValidateCleanupAction(Validator):
         "labels": None,
         "annotations": None,
         "service_account_name": None,
-        "spark_driver_service_account_name": None,
     }
     validators = {
         "name": valid_cleanup_action_name,
@@ -554,7 +551,6 @@ class ValidateCleanupAction(Validator):
         "labels": valid_dict,
         "annotations": valid_dict,
         "service_account_name": valid_string,
-        "spark_driver_service_account_name": valid_string,
     }
 
     def post_validation(self, action, config_context):

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -37,6 +37,7 @@ from tron.utils.state import Machine
 log = logging.getLogger(__name__)
 MAX_RECOVER_TRIES = 5
 INITIAL_RECOVER_DELAY = 3
+KUBERNETES_ACTIONRUN_EXECUTORS = {ExecutorTypes.kubernetes.value, ExecutorTypes.spark.value}
 
 
 class ActionRunFactory:
@@ -93,7 +94,7 @@ class ActionRunFactory:
         }
         if action.executor == ExecutorTypes.mesos.value:
             return MesosActionRun(**args)
-        elif action.executor == ExecutorTypes.kubernetes.value:
+        elif action.executor in KUBERNETES_ACTIONRUN_EXECUTORS:
             return KubernetesActionRun(**args)
         return SSHActionRun(**args)
 
@@ -111,7 +112,7 @@ class ActionRunFactory:
 
         if state_data.get("executor") == ExecutorTypes.mesos.value:
             return MesosActionRun.from_state(**args)
-        if state_data.get("executor") == ExecutorTypes.kubernetes.value:
+        if state_data.get("executor") in KUBERNETES_ACTIONRUN_EXECUTORS:
             return KubernetesActionRun.from_state(**args)
         return SSHActionRun.from_state(**args)
 

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -225,6 +225,8 @@ class KubernetesCluster:
             return self.runner
 
         try:
+            # TODO(TRON-1701): we'll need to figure out a good way to support multiple clusters here
+            # (with each cluster only using a single namespace for tron purposes)
             executor = self.processor.executor_from_config(
                 provider="kubernetes",
                 provider_config={


### PR DESCRIPTION
For now, we should be able to just use a KubernetesActionRun for Spark
drivers - worst case, I think we'll just have a couple places where we
branch on `executor` if we absolutely need to do something
Spark-specific and can't just pass that down from paasta-tools

This PR also removes spark_driver_service_account_name - I'm not sure
what I was thinking initially - we don't really need anything to
distinguish between the driver and executor SA since the executor SA
is configured by the arguments used to start the driver (and thus we
can just start the driver pod as we normally would by using the service
account payload that we'd use for a normal tron-launched pod)