### PR TITLE
Add arg to `tronctl retry` for waiting for dependencies

### DIFF
--- a/bin/tronctl
+++ b/bin/tronctl
@@ -36,6 +36,7 @@ from tron.commands.cmd_utils import ExitCode
 from tron.commands.cmd_utils import suggest_possibilities
 from tron.commands.cmd_utils import tron_jobs_completer
 from tron.commands.retry import parse_deps_timeout
+from tron.commands.retry import print_retries_table
 from tron.commands.retry import retry_actions
 
 COMMAND_HELP = (
@@ -291,7 +292,10 @@ def retry(args):
         print()
         pprint.pprint(args.id)
         print()
-    yield all(retry_actions(args.server, args.id, args.use_latest_command, args.deps_timeout))
+
+    retries = retry_actions(args.server, args.id, args.use_latest_command, args.deps_timeout)
+    print_retries_table(retries)
+    yield all([r.succeeded for r in retries])
 
 
 def move(args):

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -172,11 +172,11 @@ def parse_cli():
         help=(
             "Max duration to wait for upstream dependencies (upstream triggers "
             "and/or same job actions) before attempting to retry. "
-            "If all dependencies are not done and a non-zero timeout expires, "
+            "If all dependencies are not done when the timeout expires, "
             "this command will exit with an error, and the action will NOT be retried. "
             "Must be either an int number of seconds, a human-readable/"
             "pytimeparse-parsable string, or 'infinity' to wait forever. "
-            "Defaults to 0 (don't wait), which will not check dependencies."
+            "Defaults to 0 (don't wait)."
         ),
     )
 

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -40,27 +40,40 @@ from tron.commands.retry import print_retries_table
 from tron.commands.retry import retry_actions
 
 COMMAND_HELP = (
-    ("start", "Start the selected job, job run, or action. Creates a new job run if starting a job.",),
-    ("rerun", "Start a new job run with the same start time command context as the given job run.",),
+    (
+        "start",
+        "job name, job run id, or action id",
+        "Start the selected job, job run, or action. Creates a new job run if starting a job.",
+    ),
+    ("rerun", "job run id", "Start a new job run with the same start time command context as the given job run.",),
     (
         "retry",
+        "action id",
         "Re-run a job action within an existing job run. Uses latest code/config except the command by default. Add --use-latest-command to use the latest command.",
     ),
-    ("recover", "Ask Tron to start tracking an UNKNOWN action run again"),
-    ("cancel", "Cancel the selected job run."),
-    ("backfill", "Start job runs for a particular date range",),
-    ("disable", "Disable selected job and cancel any outstanding runs"),
-    ("enable", "Enable the selected job and schedule the next run"),
-    ("fail", "Mark an UNKNOWN job or action as failed. Does not publish action triggers.",),
-    ("success", "Mark an UNKNOWN job or action as having succeeded. Will publish action triggers.",),
-    ("skip", "Skip a failed action, unblocks dependent actions. Does *not* publish action triggers.",),
-    ("skip-and-publish", "Skip a failed action, unblocks dependent actions. *Does* publish action triggers.",),
-    ("stop", "Stop the action run (SIGTERM)"),
-    ("kill", "Force kill the action run (SIGKILL)"),
-    ("move", "Rename a job"),
-    ("publish", "Publish actionrun trigger to kick off downstream jobs"),
-    ("discard", "Discard existing actionrun trigger"),
-    ("version", "Print tron client and server versions"),
+    ("recover", "action id", "Ask Tron to start tracking an UNKNOWN action run again"),
+    ("cancel", "job run id", "Cancel the selected job run."),
+    ("backfill", "job name", "Start job runs for a particular date range",),
+    ("disable", "job name", "Disable selected job and cancel any outstanding runs"),
+    ("enable", "job name", "Enable the selected job and schedule the next run"),
+    ("fail", "job run or action id", "Mark an UNKNOWN job or action as failed. Does not publish action triggers.",),
+    (
+        "success",
+        "job run or action id",
+        "Mark an UNKNOWN job or action as having succeeded. Will publish action triggers.",
+    ),
+    ("skip", "action id", "Skip a failed action, unblocks dependent actions. Does *not* publish action triggers.",),
+    (
+        "skip-and-publish",
+        "action id",
+        "Skip a failed action, unblocks dependent actions. *Does* publish action triggers.",
+    ),
+    ("stop", "action id", "Stop the action run (SIGTERM)"),
+    ("kill", "action id", "Force kill the action run (SIGKILL)"),
+    ("move", "job name", "Rename a job"),
+    ("publish", "action id", "Publish actionrun trigger to kick off downstream jobs"),
+    ("discard", "trigger id", "Discard existing actionrun trigger"),
+    ("version", None, "Print tron client and server versions"),
 )
 
 log = logging.getLogger("tronctl")
@@ -72,15 +85,16 @@ def parse_date(date_string):
 
 def parse_cli():
     parser = cmd_utils.build_option_parser()
-
     subparsers = parser.add_subparsers(dest="command", title="commands", help="Tronctl command to run")
     subparsers.required = True  # add_subparsers only supports required arg from py37
+
     cmd_parsers = {}
-    for cmd_name, desc in COMMAND_HELP:
+    for cmd_name, id_help_text, desc in COMMAND_HELP:
         cmd_parsers[cmd_name] = subparsers.add_parser(cmd_name, help=desc, description=desc)
-        cmd_parsers[cmd_name].add_argument(
-            "id", nargs="*", help="job name, job run id, or action id",
-        ).completer = cmd_utils.tron_jobs_completer
+        if id_help_text:
+            cmd_parsers[cmd_name].add_argument(
+                "id", nargs="*", help=id_help_text
+            ).completer = cmd_utils.tron_jobs_completer
 
     # start
     cmd_parsers["start"].add_argument(

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -8,6 +8,7 @@ import argparse
 import asyncio
 import datetime
 import logging
+import pprint
 import sys
 from collections import defaultdict
 from typing import Any
@@ -35,7 +36,7 @@ from tron.commands.cmd_utils import ExitCode
 from tron.commands.cmd_utils import suggest_possibilities
 from tron.commands.cmd_utils import tron_jobs_completer
 from tron.commands.retry import parse_deps_timeout
-from tron.commands.retry import retry_action
+from tron.commands.retry import retry_actions
 
 COMMAND_HELP = (
     ("start", "Start the selected job, job run, or action. Creates a new job run if starting a job.",),
@@ -274,15 +275,23 @@ def control_objects(args: argparse.Namespace):
             data = dict(command=args.command)
             if args.command == "start" and args.run_date:
                 data["run_time"] = str(args.run_date)
-            if args.command == "retry":
-                yield retry_action(
-                    tron_client,
-                    identifier,
-                    use_latest_command=args.use_latest_command,
-                    deps_timeout_s=args.deps_timeout,
-                )
-                return
             yield request(urljoin(args.server, tron_id.url), data)
+
+
+def retry(args):
+    if args.deps_timeout != 0:
+        deps_timeout_str = "forever"
+        if args.deps_timeout > 0:
+            deps_timeout_str = "up to " + str(datetime.timedelta(seconds=args.deps_timeout))
+        print(
+            f"We will wait {deps_timeout_str} for all upstream triggers to be published "
+            "and required actions to finish successfully before issuing retries for the "
+            "following actions:"
+        )
+        print()
+        pprint.pprint(args.id)
+        print()
+    yield all(retry_actions(args.server, args.id, args.use_latest_command, args.deps_timeout))
 
 
 def move(args):
@@ -362,6 +371,7 @@ COMMANDS: Dict[str, Callable[[argparse.Namespace], Generator[bool, None, None]]]
     discard=event_discard,
     backfill=backfill,
     move=move,
+    retry=retry,
     version=tron_version,
 )
 

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -38,6 +38,7 @@ from tron.commands.cmd_utils import tron_jobs_completer
 from tron.commands.retry import parse_deps_timeout
 from tron.commands.retry import print_retries_table
 from tron.commands.retry import retry_actions
+from tron.commands.retry import RetryAction
 
 COMMAND_HELP = (
     (
@@ -294,8 +295,8 @@ def control_objects(args: argparse.Namespace):
 
 
 def retry(args):
-    if args.deps_timeout != 0:
-        deps_timeout_str = "forever"
+    if args.deps_timeout != RetryAction.NO_TIMEOUT:
+        deps_timeout_str = "forever"  # timeout = -1 (RetryAction.WAIT_FOREVER)
         if args.deps_timeout > 0:
             deps_timeout_str = "up to " + str(datetime.timedelta(seconds=args.deps_timeout))
         print(

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -34,6 +34,8 @@ from tron.commands.client import RequestError
 from tron.commands.cmd_utils import ExitCode
 from tron.commands.cmd_utils import suggest_possibilities
 from tron.commands.cmd_utils import tron_jobs_completer
+from tron.commands.retry import parse_deps_timeout
+from tron.commands.retry import retry_action
 
 COMMAND_HELP = (
     ("start", "Start the selected job, job run, or action. Creates a new job run if starting a job.",),
@@ -153,11 +155,27 @@ def parse_cli():
     )
 
     # retry
-    cmd_parsers["retry"].add_argument(
+    retry_parser = cmd_parsers["retry"]
+    retry_parser.add_argument(
         "--use-latest-command",
         action="store_true",
         default=False,
         help="Use the latest command in tronfig rather than the original command when the action run was created",
+    )
+    retry_parser.add_argument(
+        "--wait-for-deps",
+        type=parse_deps_timeout,
+        default=0,
+        dest="deps_timeout",
+        help=(
+            "Max duration to wait for upstream dependencies (upstream triggers "
+            "and/or same job actions) before attempting to retry. "
+            "If all dependencies are not done and a non-zero timeout expires, "
+            "this command will exit with an error, and the action will NOT be retried. "
+            "Must be either an int number of seconds, a human-readable/"
+            "pytimeparse-parsable string, or 'infinity' to wait forever. "
+            "Defaults to 0 (don't wait), which will not check dependencies."
+        ),
     )
 
     argcomplete.autocomplete(parser)
@@ -257,7 +275,13 @@ def control_objects(args: argparse.Namespace):
             if args.command == "start" and args.run_date:
                 data["run_time"] = str(args.run_date)
             if args.command == "retry":
-                data["use_latest_command"] = int(args.use_latest_command)
+                yield retry_action(
+                    tron_client,
+                    identifier,
+                    use_latest_command=args.use_latest_command,
+                    deps_timeout_s=args.deps_timeout,
+                )
+                return
             yield request(urljoin(args.server, tron_id.url), data)
 
 

--- a/cluster_itests/docker-compose.yml
+++ b/cluster_itests/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - zookeeper
+    environment:
+      - MESOS_SYSTEMD_ENABLE_SUPPORT=false
 
   tronmaster:
     build:

--- a/tests/commands/retry_test.py
+++ b/tests/commands/retry_test.py
@@ -1,0 +1,203 @@
+import random
+
+import mock
+import pytest
+
+from tron.commands import client
+from tron.commands import retry
+
+
+async def _empty_coro(*args, **kwargs):
+    return None
+
+
+@pytest.fixture(autouse=True)
+def mock_sleep():
+    with mock.patch("asyncio.sleep", _empty_coro, autospec=None):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_client():
+    with mock.patch.object(client, "Client", autospec=True) as m:
+        m.return_value.url_base = "http://localhost"
+        yield m
+
+
+@pytest.fixture(autouse=True)
+def mock_urlopen():  # prevent any requests from being made
+    with mock.patch("urllib.request.urlopen", autospec=True) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_client_request():
+    with mock.patch.object(client, "request", autospec=True) as m:
+        m.return_value = mock.Mock(error=False, content={})  # response
+        yield m
+
+
+@mock.patch.object(
+    client,
+    "get_object_type_from_identifier",
+    return_value=client.TronObjectIdentifier("JOB_RUN", "/a_job_run"),
+    autospec=True,
+)
+def test_retry_action_init_not_an_action(mock_get_obj_type, mock_client):
+    tron_client = mock_client.return_value
+    with pytest.raises(ValueError):
+        retry.RetryAction(tron_client, "a_fake_action_run")
+
+
+@pytest.fixture
+def fake_retry_action(mock_client):
+    tron_client = mock_client.return_value
+    tron_client.action_runs.return_value = dict(
+        action_name="a_fake_action",
+        requirements=["required_action_0", "required_action_1"],
+        triggered_by="a_fake_trigger_0 (done), a_fake_trigger_1",
+    )
+    tron_client.job_runs.return_value = dict(
+        job_name="a_fake_job",
+        run_num=1234,
+        runs=[
+            dict(action_name="required_action_0", state="succeeded"),
+            dict(action_name="required_action_1", state="failed"),
+            dict(action_name="upstream_action_0", trigger_downstreams="a_fake_trigger_0"),
+            dict(action_name="upstream_action_1", trigger_downstreams="a_fake_trigger_1"),
+            tron_client.action_runs.return_value,
+        ],
+    )
+
+    with mock.patch.object(
+        client,
+        "get_object_type_from_identifier",
+        side_effect=[
+            client.TronObjectIdentifier("ACTION_RUN", "/a_fake_job/0/a_fake_action"),
+            client.TronObjectIdentifier("JOB_RUN", "/a_fake_job/0"),
+        ],
+        autospec=True,
+    ):
+        yield retry.RetryAction(tron_client, "a_fake_job.0.a_fake_action", use_latest_command=True)
+
+
+def test_retry_action_init_ok(fake_retry_action):
+    assert fake_retry_action.retry_params == dict(command="retry", use_latest_command=1)
+    assert fake_retry_action.full_action_name == "a_fake_job.0.a_fake_action"
+    fake_retry_action.tron_client.action_runs.assert_called_once_with(
+        "/a_fake_job/0/a_fake_action", num_lines=0,
+    )
+    assert fake_retry_action.action_name == "a_fake_action"
+    assert fake_retry_action.action_run_id.url == "/a_fake_job/0/a_fake_action"
+    fake_retry_action.tron_client.job_runs.assert_called_once_with("/a_fake_job/0")
+    assert fake_retry_action.job_run_name == "a_fake_job.0"
+    assert fake_retry_action.job_run_id.url == "/a_fake_job/0"
+    assert fake_retry_action._required_action_indices == {"required_action_0": 0, "required_action_1": 1}
+
+
+def test_get_triggers(fake_retry_action, event_loop):
+    expected = dict(a_fake_trigger_0=True, a_fake_trigger_1=False)
+    assert expected == event_loop.run_until_complete(fake_retry_action.get_triggers())
+    assert fake_retry_action.tron_client.action_runs.call_args_list[1] == mock.call(  # 0th call is in init
+        "/a_fake_job/0/a_fake_action", num_lines=0,
+    )
+
+
+def test_get_required_actions(fake_retry_action, event_loop):
+    expected = dict(required_action_0=True, required_action_1=False)
+    assert expected == event_loop.run_until_complete(fake_retry_action.get_required_actions())
+    assert fake_retry_action.tron_client.job_runs.call_args_list[1] == mock.call("/a_fake_job/0")  # 0th call is in init
+
+
+@pytest.mark.parametrize(
+    "expected,triggered_by,required_action_1_state",
+    [
+        (False, "a_fake_trigger_0 (done), a_fake_trigger_1", "skipped"),  # unpublished triggers
+        (False, "a_fake_trigger_0 (done), a_fake_trigger_1 (done)", "failed"),  # required not succeeded
+        (True, "a_fake_trigger_0 (done), a_fake_trigger_1 (done)", "succeeded"),  # all done
+    ],
+)
+def test_can_retry(fake_retry_action, event_loop, expected, triggered_by, required_action_1_state):
+    fake_retry_action.tron_client.action_runs.return_value["triggered_by"] = triggered_by
+    fake_retry_action.tron_client.job_runs.return_value["runs"][1]["state"] = required_action_1_state
+    assert expected == event_loop.run_until_complete(fake_retry_action.can_retry())
+
+
+def test_wait_for_deps_timeout(fake_retry_action, event_loop):
+    assert not event_loop.run_until_complete(fake_retry_action.wait_for_deps(deps_timeout_s=3, poll_intv_s=1))
+    assert fake_retry_action._elapsed.seconds == 3
+    assert fake_retry_action.tron_client.action_runs.call_count == 5  # 1 in init, 4 in this test
+
+
+def test_wait_for_deps_all_deps_done(fake_retry_action, event_loop):
+    fake_retry_action.tron_client.job_runs.return_value["runs"][1]["state"] = "skipped"
+    fake_retry_action.tron_client.action_runs.return_value = None
+    triggered_by_results = [
+        "a_fake_trigger_0 (done), a_fake_trigger_1",
+        "a_fake_trigger_0 (done), a_fake_trigger_1",
+        "a_fake_trigger_0 (done), a_fake_trigger_1 (done)",
+    ]
+    fake_retry_action.tron_client.action_runs.side_effect = [
+        dict(action_name="a_fake_action", requirements=["required_action_0", "required_action_1"], triggered_by=r,)
+        for r in triggered_by_results
+    ]
+
+    assert event_loop.run_until_complete(fake_retry_action.wait_for_deps(deps_timeout_s=3, poll_intv_s=1))
+    # 3rd triggered_by result returned on check at 2nd second
+    assert fake_retry_action._elapsed.seconds == 2
+    assert fake_retry_action.tron_client.action_runs.call_count == 4  # 1 in init, 3 in this test
+
+
+@pytest.mark.parametrize("expected,error", [(False, True), (True, False)])
+def test_issue_retry(fake_retry_action, mock_client_request, event_loop, expected, error):
+    mock_client_request.return_value.error = error
+    assert expected == event_loop.run_until_complete(fake_retry_action.issue_retry())
+    assert expected == fake_retry_action.succeeded
+
+
+def test_wait_for_retry_deps_not_done(fake_retry_action, mock_client_request, event_loop):
+    assert not event_loop.run_until_complete(
+        fake_retry_action.wait_and_retry(deps_timeout_s=10, poll_intv_s=1, random_init_delay=True),
+    )
+    assert fake_retry_action._elapsed.seconds == 10  # timeout
+    mock_client_request.assert_not_called()  # retry not attempted
+
+
+def test_wait_for_retry_deps_done(fake_retry_action, mock_client_request, event_loop):
+    fake_retry_action.tron_client.job_runs.return_value["runs"][1]["state"] = "skipped"
+    fake_retry_action.tron_client.action_runs.return_value[
+        "triggered_by"
+    ] = "a_fake_trigger_0 (done), a_fake_trigger_1 (done)"
+    mock_client_request.return_value.error = False
+    random.seed(1)  # init delay is 1s
+
+    assert event_loop.run_until_complete(
+        fake_retry_action.wait_and_retry(deps_timeout_s=10, poll_intv_s=5, random_init_delay=True),
+    )
+    assert fake_retry_action._elapsed.seconds == 1  # init delay only
+    mock_client_request.assert_called_once_with(
+        "http://localhost/a_fake_job/0/a_fake_action", data=dict(command="retry", use_latest_command=1)
+    )
+
+
+@mock.patch.object(retry, "RetryAction", autospec=True)
+def test_retry_actions(mock_retry_action, mock_client, event_loop):
+    mock_wait_and_retry = mock_retry_action.return_value.wait_and_retry
+    mock_wait_and_retry.return_value = _empty_coro()
+
+    r_actions = retry.retry_actions(
+        "http://localhost",
+        ["a_job.0.an_action_0", "another_job.1.an_action_1"],
+        use_latest_command=True,
+        deps_timeout_s=4,
+    )
+
+    assert r_actions == [mock_retry_action.return_value] * 2
+    assert mock_retry_action.call_args_list == [
+        mock.call(mock_client.return_value, "a_job.0.an_action_0", use_latest_command=True),
+        mock.call(mock_client.return_value, "another_job.1.an_action_1", use_latest_command=True),
+    ]
+    assert mock_wait_and_retry.call_args_list == [
+        mock.call(deps_timeout_s=4, random_init_delay=False),
+        mock.call(deps_timeout_s=4),
+    ]

--- a/tron/commands/retry.py
+++ b/tron/commands/retry.py
@@ -39,7 +39,7 @@ class RetryAction:
         self, tron_client: client.Client, full_action_name: str, use_latest_command: bool = False,
     ):
         self.tron_client = tron_client
-        self.retry_params = dict(command="retry", use_latest_command=use_latest_command)
+        self.retry_params = dict(command="retry", use_latest_command=int(use_latest_command))
 
         self.full_action_name = full_action_name
         self.action_run_id = self._validate_action_name(full_action_name)
@@ -201,7 +201,7 @@ class RetryAction:
             self._log(f"Got result: {response.content.get('result')}")
             self._log(f"Check the status of the retry run using: `tronview {self.full_action_name}`")
             self._retry_request_result = True
-        return bool(self._retry_request_result)
+        return self._retry_request_result
 
 
 def retry_actions(

--- a/tron/commands/retry.py
+++ b/tron/commands/retry.py
@@ -1,7 +1,10 @@
 import argparse
+import asyncio
 import datetime
-import time
+import functools
+import random
 from typing import Dict
+from typing import List
 from typing import Optional
 from urllib.parse import urljoin
 
@@ -30,28 +33,22 @@ def parse_deps_timeout(d_str):
     return seconds
 
 
-def retry_action(
-    tron_client, full_action_name, use_latest_command=False, deps_timeout_s=None,
-):
-
-    r_action = RetryAction(tron_client, full_action_name, use_latest_command=use_latest_command)
-    return r_action.wait_and_retry(deps_timeout_s=deps_timeout_s, use_latest_command=use_latest_command)
-
-
 class RetryAction:
     def __init__(
         self, tron_client: client.Client, full_action_name: str, use_latest_command: bool = False,
     ):
         self.tron_client = tron_client
-        self.retry_params = dict(command="retry", use_latest_command=use_latest_command,)
+        self.retry_params = dict(command="retry", use_latest_command=use_latest_command)
 
         self.full_action_name = full_action_name
         self.action_run_id = self._validate_action_name(full_action_name)
         self.job_run_id = client.get_object_type_from_identifier(self.tron_client.index(), self.job_run_name)
 
         self._required_action_indices = self._get_required_action_indices()
+        self._elapsed = datetime.timedelta(seconds=0)
         self._triggers_done = False
         self._required_actions_done = False
+        self._retry_request_result = None  # None = not issued, True = success, False = fail
 
     @property
     def job_run_name(self):
@@ -61,103 +58,24 @@ class RetryAction:
     def action_name(self):
         return self.full_action_name.rsplit(".", 1)[1]
 
-    def can_retry(self, elapsed: Optional[datetime.timedelta] = None) -> bool:
-        def log(s):
-            prefix = f"[{elapsed}]" if elapsed is not None else ""
-            print(f"{prefix} {s}")
-
+    @property
+    def status(self):
         if not self._triggers_done:
-            triggers = self.get_triggers()
-            self._triggers_done = all(triggers.values())
-            if self._triggers_done:
-                if len(triggers) > 0:
-                    log("All upstream triggers published")
-            else:
-                remaining_triggers = [trigger for trigger, is_done in triggers.items() if not is_done]
-                log(f"Still waiting on the following triggers to publish: {remaining_triggers}")
-        if not self._required_actions_done:
-            required_actions = self.get_required_actions()
-            self._required_actions_done = all(required_actions.values())
-            if self._required_actions_done:
-                if len(required_actions) > 0:
-                    log("All required actions finished")
-            else:
-                remaining_required_actions = [action for action, is_done in required_actions.items() if not is_done]
-                log(
-                    "Still waiting on the following required actions to "
-                    f"complete successfully: {remaining_required_actions}"
-                )
-        return self._triggers_done and self._required_actions_done
-
-    def get_triggers(self) -> Dict[str, bool]:
-        action_run = self.tron_client.action_runs(self.action_run_id.url, num_lines=0)
-        # from tron.api.adapter:ActionRunAdapter.get_triggered_by:
-        # triggered_by is a single string with this format:
-        #   {trigger_1} (done), {trigger_2}, etc.
-        # where trigger_1 has been published, and trigger_2 is still waiting
-        trigger_states = {}
-        for trigger_and_state in action_run["triggered_by"].split(", "):
-            if trigger_and_state:
-                parts = trigger_and_state.split(" ")
-                # if len(parts) == 2, then parts is [{trigger}, "(done)"]
-                # else, parts is [{trigger}]
-                trigger_states[parts[0]] = len(parts) == 2
-        return trigger_states
-
-    def get_required_actions(self) -> Dict[str, bool]:
-        action_runs = self.tron_client.job_runs(self.job_run_id.url)["runs"]
-        return {
-            action_runs[i]["action_name"]: action_runs[i]["state"] in BackfillRun.SUCCESS_STATES
-            for i in self._required_action_indices.values()
-        }
-
-    def wait_and_retry(self, deps_timeout_s: Optional[int] = None, use_latest_command: bool = False,) -> bool:
-        if self.wait_for_deps(deps_timeout_s=deps_timeout_s):
-            return self.issue_retry(use_latest_command=use_latest_command)
+            return "Upstream triggers not all published"
+        elif not self._required_actions_done:
+            return "Required actions not all successfully completed"
+        elif self._retry_request_result is None:
+            return "Retry request not issued, but dependencies done"
+        elif self._retry_request_result:
+            return "Retry request issued successfully"
         else:
-            deps_timeout_td = datetime.timedelta(seconds=deps_timeout_s)
-            print(f"Not all triggers published after {deps_timeout_td}. Action will not be retried.")
-            return False
-
-    def wait_for_deps(
-        self, deps_timeout_s: Optional[int] = None, poll_intv_s: int = DEFAULT_POLLING_INTERVAL_S,
-    ) -> bool:
-        """Wait for all upstream dependencies to finished up to a timeout. Once the
-        timeout has expired, one final check is always conducted.
-
-        Returns whether or not deps successfully finished.
-        """
-        elapsed = datetime.timedelta(seconds=0)
-
-        while deps_timeout_s == -1 or elapsed.seconds < deps_timeout_s:
-            if self.can_retry(elapsed=elapsed):
-                return True
-            wait_for = poll_intv_s
-            if deps_timeout_s != -1:
-                wait_for = min(wait_for, int(deps_timeout_s - elapsed.seconds))
-            time.sleep(wait_for)
-            elapsed += datetime.timedelta(seconds=wait_for)
-
-        return self.can_retry(elapsed=elapsed)
-
-    def issue_retry(self, use_latest_command: bool = False) -> bool:
-        print(f"Issuing retry request for {self.full_action_name}")
-        response = client.request(
-            urljoin(self.tron_client.url_base, self.action_run_id.url),
-            data=dict(command="retry", use_latest_command=int(use_latest_command),),
-        )
-        if response.error:
-            print(f"Error: couldn't issue retry request: {response.content}")
-        else:
-            print(f"Got result: {response.content.get('result')}")
-            print("Check the status of the retry run using:")
-            print(f"   tronview {self.full_action_name}")
-        return bool(response.error)
+            return "Failed to issue retry request"
 
     def _validate_action_name(self, full_action_name: str) -> client.TronObjectIdentifier:
         action_run_id = client.get_object_type_from_identifier(self.tron_client.index(), full_action_name)
         if action_run_id.type != client.TronObjectType.action_run:
-            raise ValueError(f"Unknown action name: '{full_action_name}'")
+            raise ValueError(f"'{full_action_name}' is a {action_run_id.type.lower()}, not an action")
+        self.tron_client.action_runs(action_run_id.url, num_lines=0)  # verify action exists
         return action_run_id
 
     def _get_required_action_indices(self) -> Dict[str, bool]:
@@ -171,3 +89,133 @@ class RetryAction:
             action_indices[action_run["action_name"]] = i
 
         return dict(filter(lambda e: e[0] in required_actions, action_indices.items()))
+
+    def _log(self, s: str) -> None:
+        print(f"[{self._elapsed}] {self.full_action_name}: {s}")
+
+    async def can_retry(self) -> bool:
+        if not self._triggers_done:
+            triggers = await self.get_triggers()
+            self._triggers_done = all(triggers.values())
+            if self._triggers_done:
+                if len(triggers) > 0:
+                    self._log("All upstream triggers published")
+            else:
+                remaining_triggers = [trigger for trigger, is_done in triggers.items() if not is_done]
+                self._log(f"Upstream triggers not yet published: {remaining_triggers}")
+        if not self._required_actions_done:
+            required_actions = await self.get_required_actions()
+            self._required_actions_done = all(required_actions.values())
+            if self._required_actions_done:
+                if len(required_actions) > 0:
+                    self._log("All required actions finished")
+            else:
+                remaining_required_actions = [action for action, is_done in required_actions.items() if not is_done]
+                self._log(f"Required actions not yet succeeded: {remaining_required_actions}")
+        return self._triggers_done and self._required_actions_done
+
+    async def get_triggers(self) -> Dict[str, bool]:
+        action_run = await asyncio.get_event_loop().run_in_executor(
+            None, functools.partial(self.tron_client.action_runs, self.action_run_id.url, num_lines=0,),
+        )
+        # from tron.api.adapter:ActionRunAdapter.get_triggered_by:
+        # triggered_by is a single string with this format:
+        #   {trigger_1} (done), {trigger_2}, etc.
+        # where trigger_1 has been published, and trigger_2 is still waiting
+        trigger_states = {}
+        for trigger_and_state in action_run["triggered_by"].split(", "):
+            if trigger_and_state:
+                parts = trigger_and_state.split(" ")
+                # if len(parts) == 2, then parts is [{trigger}, "(done)"]
+                # else, parts is [{trigger}]
+                trigger_states[parts[0]] = len(parts) == 2
+        return trigger_states
+
+    async def get_required_actions(self) -> Dict[str, bool]:
+        action_runs = (
+            await asyncio.get_event_loop().run_in_executor(None, self.tron_client.job_runs, self.job_run_id.url,)
+        )["runs"]
+        return {
+            action_runs[i]["action_name"]: action_runs[i]["state"] in BackfillRun.SUCCESS_STATES
+            for i in self._required_action_indices.values()
+        }
+
+    async def wait_and_retry(
+        self,
+        deps_timeout_s: Optional[int] = None,
+        poll_intv_s: int = DEFAULT_POLLING_INTERVAL_S,
+        random_init_delay: bool = True,
+    ) -> bool:
+
+        if random_init_delay:
+            init_delay_s = random.randint(1, min(deps_timeout_s, poll_intv_s)) - 1
+            self._elapsed += datetime.timedelta(seconds=init_delay_s)
+            await asyncio.sleep(init_delay_s)
+
+        if await self.wait_for_deps(deps_timeout_s=deps_timeout_s, poll_intv_s=poll_intv_s):
+            return await self.issue_retry()
+        else:
+            deps_timeout_td = datetime.timedelta(seconds=deps_timeout_s)
+            msg = "Action will not be retried."
+            if deps_timeout_s != 0:
+                msg = f"Not all dependencies completed after waiting for {deps_timeout_td}. " + msg
+            self._log(msg)
+            return False
+
+    async def wait_for_deps(
+        self, deps_timeout_s: Optional[int] = None, poll_intv_s: int = DEFAULT_POLLING_INTERVAL_S,
+    ) -> bool:
+        """Wait for all upstream dependencies to finished up to a timeout. Once the
+        timeout has expired, one final check is always conducted.
+
+        Returns whether or not deps successfully finished.
+        """
+        while deps_timeout_s == -1 or self._elapsed.seconds < deps_timeout_s:
+            if await self.can_retry():
+                return True
+            wait_for = poll_intv_s
+            if deps_timeout_s != -1:
+                wait_for = min(wait_for, int(deps_timeout_s - self._elapsed.seconds))
+            await asyncio.sleep(wait_for)
+            self._elapsed += datetime.timedelta(seconds=wait_for)
+
+        return await self.can_retry()
+
+    async def issue_retry(self) -> bool:
+        self._log("Issuing retry request")
+        response = await asyncio.get_event_loop().run_in_executor(
+            None,
+            functools.partial(
+                client.request, urljoin(self.tron_client.url_base, self.action_run_id.url), data=self.retry_params,
+            ),
+        )
+        if response.error:
+            self._log(f"Error: couldn't issue retry request: {response.content}")
+            self._retry_request_result = False
+        else:
+            self._log(f"Got result: {response.content.get('result')}")
+            self._log(f"Check the status of the retry run using: `tronview {self.full_action_name}`")
+            self._retry_request_result = True
+        return bool(self._retry_request_result)
+
+
+def retry_actions(
+    tron_server: str,
+    full_action_names: List[str],
+    use_latest_command: bool = False,
+    deps_timeout_s: Optional[int] = None,
+):
+    tron_client = client.Client(tron_server)
+    r_actions = [RetryAction(tron_client, name, use_latest_command=use_latest_command) for name in full_action_names]
+
+    loop = asyncio.get_event_loop()
+    try:
+        loop.run_until_complete(
+            asyncio.gather(
+                r_actions[0].wait_and_retry(deps_timeout_s=deps_timeout_s, random_init_delay=False),
+                *[ra.wait_and_retry(deps_timeout_s=deps_timeout_s) for ra in r_actions[1:]],
+            )
+        )
+    finally:
+        loop.close()
+    return r_actions

--- a/tron/commands/retry.py
+++ b/tron/commands/retry.py
@@ -1,0 +1,173 @@
+import argparse
+import datetime
+import time
+from typing import Dict
+from typing import Optional
+from urllib.parse import urljoin
+
+import pytimeparse
+
+from tron.commands import client
+from tron.commands.backfill import BackfillRun
+
+
+DEFAULT_POLLING_INTERVAL_S = 10
+
+
+def parse_deps_timeout(d_str):
+    if d_str == "infinity":
+        return -1
+    elif d_str.isnumeric():
+        seconds = int(d_str)
+    else:
+        seconds = pytimeparse.parse(d_str)
+        if seconds is None:
+            raise argparse.ArgumentTypeError(
+                f"'{d_str}' is not a valid duration. Must be either number of seconds or pytimeparse-parsable string."
+            )
+    if seconds < 0:
+        raise argparse.ArgumentTypeError(f"'{d_str}' must not be negative")
+    return seconds
+
+
+def retry_action(
+    tron_client, full_action_name, use_latest_command=False, deps_timeout_s=None,
+):
+
+    r_action = RetryAction(tron_client, full_action_name, use_latest_command=use_latest_command)
+    return r_action.wait_and_retry(deps_timeout_s=deps_timeout_s, use_latest_command=use_latest_command)
+
+
+class RetryAction:
+    def __init__(
+        self, tron_client: client.Client, full_action_name: str, use_latest_command: bool = False,
+    ):
+        self.tron_client = tron_client
+        self.retry_params = dict(command="retry", use_latest_command=use_latest_command,)
+
+        self.full_action_name = full_action_name
+        self.action_run_id = self._validate_action_name(full_action_name)
+        self.job_run_id = client.get_object_type_from_identifier(self.tron_client.index(), self.job_run_name)
+
+        self._required_action_indices = self._get_required_action_indices()
+        self._triggers_done = False
+        self._required_actions_done = False
+
+    @property
+    def job_run_name(self):
+        return self.full_action_name.rsplit(".", 1)[0]
+
+    @property
+    def action_name(self):
+        return self.full_action_name.rsplit(".", 1)[1]
+
+    def can_retry(self, elapsed: Optional[datetime.timedelta] = None) -> bool:
+        def log(s):
+            prefix = f"[{elapsed}]" if elapsed is not None else ""
+            print(f"{prefix} {s}")
+
+        if not self._triggers_done:
+            triggers = self.get_triggers()
+            self._triggers_done = all(triggers.values())
+            if self._triggers_done:
+                if len(triggers) > 0:
+                    log("All upstream triggers published")
+            else:
+                remaining_triggers = [trigger for trigger, is_done in triggers.items() if not is_done]
+                log(f"Still waiting on the following triggers to publish: {remaining_triggers}")
+        if not self._required_actions_done:
+            required_actions = self.get_required_actions()
+            self._required_actions_done = all(required_actions.values())
+            if self._required_actions_done:
+                if len(required_actions) > 0:
+                    log("All required actions finished")
+            else:
+                remaining_required_actions = [action for action, is_done in required_actions.items() if not is_done]
+                log(
+                    "Still waiting on the following required actions to "
+                    f"complete successfully: {remaining_required_actions}"
+                )
+        return self._triggers_done and self._required_actions_done
+
+    def get_triggers(self) -> Dict[str, bool]:
+        action_run = self.tron_client.action_runs(self.action_run_id.url, num_lines=0)
+        # from tron.api.adapter:ActionRunAdapter.get_triggered_by:
+        # triggered_by is a single string with this format:
+        #   {trigger_1} (done), {trigger_2}, etc.
+        # where trigger_1 has been published, and trigger_2 is still waiting
+        trigger_states = {}
+        for trigger_and_state in action_run["triggered_by"].split(", "):
+            if trigger_and_state:
+                parts = trigger_and_state.split(" ")
+                # if len(parts) == 2, then parts is [{trigger}, "(done)"]
+                # else, parts is [{trigger}]
+                trigger_states[parts[0]] = len(parts) == 2
+        return trigger_states
+
+    def get_required_actions(self) -> Dict[str, bool]:
+        action_runs = self.tron_client.job_runs(self.job_run_id.url)["runs"]
+        return {
+            action_runs[i]["action_name"]: action_runs[i]["state"] in BackfillRun.SUCCESS_STATES
+            for i in self._required_action_indices.values()
+        }
+
+    def wait_and_retry(self, deps_timeout_s: Optional[int] = None, use_latest_command: bool = False,) -> bool:
+        if self.wait_for_deps(deps_timeout_s=deps_timeout_s):
+            return self.issue_retry(use_latest_command=use_latest_command)
+        else:
+            deps_timeout_td = datetime.timedelta(seconds=deps_timeout_s)
+            print(f"Not all triggers published after {deps_timeout_td}. Action will not be retried.")
+            return False
+
+    def wait_for_deps(
+        self, deps_timeout_s: Optional[int] = None, poll_intv_s: int = DEFAULT_POLLING_INTERVAL_S,
+    ) -> bool:
+        """Wait for all upstream dependencies to finished up to a timeout. Once the
+        timeout has expired, one final check is always conducted.
+
+        Returns whether or not deps successfully finished.
+        """
+        elapsed = datetime.timedelta(seconds=0)
+
+        while deps_timeout_s == -1 or elapsed.seconds < deps_timeout_s:
+            if self.can_retry(elapsed=elapsed):
+                return True
+            wait_for = poll_intv_s
+            if deps_timeout_s != -1:
+                wait_for = min(wait_for, int(deps_timeout_s - elapsed.seconds))
+            time.sleep(wait_for)
+            elapsed += datetime.timedelta(seconds=wait_for)
+
+        return self.can_retry(elapsed=elapsed)
+
+    def issue_retry(self, use_latest_command: bool = False) -> bool:
+        print(f"Issuing retry request for {self.full_action_name}")
+        response = client.request(
+            urljoin(self.tron_client.url_base, self.action_run_id.url),
+            data=dict(command="retry", use_latest_command=int(use_latest_command),),
+        )
+        if response.error:
+            print(f"Error: couldn't issue retry request: {response.content}")
+        else:
+            print(f"Got result: {response.content.get('result')}")
+            print("Check the status of the retry run using:")
+            print(f"   tronview {self.full_action_name}")
+        return bool(response.error)
+
+    def _validate_action_name(self, full_action_name: str) -> client.TronObjectIdentifier:
+        action_run_id = client.get_object_type_from_identifier(self.tron_client.index(), full_action_name)
+        if action_run_id.type != client.TronObjectType.action_run:
+            raise ValueError(f"Unknown action name: '{full_action_name}'")
+        return action_run_id
+
+    def _get_required_action_indices(self) -> Dict[str, bool]:
+        job_run = self.tron_client.job_runs(self.job_run_id.url)
+        required_actions = set()
+        action_indices = {}
+
+        for i, action_run in enumerate(job_run["runs"]):
+            if action_run["action_name"] == self.action_name:
+                required_actions = set(action_run["requirements"])
+            action_indices[action_run["action_name"]] = i
+
+        return dict(filter(lambda e: e[0] in required_actions, action_indices.items()))

--- a/yelp_package/bionic/Dockerfile
+++ b/yelp_package/bionic/Dockerfile
@@ -36,5 +36,5 @@ RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list
 RUN echo "deb http://deb.nodesource.com/node_10.x bionic main" > /etc/apt/sources.list.d/nodesource.list
 RUN apt-get -q update && apt-get -q install -y --no-install-recommends yarn nodejs
 
-RUN pip3 install --index-url ${PIP_INDEX_URL} virtualenv==16.0.0
+RUN pip3 install --index-url ${PIP_INDEX_URL} virtualenv==16.7.5
 WORKDIR /work


### PR DESCRIPTION
### Description
This PR gives `tronctl retry` a new option, `--wait-for-deps` that, if set, will make `tronctl` wait for all upstream triggers and required actions to complete before attempting to retry a given action. An arg can be passed to the option specifying a timeout, including "infinity" (i.e. never timeout), for how long to wait before giving up.

By default, the behavior of not waiting before retrying is preserved. However, I've made it so that even with the default timeout of 0 (i.e. don't want), we check to make sure all dependencies are done, because the current behavior is to issue a retry, to which the server will respond with an OK, even if the retry will fail anyway because dependencies are not done.

### Testing
`make test`
manual testing on an example cluster, using a job with an action that has both upstream triggers and required actions