### PR TITLE
Pass port/field selector envvars to task_proc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.3.0
+task-processing==0.4.0
 traitlets==4.3.3
 Twisted==20.3.0
 typing-extensions==3.10.0.0

--- a/tests/core/actionrun_test.py
+++ b/tests/core/actionrun_test.py
@@ -1629,6 +1629,7 @@ class TestKubernetesActionRun:
                 docker_image=mock_k8s_action_run.command_config.docker_image,
                 env=mock.ANY,
                 secret_env=mock_k8s_action_run.command_config.secret_env,
+                field_selector_env=mock_k8s_action_run.command_config.field_selector_env,
                 serializer=serializer,
                 volumes=mock_k8s_action_run.command_config.extra_volumes,
                 cap_add=mock_k8s_action_run.command_config.cap_add,
@@ -1639,6 +1640,7 @@ class TestKubernetesActionRun:
                 pod_labels=mock_k8s_action_run.command_config.labels,
                 pod_annotations=mock_k8s_action_run.command_config.annotations,
                 service_account_name=mock_k8s_action_run.command_config.service_account_name,
+                ports=mock_k8s_action_run.command_config.ports,
             ), mock_get_cluster.return_value.create_task.calls
             task = mock_get_cluster.return_value.create_task.return_value
             mock_get_cluster.return_value.recover.assert_called_once_with(task)

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -36,6 +36,7 @@ from tron.config.schema import CLEANUP_ACTION_NAME
 from tron.config.schema import ConfigAction
 from tron.config.schema import ConfigCleanupAction
 from tron.config.schema import ConfigConstraint
+from tron.config.schema import ConfigFieldSelectorSource
 from tron.config.schema import ConfigJob
 from tron.config.schema import ConfigKubernetes
 from tron.config.schema import ConfigMesos
@@ -264,6 +265,16 @@ class ValidateSecretSource(Validator):
 valid_secret_source = ValidateSecretSource()
 
 
+class ValidateFieldSelectorSource(Validator):
+    config_class = ConfigFieldSelectorSource
+    validators = {
+        "field_path": valid_string,  # k8s field path - e.g., `status.podIP`
+    }
+
+
+valid_field_selector_source = ValidateFieldSelectorSource()
+
+
 def _valid_node_affinity_operator(value: str, config_context: ConfigContext) -> str:
     valid_operators = {"In", "NotIn", "Exists", "NotExists", "Gt", "Lt"}
     if value not in valid_operators:
@@ -437,6 +448,7 @@ class ValidateAction(Validator):
         "docker_parameters": None,
         "env": None,
         "secret_env": None,
+        "field_selector_env": None,
         "extra_volumes": None,
         "trigger_downstreams": None,
         "triggered_by": None,
@@ -447,6 +459,7 @@ class ValidateAction(Validator):
         "labels": None,
         "annotations": None,
         "service_account_name": None,
+        "ports": None,
     }
     requires = build_list_of_type_validator(valid_action_name, allow_empty=True,)
     validators = {
@@ -468,6 +481,7 @@ class ValidateAction(Validator):
         "docker_parameters": build_list_of_type_validator(valid_docker_parameter, allow_empty=True,),
         "env": valid_dict,
         "secret_env": build_dict_value_validator(valid_secret_source),
+        "field_selector_env": build_dict_value_validator(valid_field_selector_source),
         "extra_volumes": build_list_of_type_validator(valid_volume, allow_empty=True),
         "trigger_downstreams": valid_trigger_downstreams,
         "triggered_by": build_list_of_type_validator(valid_string, allow_empty=True),
@@ -478,6 +492,7 @@ class ValidateAction(Validator):
         "labels:": valid_dict,
         "annotations": valid_dict,
         "service_account_name": valid_string,
+        "ports": build_list_of_type_validator(valid_int, allow_empty=True),
     }
 
     def post_validation(self, action, config_context):
@@ -513,6 +528,8 @@ class ValidateCleanupAction(Validator):
         "docker_image": None,
         "docker_parameters": None,
         "env": None,
+        "secret_env": None,
+        "field_selector_env": None,
         "extra_volumes": None,
         "trigger_downstreams": None,
         "triggered_by": None,
@@ -523,6 +540,7 @@ class ValidateCleanupAction(Validator):
         "labels": None,
         "annotations": None,
         "service_account_name": None,
+        "ports": None,
     }
     validators = {
         "name": valid_cleanup_action_name,
@@ -541,6 +559,8 @@ class ValidateCleanupAction(Validator):
         "docker_image": valid_string,
         "docker_parameters": build_list_of_type_validator(valid_docker_parameter, allow_empty=True,),
         "env": valid_dict,
+        "secret_env": build_dict_value_validator(valid_secret_source),
+        "field_selector_env": build_dict_value_validator(valid_field_selector_source),
         "extra_volumes": build_list_of_type_validator(valid_volume, allow_empty=True),
         "trigger_downstreams": valid_trigger_downstreams,
         "triggered_by": build_list_of_type_validator(valid_string, allow_empty=True),
@@ -551,6 +571,7 @@ class ValidateCleanupAction(Validator):
         "labels": valid_dict,
         "annotations": valid_dict,
         "service_account_name": valid_string,
+        "ports": build_list_of_type_validator(valid_int, allow_empty=True),
     }
 
     def post_validation(self, action, config_context):

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -141,6 +141,7 @@ ConfigAction = config_object_factory(
         "docker_parameters",  # List of ConfigParameter
         "env",  # dict
         "secret_env",  # dict of str, ConfigSecretSource
+        "field_selector_env",  # dict of str, ConfigFieldSelectorSource
         "extra_volumes",  # List of ConfigVolume
         "expected_runtime",  # datetime.Timedelta
         "trigger_downstreams",  # None, bool or dict
@@ -152,7 +153,7 @@ ConfigAction = config_object_factory(
         "labels",  # Dict of str, str
         "annotations",  # Dict of str, str
         "service_account_name",  # str
-        "spark_driver_service_account_name",  # str
+        "ports",  # List of int
     ],
 )
 
@@ -176,6 +177,7 @@ ConfigCleanupAction = config_object_factory(
         "docker_parameters",  # List of ConfigParameter
         "env",  # dict
         "secret_env",  # dict of str, ConfigSecretSource
+        "field_selector_env",  # dict of str, ConfigFieldSelectorSource
         "extra_volumes",  # List of ConfigVolume
         "trigger_downstreams",  # None, bool or dict
         "triggered_by",  # list or None
@@ -186,7 +188,7 @@ ConfigCleanupAction = config_object_factory(
         "labels",  # Dict of str, str
         "annotations",  # Dict of str, str
         "service_account_name",  # str
-        "spark_driver_service_account_name",  # str
+        "ports",  # List of int
     ],
 )
 
@@ -199,6 +201,10 @@ ConfigVolume = config_object_factory(
 )
 
 ConfigSecretSource = config_object_factory(name="ConfigSecretSource", required=["secret_name", "key"], optional=[],)
+
+ConfigFieldSelectorSource = config_object_factory(
+    name="ConfigFieldSelectorSource", required=["field_path"], optional=[],
+)
 
 ConfigNodeAffinity = config_object_factory(
     name="ConfigNodeAffinity", required=["key", "operator", "value"], optional=[],

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -9,6 +9,7 @@ from dataclasses import fields
 
 from tron import node
 from tron.config.schema import CLEANUP_ACTION_NAME
+from tron.config.schema import ConfigAction
 from tron.config.schema import ConfigNodeAffinity
 
 log = logging.getLogger(__name__)
@@ -30,12 +31,14 @@ class ActionCommandConfig:
     docker_parameters: set = field(default_factory=set)
     env: dict = field(default_factory=dict)
     secret_env: dict = field(default_factory=dict)
+    field_selector_env: dict = field(default_factory=dict)
     extra_volumes: set = field(default_factory=set)
     node_selectors: dict = field(default_factory=dict)
     node_affinities: List[ConfigNodeAffinity] = field(default_factory=list)
     labels: dict = field(default_factory=dict)
     annotations: dict = field(default_factory=dict)
     service_account_name: Optional[str] = None
+    ports: List[int] = field(default_factory=list)
 
     @property
     def state_data(self):
@@ -70,7 +73,7 @@ class Action:
         return self.command_config.command
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config: ConfigAction) -> "Action":
         """Factory method for creating a new Action."""
         node_repo = node.NodePoolRepository.get_instance()
         command_config = ActionCommandConfig(
@@ -84,6 +87,7 @@ class Action:
             extra_volumes=set(config.extra_volumes or []),
             env=config.env or {},
             secret_env=config.secret_env or {},
+            field_selector_env=config.field_selector_env or {},
             cap_add=config.cap_add or [],
             cap_drop=config.cap_drop or [],
             node_selectors=config.node_selectors or {},
@@ -91,6 +95,7 @@ class Action:
             labels=config.labels or {},
             annotations=config.annotations or {},
             service_account_name=config.service_account_name or None,
+            ports=config.ports or [],
         )
         kwargs = dict(
             name=config.name,

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -1053,6 +1053,7 @@ class KubernetesActionRun(ActionRun, Observer):
                 docker_image=attempt.command_config.docker_image,
                 env=build_environment(original_env=attempt.command_config.env, run_id=self.id),
                 secret_env=attempt.command_config.secret_env,
+                field_selector_env=attempt.command_config.field_selector_env,
                 serializer=filehandler.OutputStreamSerializer(self.output_path),
                 volumes=attempt.command_config.extra_volumes,
                 cap_add=attempt.command_config.cap_add,
@@ -1062,6 +1063,7 @@ class KubernetesActionRun(ActionRun, Observer):
                 pod_labels=attempt.command_config.labels,
                 pod_annotations=attempt.command_config.annotations,
                 service_account_name=attempt.command_config.service_account_name,
+                ports=attempt.command_config.ports,
             )
         except InvariantException:
             log.exception(f"Unable to create task for ActionRun {self.id}")
@@ -1116,6 +1118,7 @@ class KubernetesActionRun(ActionRun, Observer):
             docker_image=last_attempt.command_config.docker_image,
             env=build_environment(original_env=last_attempt.command_config.env, run_id=self.id),
             secret_env=last_attempt.command_config.secret_env,
+            field_selector_env=last_attempt.command_config.field_selector_env,
             serializer=filehandler.OutputStreamSerializer(self.output_path),
             volumes=last_attempt.command_config.extra_volumes,
             cap_add=last_attempt.command_config.cap_add,
@@ -1126,6 +1129,7 @@ class KubernetesActionRun(ActionRun, Observer):
             pod_labels=last_attempt.command_config.labels,
             pod_annotations=last_attempt.command_config.annotations,
             service_account_name=last_attempt.command_config.service_account_name,
+            ports=last_attempt.command_config.ports,
         )
         if not task:
             log.warning(

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -16,6 +16,7 @@ from twisted.internet.defer import logError
 
 import tron.metrics as metrics
 from tron.actioncommand import ActionCommand
+from tron.config.schema import ConfigFieldSelectorSource
 from tron.config.schema import ConfigKubernetes
 from tron.config.schema import ConfigNodeAffinity
 from tron.config.schema import ConfigSecretSource
@@ -356,14 +357,16 @@ class KubernetesCluster:
         docker_image: str,
         env: Dict[str, str],
         secret_env: Dict[str, ConfigSecretSource],
+        field_selector_env: Dict[str, ConfigFieldSelectorSource],
         volumes: Collection[ConfigVolume],
         cap_add: Collection[str],
         cap_drop: Collection[str],
         node_selectors: Dict[str, str],
-        node_affinities: ConfigNodeAffinity,
+        node_affinities: List[ConfigNodeAffinity],
         pod_labels: Dict[str, str],
         pod_annotations: Dict[str, str],
         service_account_name: Optional[str],
+        ports: List[int],
         task_id: Optional[str] = None,
     ) -> Optional[KubernetesTask]:
         """
@@ -388,6 +391,7 @@ class KubernetesCluster:
                 disk=DEFAULT_DISK_LIMIT if disk is None else disk,
                 environment=env,
                 secret_environment={k: v._asdict() for k, v in secret_env.items()},
+                field_selector_environment={k: v._asdict() for k, v in field_selector_env.items()},
                 cap_add=cap_add,
                 cap_drop=cap_drop,
                 volumes=[
@@ -399,6 +403,7 @@ class KubernetesCluster:
                 labels=pod_labels,
                 annotations=pod_annotations,
                 service_account_name=service_account_name,
+                ports=ports,
             ),
         )
 


### PR DESCRIPTION
we need this for spark drivers in k8s to work - and without the field selector env vars we're not able to fully adhere to the paasta workload contract