### PR TITLE
Fix internal build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,19 @@ UID:=$(shell id -u)
 GID:=$(shell id -g)
 
 ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
-	export PIP_INDEX_URL ?= https://pypi.yelpcorp.com/simple
-	export NPM_CONFIG_REGISTRY ?= https://npm.yelpcorp.com/
 	PAASTA_ENV ?= YELP
 else
-	export PIP_INDEX_URL ?= https://pypi.python.org/simple
-	export NPM_CONFIG_REGISTRY ?= https://registry.npmjs.org
 	PAASTA_ENV ?= $(shell hostname --fqdn)
 endif
 
 NOOP = true
 ifeq ($(PAASTA_ENV),YELP)
+	export PIP_INDEX_URL ?= https://pypi.yelpcorp.com/simple
+	export NPM_CONFIG_REGISTRY ?= https://npm.yelpcorp.com/
 	ADD_MISSING_DEPS_MAYBE:=-diff --unchanged-line-format= --old-line-format= --new-line-format='%L' ./requirements.txt ./yelp_package/extra_requirements_yelp.txt >> ./requirements.txt
 else
+	export PIP_INDEX_URL ?= https://pypi.python.org/simple
+	export NPM_CONFIG_REGISTRY ?= https://registry.npmjs.org
 	ADD_MISSING_DEPS_MAYBE:=$(NOOP)
 endif
 

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
         "eslint-config-airbnb": "^18.2.0",
         "eslint-plugin-import": "^2.22.0",
         "eslint-plugin-jsx-a11y": "^6.3.1",
-        "axe-core": "^4.0.3",
         "eslint-plugin-react": "^7.20.6",
         "eslint-plugin-react-hooks": "^4.1.0"
+    },
+    "resolutions": {
+        "axe-core": "4.3.3"
     },
     "engines": {
         "node-version-shim": "10.x",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "eslint-config-airbnb": "^18.2.0",
         "eslint-plugin-import": "^2.22.0",
         "eslint-plugin-jsx-a11y": "^6.3.1",
+        "axe-core": "^4.0.3",
         "eslint-plugin-react": "^7.20.6",
         "eslint-plugin-react-hooks": "^4.1.0"
     },

--- a/tronweb2/package.json
+++ b/tronweb2/package.json
@@ -42,6 +42,9 @@
         "eslint-plugin-react": "^7.20.6",
         "eslint-plugin-react-hooks": "^4.1.0"
     },
+    "resolutions": {
+        "axe-core": "4.3.3"
+    },
     "engines": {
         "node-version-shim": "10.x",
         "node": ">=10"


### PR DESCRIPTION
Our internal build now runs inside a container whose `hostname` no longer matches `yelpcorp.com`.

This instead changes our makefile to set internal-only things based on `PAASTA_ENV`, and a separate change will force our internal build to set `PAASTA_ENV=YELP` when building. 

In addition to the internal build PIP problem, a dependency for one of our node eslint checks was updated to a version that was no longer compatible w/ node <12.0.  To minimize potential breakage on tronweb, I am just pinning to an older version of axe-core for now, and will ticket updating to node 12+ separately.

This got past `make test` on an internal build on k8s: https://jenkins-test.yelpcorp.com/blue/organizations/jenkins/test-jfong-tron/detail/test-jfong-tron/6/pipeline/ e.g. with `15:06:08  Now running on hostname: test-jfong-tron-6-bgkhg-z59c9-8qbsv`