### PR TITLE
bumped up taskproc ver pass tron version to tskprc gsf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.4.0
+task-processing==0.6.0
 traitlets==4.3.3
 Twisted==20.3.0
 typing-extensions==3.10.0.0

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -15,6 +15,7 @@ from twisted.internet.defer import Deferred  # type: ignore  # need to upgrade t
 from twisted.internet.defer import logError
 
 import tron.metrics as metrics
+from tron import __version__
 from tron.actioncommand import ActionCommand
 from tron.config.schema import ConfigFieldSelectorSource
 from tron.config.schema import ConfigKubernetes
@@ -232,6 +233,7 @@ class KubernetesCluster:
                 provider="kubernetes",
                 provider_config={
                     "namespace": "tron",
+                    "version": __version__,
                     "kubeconfig_path": self.kubeconfig_path,
                     "task_configs": [task.get_config() for task in self.tasks.values()],
                 },


### PR DESCRIPTION
https://jira.yelpcorp.com/browse/TRON-1743
set custom user agent for k8s client usage from tron/task_proc

Bumped up task-processing version used by Tron.
Pass tron version info to task-processing which will be used for setting the useragent as per the changes in [this PR](https://github.com/Yelp/task_processing/pull/195)
