### PR TITLE
Detect abnormal successful exits in k8s

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: [--remove]
       - id: pretty-format-json
         args: [--autofix, --indent, '4', --no-sort-keys]
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
       - id: flake8

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -134,6 +134,51 @@ def test_handle_event_exit_on_failed(mock_kubernetes_task):
     assert mock_kubernetes_task.is_done
 
 
+def test_handle_event_abnormal_exit(mock_kubernetes_task):
+    mock_kubernetes_task.started()
+    raw_event_data = {
+        "status": {
+            "container_statuses": [
+                {
+                    "container_id": "docker://asdf",
+                    "image": "someimage",
+                    "image_id": "docker-pullable://someimage:sometag",
+                    "last_state": {"running": None, "terminated": None, "waiting": None},
+                    "name": "main",
+                    "ready": False,
+                    "restart_count": 0,
+                    "started": False,
+                    "state": {
+                        "running": None,
+                        "terminated": {
+                            "container_id": "docker://asdf",
+                            "exit_code": 0,
+                            "finished_at": None,
+                            "message": None,
+                            "reason": None,
+                            "signal": None,
+                            "started_at": None,
+                        },
+                        "waiting": None,
+                    },
+                }
+            ],
+        }
+    }
+    mock_kubernetes_task.handle_event(
+        mock_event_factory(
+            task_id=mock_kubernetes_task.get_kubernetes_id(),
+            raw=raw_event_data,
+            platform_type="finished",
+            terminal=True,
+            success=False,
+        )
+    )
+
+    assert mock_kubernetes_task.is_failed
+    assert mock_kubernetes_task.is_done
+
+
 def test_handle_event_lost(mock_kubernetes_task):
     mock_kubernetes_task.started()
     mock_kubernetes_task.handle_event(

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -113,9 +113,42 @@ def test_handle_event_running(mock_kubernetes_task):
 
 def test_handle_event_exit_on_finished(mock_kubernetes_task):
     mock_kubernetes_task.started()
+    raw_event_data = {
+        "status": {
+            "container_statuses": [
+                {
+                    "container_id": "docker://asdf",
+                    "image": "someimage",
+                    "image_id": "docker-pullable://someimage:sometag",
+                    "last_state": {"running": None, "terminated": None, "waiting": None},
+                    "name": "main",
+                    "ready": False,
+                    "restart_count": 0,
+                    "started": False,
+                    "state": {
+                        "running": None,
+                        "terminated": {
+                            "container_id": "docker://asdf",
+                            "exit_code": 0,
+                            "finished_at": "2022-11-19 00:11:02+00:00",
+                            "message": None,
+                            "reason": "Completed",
+                            "signal": None,
+                            "started_at": None,
+                        },
+                        "waiting": None,
+                    },
+                }
+            ],
+        }
+    }
     mock_kubernetes_task.handle_event(
         mock_event_factory(
-            task_id=mock_kubernetes_task.get_kubernetes_id(), platform_type="finished", terminal=True, success=True
+            task_id=mock_kubernetes_task.get_kubernetes_id(),
+            raw=raw_event_data,
+            platform_type="finished",
+            terminal=True,
+            success=True,
         )
     )
     assert mock_kubernetes_task.state == mock_kubernetes_task.COMPLETE

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -213,6 +213,7 @@ class ActionRun(Observable):
     EXIT_KUBERNETES_DISABLED = -6
     EXIT_KUBERNETES_NOT_CONFIGURED = -7
     EXIT_KUBERNETES_TASK_INVALID = -8
+    EXIT_KUBERNETES_ABNORMAL = -9
 
     EXIT_REASONS = {
         EXIT_INVALID_COMMAND: "Invalid command",
@@ -223,6 +224,7 @@ class ActionRun(Observable):
         EXIT_KUBERNETES_DISABLED: "Kubernetes disabled",
         EXIT_KUBERNETES_NOT_CONFIGURED: "Kubernetes enabled, but not configured",
         EXIT_KUBERNETES_TASK_INVALID: "Kubernetes task was not valid",
+        EXIT_KUBERNETES_ABNORMAL: "Kubernetes task failed in an unexpected manner",
     }
 
     # This is a list of "alternate locations" that we can look for stdout/stderr in

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -192,6 +192,13 @@ class KubernetesTask(ActionCommand):
         if event.terminal:
             self.log.info("This Kubernetes event was terminal, ending this action")
             self.report_resources(decrement=True)
+
+            exit_code = int(not getattr(event, "success", False))
+            # Returns False if we've already exited normally above
+            unexpected_error = self.exited(exit_code)
+            if unexpected_error:
+                self.log.error("Unexpected failure, exiting")
+
             self.done()
 
 

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -135,8 +135,9 @@ class KubernetesTask(ActionCommand):
         if k8s_type == "running":
             self.started()
         elif k8s_type == "finished":
-            raw_object = getattr(event, "raw", {})
-            container_statuses = raw_object.get("status", {}).get("container_statuses", []) or []
+            raw_object = getattr(event, "raw", {}) or {}
+            pod_status = raw_object.get("status", {}) or {}
+            container_statuses = pod_status.get("container_statuses", []) or []
             abnormal_exit = False
 
             if len(container_statuses) > 1 or len(container_statuses) == 0:


### PR DESCRIPTION
this is kinda wild: we're seeing that a kubelet will sometimes fail to start a container (usually due to what appear to be race conditions like those mentioned in https://github.com/kubernetes/kubernetes/issues/100047#issuecomment-797624208 and then decide that these Pods should be phase=Succeeded with an exit code of 0 - even though the container never actually started.

So far, we've noticed that when this happens, the `finished_at` and `reason` fields will be `None` - thus we'll check for at least one of these conditions to detect an abnormal exit and actually "fail" the affected action