### PR TITLE
Use correct dict casing for k8s metadata

### DIFF
--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -115,30 +115,30 @@ def test_handle_event_exit_on_finished(mock_kubernetes_task):
     mock_kubernetes_task.started()
     raw_event_data = {
         "status": {
-            "container_statuses": [
+            "containerStatuses": [
                 {
-                    "container_id": "docker://asdf",
+                    "containerID": "docker://asdf",
                     "image": "someimage",
-                    "image_id": "docker-pullable://someimage:sometag",
-                    "last_state": {"running": None, "terminated": None, "waiting": None},
+                    "imageID": "docker-pullable://someimage:sometag",
+                    "lastState": {"running": None, "terminated": None, "waiting": None},
                     "name": "main",
                     "ready": False,
-                    "restart_count": 0,
+                    "restartCount": 0,
                     "started": False,
                     "state": {
                         "running": None,
                         "terminated": {
-                            "container_id": "docker://asdf",
-                            "exit_code": 0,
-                            "finished_at": "2022-11-19 00:11:02+00:00",
+                            "containerID": "docker://asdf",
+                            "exitCode": 0,
+                            "finishedAt": "2022-11-19 00:11:02+00:00",
                             "message": None,
                             "reason": "Completed",
                             "signal": None,
-                            "started_at": None,
+                            "startedAt": None,
                         },
                         "waiting": None,
                     },
-                }
+                },
             ],
         }
     }
@@ -171,11 +171,11 @@ def test_handle_event_abnormal_exit(mock_kubernetes_task):
     mock_kubernetes_task.started()
     raw_event_data = {
         "status": {
-            "container_statuses": [
+            "containerStatuses": [
                 {
                     "container_id": "docker://asdf",
                     "image": "someimage",
-                    "image_id": "docker-pullable://someimage:sometag",
+                    "imageID": "docker-pullable://someimage:sometag",
                     "last_state": {"running": None, "terminated": None, "waiting": None},
                     "name": "main",
                     "ready": False,
@@ -184,17 +184,17 @@ def test_handle_event_abnormal_exit(mock_kubernetes_task):
                     "state": {
                         "running": None,
                         "terminated": {
-                            "container_id": "docker://asdf",
-                            "exit_code": 0,
-                            "finished_at": None,
+                            "containerID": "docker://asdf",
+                            "exitCode": 0,
+                            "finishedAt": None,
                             "message": None,
                             "reason": None,
                             "signal": None,
-                            "started_at": None,
+                            "startedAt": None,
                         },
                         "waiting": None,
                     },
-                }
+                },
             ],
         }
     }

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -137,7 +137,7 @@ class KubernetesTask(ActionCommand):
         elif k8s_type == "finished":
             raw_object = getattr(event, "raw", {}) or {}
             pod_status = raw_object.get("status", {}) or {}
-            container_statuses = pod_status.get("container_statuses", []) or []
+            container_statuses = pod_status.get("containerStatuses", []) or []
             abnormal_exit = False
 
             if len(container_statuses) > 1 or len(container_statuses) == 0:
@@ -163,8 +163,8 @@ class KubernetesTask(ActionCommand):
                     # the affected action
                     # NOTE: hopefully this won't change too drastically in future k8s upgrades without the actual problem (incorrect
                     # success) being fixed :p
-                    abnormal_exit = termination_metadata.get("exit_code") == 0 and (
-                        termination_metadata.get("finished_at") is None and termination_metadata.get("reason") is None
+                    abnormal_exit = termination_metadata.get("exitCode") == 0 and (
+                        termination_metadata.get("finishedAt") is None and termination_metadata.get("reason") is None
                     )
                     if abnormal_exit:
                         self.log.warning("Container never started due to a Kubernetes/infra flake!")


### PR DESCRIPTION
The data we'd been dumping into our logging streams was using different key names than what task_proc was actually sending k8s: we were logging the python-ified names, but task_proc was sending tron the literal k8s payloads (i.e., keynames being camelCased).

We didn't notice this 'cause until the initial attempt at working around this weird k8s bug we weren't actually logging what tron was seeing and our test data in the unit tests was based on what we'd been seeing in our logging streams