### PR TITLE
TRON-1723: Add user attribution into user agent when invoking tronctl commands

### DIFF
--- a/bin/tronctl
+++ b/bin/tronctl
@@ -202,7 +202,8 @@ def parse_cli():
 
 
 def request(url: str, data: Dict[str, Any], headers=None, method=None) -> bool:
-    response = client.request(url, data=data, headers=headers, method=method)
+    # We want every tronctl request to be attributable
+    response = client.request(url, data=data, headers=headers, method=method, user_attribution=True)
     if response.error:
         print(f"Error: {response.content}")
         return False
@@ -250,7 +251,7 @@ def _get_triggers_for_action(server: str, action_identifier: str) -> Optional[Tu
 
 
 def control_objects(args: argparse.Namespace):
-    tron_client = client.Client(args.server)
+    tron_client = client.Client(args.server, user_attribution=True)
     url_index = tron_client.index()
     for identifier in args.id:
         try:
@@ -320,7 +321,7 @@ def move(args):
     except IndexError as e:
         raise SystemExit(f"Error: Move command needs two arguments.\n{e}")
 
-    tron_client = client.Client(args.server)
+    tron_client = client.Client(args.server, user_attribution=True)
     url_index = tron_client.index()
     job_index = url_index["jobs"]
     if old_name not in job_index.keys():

--- a/tests/commands/client_test.py
+++ b/tests/commands/client_test.py
@@ -153,6 +153,24 @@ class TestClient(TestCase):
         )
 
 
+class TestUserAttribution(TestCase):
+    def test_default_user_agent(self):
+        url = "http://localhost:8089/"
+        with mock.patch("tron.commands.client.os.environ", autospec=True,) as mock_environ:
+            mock_environ.get.return_value = "testuser"
+            default_client = client.Client(url, user_attribution=False)
+            # we do not add user attribution by default
+            assert "(testuser)" not in default_client.headers["User-Agent"]
+
+    def test_attributed_user_agent(self):
+        url = "http://localhost:8089/"
+        with mock.patch("tron.commands.client.os.environ", autospec=True,) as mock_environ:
+            mock_environ.get.return_value = "testuser"
+            default_client = client.Client(url, user_attribution=True)
+            # we do not add user attribution by default
+            assert "(testuser)" in default_client.headers["User-Agent"]
+
+
 class TestGetUrl(TestCase):
     def test_get_job_url_for_action_run(self):
         url = client.get_job_url("MASTER.name.1.act")

--- a/tests/commands/retry_test.py
+++ b/tests/commands/retry_test.py
@@ -177,7 +177,9 @@ def test_wait_for_retry_deps_done(fake_retry_action, mock_client_request, event_
     )
     assert fake_retry_action._elapsed.seconds == 1  # init delay only
     mock_client_request.assert_called_once_with(
-        "http://localhost/a_fake_job/0/a_fake_action", data=dict(command="retry", use_latest_command=1)
+        "http://localhost/a_fake_job/0/a_fake_action",
+        data=dict(command="retry", use_latest_command=1),
+        user_attribution=True,
     )
 
 

--- a/tron/commands/backfill.py
+++ b/tron/commands/backfill.py
@@ -94,6 +94,7 @@ class BackfillRun:
                 client.request,
                 urljoin(self.tron_client.url_base, self.job_id.url),
                 data=dict(command="start", run_time=self.run_time),
+                user_attribution=True,
             ),
         )
 
@@ -184,7 +185,10 @@ class BackfillRun:
             response = await loop.run_in_executor(
                 None,
                 functools.partial(
-                    client.request, urljoin(self.tron_client.url_base, self.run_id.url), data=dict(command="cancel"),
+                    client.request,
+                    urljoin(self.tron_client.url_base, self.run_id.url),
+                    data=dict(command="cancel"),
+                    user_attribution=True,
                 ),
             )
             if response.error:
@@ -218,7 +222,7 @@ async def run_backfill_for_date_range(
     most, max_parallel runs can run in parallel to prevent resource exhaustion.
     """
     loop = asyncio.get_event_loop()
-    tron_client = client.Client(server)
+    tron_client = client.Client(server, user_attribution=True)
     url_index = tron_client.index()
 
     # check job_name identifies a valid tron object

--- a/tron/commands/retry.py
+++ b/tron/commands/retry.py
@@ -195,7 +195,10 @@ class RetryAction:
         response = await asyncio.get_event_loop().run_in_executor(
             None,
             functools.partial(
-                client.request, urljoin(self.tron_client.url_base, self.action_run_id.url), data=self.retry_params,
+                client.request,
+                urljoin(self.tron_client.url_base, self.action_run_id.url),
+                data=self.retry_params,
+                user_attribution=True,
             ),
         )
         if response.error:
@@ -214,7 +217,7 @@ def retry_actions(
     use_latest_command: bool = False,
     deps_timeout_s: int = RetryAction.NO_TIMEOUT,
 ) -> List[RetryAction]:
-    tron_client = client.Client(tron_server)
+    tron_client = client.Client(tron_server, user_attribution=True)
     r_actions = [RetryAction(tron_client, name, use_latest_command=use_latest_command) for name in full_action_names]
 
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
This adds an option to our tron Client to add the current username to the useragent when connecting to the API.

This then adds attribution to any client calls through tronctl (though i also see an argument for just adding it to everything by default too, if we wanna go that route).

Manually ran a few tronview commands and confirmed user-agent remained the same in the logs, and confirmed tronctl commands added the user attribution

Tronview:
```
Dec  2 10:00:36 tronplayground1-uswest1cdevc tron.api.www.access b'"127.0.0.1" - - [02/Dec/2022:18:00:35 +0000] "GET /api/jobs/paasta-contract-monitor.long_job?include_action_runs=0&num_runs=10 HTTP/1.1" 200 5452 "-" "Tron Command/1.23.7 +http://github.com/Yelp/Tron"'
```

Tronctl:
```
Dec  1 18:46:04 tronplayground1-uswest1cdevc tron.api.www.access b'"127.0.0.1" - - [02/Dec/2022:02:46:03 +0000] "GET /api/ HTTP/1.1" 200 1428 "-" "Tron Command/1.23.7 +http://github.com/Yelp/Tron (jfong)"'
Dec  1 18:46:04 tronplayground1-uswest1cdevc tron.api.www.access b'"127.0.0.1" - - [02/Dec/2022:02:46:03 +0000] "POST /api/jobs/paasta-contract-monitor.long_job HTTP/1.1" 200 67 "-" "Tron Command/1.23.7 +http://github.com/Yelp/Tron (jfong)"'
Dec  1 18:46:04 tronplayground1-uswest1cdevc tron.api.www.access b'"127.0.0.1" - - [02/Dec/2022:02:46:03 +0000] "GET /api/jobs/paasta-contract-monitor.long_job/36806?include_action_graph=0&include_action_runs=0 HTTP/1.1" 200 448 "-" "Tron Command/1.23.7 +http://github.com/Yelp/Tron (jfong)"'
```
