### PR TITLE
Adding ExecStopPost to systemd unit file to log tron exit status

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: tron
 Section: admin
 Priority: optional
 Maintainer: Daniel Nephin <dnephin@yelp.com>
-Build-Depends: debhelper (>= 7), python3.6-dev, libdb5.3-dev, libyaml-dev, libssl-dev, libffi-dev, dh-virtualenv
+Build-Depends: bsdutils, debhelper (>= 7), python3.6-dev, libdb5.3-dev, libyaml-dev, libssl-dev, libffi-dev, dh-virtualenv
 Standards-Version: 3.8.3
 
 Package: tron

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: tron
 Section: admin
 Priority: optional
 Maintainer: Daniel Nephin <dnephin@yelp.com>
-Build-Depends: bsdutils, debhelper (>= 7), python3.6-dev, libdb5.3-dev, libyaml-dev, libssl-dev, libffi-dev, dh-virtualenv
+Build-Depends: debhelper (>= 7), python3.6-dev, libdb5.3-dev, libyaml-dev, libssl-dev, libffi-dev, dh-virtualenv
 Standards-Version: 3.8.3
 
 Package: tron
 Architecture: all
 Homepage: http://github.com/yelp/Tron
-Depends: python3.6, libdb5.3, libyaml-0-2, libssl1.0.0, libffi6, ${shlibs:Depends}, ${misc:Depends}
+Depends: bsdutils, python3.6, libdb5.3, libyaml-0-2, libssl1.0.0, libffi6, ${shlibs:Depends}, ${misc:Depends}
 Description: Tron is a job scheduling, running and monitoring package.
   Designed to replace Cron for complex scheduling and dependencies.
   Provides:

--- a/debian/tron.service
+++ b/debian/tron.service
@@ -6,6 +6,7 @@ After=network.target
 User=tron
 EnvironmentFile=/etc/default/tron
 ExecStart=/usr/bin/trond --lock-file=${LOCKFILE:-$PIDFILE} --working-dir=${WORKINGDIR} --host ${LISTEN_HOST} --port ${LISTEN_PORT} ${DAEMON_OPTS}
+ExecStopPost=/usr/bin/logger -t tron_exit_status "SERVICE_RESULT:${SERVICE_RESULT} EXIT_CODE:${EXIT_CODE} EXIT_STATUS:${EXIT_STATUS}"
 TimeoutStopSec=20
 Restart=always
 LimitNOFILE=10000


### PR DESCRIPTION
This PR adds a ExecStopPost to the systemd unit file to log tron exit status