### PR TITLE
Upgrades requirements and adds caching on get loggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "eslint-plugin-react-hooks": "^4.1.0"
     },
     "resolutions": {
-        "axe-core": "4.3.3"
+        "axe-core": "4.4.1"
     },
     "engines": {
         "node-version-shim": "10.x",

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 docutils==0.14
-Jinja2==2.10.1
+Jinja2==2.11.3
 markupsafe==2.0.1
 mock==2.0.0
 Pygments==2.2.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,7 +1,6 @@
-docutils==0.14
-Jinja2==2.11.3
-markupsafe==2.0.1
-mock==2.0.0
-Pygments==2.2.0
-Sphinx==2.2.0
+Jinja2==3.1.2
+markupsafe==2.1.1
+mock==3.0.5
+Pygments==2.13
+Sphinx==6.1.3
 Sphinx-PyPI-upload==0.2.1

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -7,7 +7,7 @@ ecdsa>=0.13.3
 humanize
 ipdb
 ipython
-Jinja2>=2.10.1
+Jinja2>=3.1.2
 lockfile
 moto
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ boto3==1.9.249
 botocore==1.12.249
 bsddb3==6.2.7
 cachetools==4.2.1
-certifi==2019.11.28
+certifi==2022.12.7
 cffi==1.12.3
 cfn-lint==0.24.4
 chardet==3.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ http-parser==0.9.0
 humanize==0.5.1
 hyperlink==19.0.0
 idna==2.8
-incremental==17.5.0
+incremental==22.10.0
 ipdb==0.13.2
 ipython==7.8.0
 ipython-genutils==0.2.0
@@ -58,7 +58,6 @@ pyasn1-modules==0.2.8
 pycparser==2.19
 pyformance==0.4
 Pygments==2.4.2
-PyHamcrest==2.0.2
 pymesos==0.3.9
 pyrsistent==0.15.4
 pysensu-yelp==0.4.4
@@ -78,7 +77,7 @@ six==1.15.0
 sshpubkeys==3.1.0
 task-processing==0.9.0
 traitlets==4.3.3
-Twisted==20.3.0
+Twisted==22.10.0
 typing-extensions==4.5.0
 urllib3==1.25.6
 wcwidth==0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 addict==2.2.1
 argcomplete==1.9.5
+asttokens==2.2.1
 attrs==19.3.0
 Automat==20.2.0
 aws-sam-translator==1.15.1
@@ -22,6 +23,7 @@ decorator==4.4.0
 docker==4.1.0
 docutils==0.15.2
 ecdsa==0.13.3
+executing==1.2.0
 future==0.18.3
 google-auth==1.23.0
 http-parser==0.9.0
@@ -30,9 +32,9 @@ hyperlink==19.0.0
 idna==2.8
 incremental==22.10.0
 ipdb==0.13.2
-ipython==7.8.0
+ipython==8.10.0
 ipython-genutils==0.2.0
-jedi==0.15.1
+jedi==0.16.0
 Jinja2==3.1.2
 jmespath==0.9.4
 jsondiff==1.1.2
@@ -43,15 +45,17 @@ jsonschema==3.2.0
 kubernetes==17.17.0
 lockfile==0.12.2
 MarkupSafe==2.1.1
+matplotlib-inline==0.1.3
 mock==3.0.5
 moto==1.3.13
 oauthlib==3.1.0
-parso==0.5.1
+parso==0.7.0
 pexpect==4.7.0
 pickleshare==0.7.5
-prompt-toolkit==2.0.10
+prompt-toolkit==3.0.38
 psutil==5.6.6
 ptyprocess==0.6.0
+pure-eval==0.2.2
 py-bcrypt==0.4
 pyasn1==0.4.7
 pyasn1-modules==0.2.8
@@ -75,8 +79,9 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.15.0
 sshpubkeys==3.1.0
+stack-data==0.6.2
 task-processing==0.9.0
-traitlets==4.3.3
+traitlets==5.0.0
 Twisted==22.10.0
 typing-extensions==4.5.0
 urllib3==1.25.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ PyYAML==5.4.1
 requests==2.25.0
 requests-oauthlib==1.2.0
 responses==0.10.6
-rsa==4.0
+rsa==4.9
 s3transfer==0.6.0
 setuptools==65.5.1
 six==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ cffi==1.12.3
 cfn-lint==0.24.4
 chardet==3.0.4
 constantly==15.1.0
-cryptography==35.0.0
+cryptography==39.0.1
 dataclasses==0.6
 DateTime==4.3
 decorator==4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ pyasn1==0.4.7
 pyasn1-modules==0.2.8
 pycparser==2.19
 pyformance==0.4
-Pygments==2.4.2
+Pygments==2.7.4
 pymesos==0.3.9
 pyrsistent==0.15.4
 pysensu-yelp==0.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ decorator==4.4.0
 docker==4.1.0
 docutils==0.15.2
 ecdsa==0.13.3
-future==0.18.1
+future==0.18.3
 google-auth==1.23.0
 http-parser==0.9.0
 humanize==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ requests-oauthlib==1.2.0
 responses==0.10.6
 rsa==4.0
 s3transfer==0.2.1
-setuptools==41.4.0
+setuptools==65.5.1
 six==1.15.0
 sshpubkeys==3.1.0
 stack-data==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ aws-sam-translator==1.15.1
 aws-xray-sdk==2.4.2
 backcall==0.1.0
 boto==2.49.0
-boto3==1.9.249
-botocore==1.12.249
+boto3==1.26.85
+botocore==1.29.86
 bsddb3==6.2.7
 cachetools==4.2.1
 certifi==2022.12.7
@@ -21,7 +21,6 @@ dataclasses==0.6
 DateTime==4.3
 decorator==4.4.0
 docker==4.1.0
-docutils==0.15.2
 ecdsa==0.13.3
 executing==1.2.0
 future==0.18.3
@@ -71,11 +70,11 @@ python-jose==3.0.1
 pytimeparse==1.1.8
 pytz==2019.3
 PyYAML==5.4.1
-requests==2.22.0
+requests==2.25.0
 requests-oauthlib==1.2.0
 responses==0.10.6
 rsa==4.0
-s3transfer==0.2.1
+s3transfer==0.6.0
 setuptools==65.5.1
 six==1.15.0
 sshpubkeys==3.1.0
@@ -84,7 +83,7 @@ task-processing==0.9.0
 traitlets==5.0.0
 Twisted==22.10.0
 typing-extensions==4.5.0
-urllib3==1.25.6
+urllib3==1.26.5
 wcwidth==0.1.7
 websocket-client==0.56.0
 Werkzeug==2.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ ipdb==0.13.2
 ipython==7.8.0
 ipython-genutils==0.2.0
 jedi==0.15.1
-Jinja2==2.10.3
+Jinja2==3.1.2
 jmespath==0.9.4
 jsondiff==1.1.2
 jsonpatch==1.24
@@ -42,7 +42,7 @@ jsonpointer==2.0
 jsonschema==3.2.0
 kubernetes==17.17.0
 lockfile==0.12.2
-MarkupSafe==1.1.1
+MarkupSafe==2.1.1
 mock==3.0.5
 moto==1.3.13
 oauthlib==3.1.0
@@ -82,7 +82,7 @@ typing-extensions==4.5.0
 urllib3==1.25.6
 wcwidth==0.1.7
 websocket-client==0.56.0
-Werkzeug==0.16.0
+Werkzeug==2.2.3
 wrapt==1.11.2
 xmltodict==0.12.0
 zope.interface==5.1.0

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -11,7 +11,7 @@ from task_processing.interfaces.event import Event
 from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
 from task_processing.runners.subscription import Subscription
 from task_processing.task_processor import TaskProcessor
-from twisted.internet.defer import Deferred  # type: ignore  # need to upgrade twisted
+from twisted.internet.defer import Deferred
 from twisted.internet.defer import logError
 
 import tron.metrics as metrics
@@ -337,11 +337,12 @@ class KubernetesCluster:
         * control: events regarding how the task_proc plugin is running - handled directly
         * task: events regarding how the actual tasks/Pods we're running our doing - forwarded to KubernetesTask
         """
-        if self.deferred and not self.deferred.called:
+        if self.deferred is not None and not self.deferred.called:
             log.warning("Already have handlers waiting for next event in queue, not adding more")
             return
 
         self.deferred = self.queue.get()
+        assert self.deferred is not None
 
         # we want to process the event we just popped off the queue, but we also want
         # to form a sort of event loop, so we add two callbacks:

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -342,8 +342,9 @@ class KubernetesCluster:
             return
 
         self.deferred = self.queue.get()
-        assert self.deferred is not None
-
+        if self.deferred is None:
+            log.warning("Unable to get a handler for next event in queue - this should never happen!")
+            return
         # we want to process the event we just popped off the queue, but we also want
         # to form a sort of event loop, so we add two callbacks:
         # * one to actually deal with the event

--- a/tron/trondaemon.py
+++ b/tron/trondaemon.py
@@ -55,6 +55,10 @@ def setup_logging(options):
     # Show stack traces for errors in twisted deferreds.
     if options.debug:
         defer.setDebugging(True)
+    # Adds lru_cache to getLogger as we are seeing kubernetes-client locking on logging causing potential events to be missed
+    # This is a workaround and ideally we would want to remove this once this is fixed on kubernetes-client library
+    # For more details on the issue visit: https://github.com/kubernetes-client/python/issues/1867
+    # misc/jolt#148 has a similar workaround for this issue as well. See https://github.yelpcorp.com/misc/jolt/pull/148
     logging.getLogger = lru_cache(maxsize=None)(logging.getLogger)
 
 

--- a/tron/trondaemon.py
+++ b/tron/trondaemon.py
@@ -7,6 +7,7 @@ import os
 import signal
 import threading
 import time
+from functools import lru_cache
 
 import ipdb
 import pkg_resources
@@ -54,6 +55,7 @@ def setup_logging(options):
     # Show stack traces for errors in twisted deferreds.
     if options.debug:
         defer.setDebugging(True)
+    logging.getLogger = lru_cache(maxsize=None)(logging.getLogger)
 
 
 @contextlib.contextmanager

--- a/tron/trondaemon.py
+++ b/tron/trondaemon.py
@@ -55,10 +55,10 @@ def setup_logging(options):
     # Show stack traces for errors in twisted deferreds.
     if options.debug:
         defer.setDebugging(True)
-    # Adds lru_cache to getLogger as we are seeing kubernetes-client locking on logging causing potential events to be missed
-    # This is a workaround and ideally we would want to remove this once this is fixed on kubernetes-client library
-    # For more details on the issue visit: https://github.com/kubernetes-client/python/issues/1867
-    # misc/jolt#148 has a similar workaround for this issue as well. See https://github.yelpcorp.com/misc/jolt/pull/148
+    # Cache getLogger calls as we are seeing kubernetes-client locking on logging causing event processing to be extremely delayed
+    # This is a workaround and ideally we would want to remove this once this is fixed upstream in kubernetes-client
+    # For more details: https://github.com/kubernetes-client/python/issues/1867
+    # For Yelpers, misc/jolt#148 has a similar workaround for this issue internally.
     logging.getLogger = lru_cache(maxsize=None)(logging.getLogger)
 
 

--- a/tronweb2/package.json
+++ b/tronweb2/package.json
@@ -43,7 +43,7 @@
         "eslint-plugin-react-hooks": "^4.1.0"
     },
     "resolutions": {
-        "axe-core": "4.3.3"
+        "axe-core": "4.4.1"
     },
     "engines": {
         "node-version-shim": "10.x",


### PR DESCRIPTION
This PR upgrades some requirements to help us as we are seeing events being lost by Tron in pnw-devc on Python 3.8

- Upgrades Twisted to the latest version to support python 3.8
- Upgrades axe-core as previous version was incompatible
- adds lru_cache to logging to stop kubernetes from [locking on get loggers](https://github.com/kubernetes-client/python/issues/1867)
- Upgrades all dependencies recommended by dependabot to address security severities and further future proof.