### PR TITLE
Ignores CryptographyDeprecationWarning

### DIFF
--- a/tron/ssh.py
+++ b/tron/ssh.py
@@ -10,10 +10,11 @@ from twisted.conch.ssh import keys
 from twisted.internet import defer
 from twisted.python import failure
 
-# We are ignoring CryptographyDeprecationWarning as it is coming from the twisted upstream library
-# The two deprecated warnings we are seeing are Blowfish and CAST5
-# Ideally we can remove this once removed in https://github.com/twisted/twisted/blob/trunk/src/twisted/conch/ssh/transport.py#L95-L109
+# Ignore CryptographyDeprecationWarning as we don't use `cryptography` directly and
+# the warnings are coming from one of our dependencies (Twisted) that does. There's
+# nothing we can do until they stop using the deprecated ciphers - so ignoring these warnings should be safe
 warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning)
+# These need to be imported after filtering warnings
 from twisted.conch.client import default  # noqa: E402
 from twisted.conch.ssh import transport  # noqa: E402
 

--- a/tron/ssh.py
+++ b/tron/ssh.py
@@ -1,14 +1,22 @@
 import logging
 import struct
+import warnings
 
-from twisted.conch.client import default
+from cryptography.utils import CryptographyDeprecationWarning
 from twisted.conch.ssh import channel
 from twisted.conch.ssh import common
 from twisted.conch.ssh import connection
 from twisted.conch.ssh import keys
-from twisted.conch.ssh import transport
 from twisted.internet import defer
 from twisted.python import failure
+
+# We are ignoring CryptographyDeprecationWarning as it is coming from the twisted upstream library
+# The two deprecated warnings we are seeing are Blowfish and CAST5
+# Ideally we can remove this once removed in https://github.com/twisted/twisted/blob/trunk/src/twisted/conch/ssh/transport.py#L95-L109
+warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning)
+from twisted.conch.client import default  # noqa: E402
+from twisted.conch.ssh import transport  # noqa: E402
+
 
 log = logging.getLogger("tron.ssh")
 


### PR DESCRIPTION
We're seeing these warnings happen when running tronctl after upgrading twisted. This is due to twisted upstream library and is safe to ignore. Ideally we can remove this workaround once it's removed in twisted.

```
❯ tronctl -h
/opt/venvs/tron/lib/python3.8/site-packages/twisted/conch/ssh/transport.py:97: CryptographyDeprecationWarning: Blowfish has been deprecated
  b”blowfish-cbc”: (algorithms.Blowfish, 16, modes.CBC),
/opt/venvs/tron/lib/python3.8/site-packages/twisted/conch/ssh/transport.py:101: CryptographyDeprecationWarning: CAST5 has been deprecated
  b”cast128-cbc”: (algorithms.CAST5, 16, modes.CBC),
/opt/venvs/tron/lib/python3.8/site-packages/twisted/conch/ssh/transport.py:106: CryptographyDeprecationWarning: Blowfish has been deprecated
  b”blowfish-ctr”: (algorithms.Blowfish, 16, modes.CTR),
/opt/venvs/tron/lib/python3.8/site-packages/twisted/conch/ssh/transport.py:107: CryptographyDeprecationWarning: CAST5 has been deprecated
  b”cast128-ctr”: (algorithms.CAST5, 16, modes.CTR),
usage: tronctl [-h] [--version] [-v] [--server SERVER] [--cluster_name CLUSTER_NAME] [-s]
               {start,rerun,retry,recover,cancel,backfill,disable,enable,fail,success,skip,skip-and-publish,stop,kill,move,publish,discard,version} ...
```
