### PR TITLE
TRON-1859: Updates date arithmetic to handle whitespace

### DIFF
--- a/tests/utils/timeutils_test.py
+++ b/tests/utils/timeutils_test.py
@@ -350,6 +350,20 @@ class DateArithmeticYMDHTest(TestCase):
         s = timeutils.DateArithmetic.parse("ym-1", dt=dt)
         assert s == "2019-02"
 
+    def test_ymd_plus_whitespace(self):
+        def parse(*ymd):
+            return DateArithmetic.parse("ymd + 1", datetime.datetime(*ymd))
+
+        assert_equal(parse(2018, 1, 1), "2018-01-02")
+        assert_equal(parse(2018, 1, 31), "2018-02-01")
+
+    def test_ymd_minus_whitespace(self):
+        def parse(*ymd):
+            return DateArithmetic.parse("ymd- 1", datetime.datetime(*ymd))
+
+        assert_equal(parse(2018, 1, 1), "2017-12-31")
+        assert_equal(parse(2018, 1, 2), "2018-01-01")
+
 
 class TestDateArithmeticWithTimezone(DateArithmeticTestCase):
 

--- a/tron/utils/timeutils.py
+++ b/tron/utils/timeutils.py
@@ -93,7 +93,7 @@ class DateArithmetic:
         based on date format (Ex: seconds for unixtime, days for day).
         """
         dt = dt or current_time()
-
+        date_str = date_str.replace(" ", "")
         match = cls.DATE_TYPE_PATTERN.match(date_str)
         if not match:
             return


### PR DESCRIPTION
```
>>> from tron.utils.timeutils import DateArithmetic
>>> da = DateArithmetic()
>>> da.parse('shortdate - 1')
'2023-03-08'
>>> da.parse('shortdate-1')
'2023-03-08'
>>> da.parse('shortdate - 2')
'2023-03-07'
```