### PR TITLE
Handle abnormal events & pod evictions before containercreated better

### DIFF
--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -357,6 +357,39 @@ def test_handle_event_abnormal_exit(mock_kubernetes_task):
     assert mock_kubernetes_task.is_done
 
 
+def test_handle_event_missing_state(mock_kubernetes_task):
+    mock_kubernetes_task.started()
+    raw_event_data = {
+        "status": {
+            "containerStatuses": [
+                {
+                    "containerID": "docker://asdf",
+                    "image": "someimage",
+                    "imageID": "docker-pullable://someimage:sometag",
+                    "lastState": {},
+                    "name": "main",
+                    "ready": False,
+                    "restartCount": 0,
+                    "started": False,
+                    "state": None,
+                },
+            ],
+        }
+    }
+    mock_kubernetes_task.handle_event(
+        mock_event_factory(
+            task_id=mock_kubernetes_task.get_kubernetes_id(),
+            raw=raw_event_data,
+            platform_type="killed",
+            terminal=True,
+            success=False,
+        )
+    )
+    assert mock_kubernetes_task.exit_status == exitcode.EXIT_KUBERNETES_ABNORMAL
+    assert mock_kubernetes_task.is_failed
+    assert mock_kubernetes_task.is_done
+
+
 def test_handle_event_lost(mock_kubernetes_task):
     mock_kubernetes_task.started()
     mock_kubernetes_task.handle_event(

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -274,6 +274,44 @@ def test_handle_event_node_scaledown_exit(mock_kubernetes_task):
     assert mock_kubernetes_task.is_done
 
 
+def test_handle_event_exit_not_terminated(mock_kubernetes_task):
+    mock_kubernetes_task.started()
+    raw_event_data = {
+        "status": {
+            "containerStatuses": [
+                {
+                    "containerID": "docker://asdf",
+                    "image": "someimage",
+                    "imageID": "docker-pullable://someimage:sometag",
+                    "lastState": {},
+                    "name": "main",
+                    "ready": False,
+                    "restartCount": 0,
+                    "started": False,
+                    "state": {
+                        "running": None,
+                        "terminated": None,
+                        "waiting": {"reason": "ContainerCreating"},
+                    },
+                },
+            ],
+        }
+    }
+    mock_kubernetes_task.handle_event(
+        mock_event_factory(
+            task_id=mock_kubernetes_task.get_kubernetes_id(),
+            raw=raw_event_data,
+            platform_type="killed",
+            terminal=True,
+            success=False,
+        )
+    )
+
+    assert mock_kubernetes_task.exit_status == exitcode.EXIT_KUBERNETES_NODE_SCALEDOWN
+    assert mock_kubernetes_task.is_failed
+    assert mock_kubernetes_task.is_done
+
+
 def test_handle_event_abnormal_exit(mock_kubernetes_task):
     mock_kubernetes_task.started()
     raw_event_data = {

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -158,15 +158,15 @@ class KubernetesTask(ActionCommand):
                 main_container_state = main_container_statuses.get("state", {}) or {}
                 main_container_last_state = main_container_statuses.get("lastState", {}) or {}
 
-                event_missing_state = main_container_state is None or main_container_state.get("terminated") is None
-                event_missing_previous_state = (
-                    main_container_last_state is None or main_container_last_state.get("terminated") is None
-                )
+                event_missing_state = main_container_state is None
+                event_missing_previous_state = main_container_last_state is None
 
                 # We are expecting this code to never be hit as we are expecting both state and last_state have values
                 # The else statement should handle the situation gracefully when either current/last state are missing
                 if event_missing_state and event_missing_previous_state:
-                    self.log.error("Got an event with missing state - assuming success.")
+                    self.log.error(
+                        f"Got an event with missing state - assuming {'success' if exit_code==0 else 'failure'}."
+                    )
                     self.log.error(f"Event with missing state: {raw_object}")
                 else:
                     state_termination_metadata = main_container_state.get("terminated", {}) or {}
@@ -191,8 +191,13 @@ class KubernetesTask(ActionCommand):
                                 f"If automatic retries are not enabled, run `tronctl retry {self.id}` to retry."
                             )
                     elif k8s_type in KUBERNETES_FAILURE_TYPES:
+                        # pod killed before it reached terminal state, assume node scaledown
+                        if not (state_termination_metadata or last_state_termination_metadata):
+                            self.log.warning("Container did not complete, likely due to scaling down a node.")
+                            exit_code = exitcode.EXIT_KUBERNETES_NODE_SCALEDOWN
+
                         # Handling spot terminations
-                        if (
+                        elif (
                             last_state_termination_metadata.get("exitCode") == 137
                             and last_state_termination_metadata.get("reason") == "ContainerStatusUnknown"
                         ):

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -145,7 +145,7 @@ class KubernetesTask(ActionCommand):
             raw_object = getattr(event, "raw", {}) or {}
             pod_status = raw_object.get("status", {}) or {}
             container_statuses = pod_status.get("containerStatuses", []) or []
-            exit_code = 0 if k8s_type == "finished" else 1
+            exit_code = 0 if k8s_type == "finished" else exitcode.EXIT_KUBERNETES_ABNORMAL
 
             if len(container_statuses) > 1 or len(container_statuses) == 0:
                 # shouldn't happen right now, but who knows what future us will do :p
@@ -158,8 +158,8 @@ class KubernetesTask(ActionCommand):
                 main_container_state = main_container_statuses.get("state", {}) or {}
                 main_container_last_state = main_container_statuses.get("lastState", {}) or {}
 
-                event_missing_state = main_container_state is None
-                event_missing_previous_state = main_container_last_state is None
+                event_missing_state = not main_container_state
+                event_missing_previous_state = not main_container_last_state
 
                 # We are expecting this code to never be hit as we are expecting both state and last_state have values
                 # The else statement should handle the situation gracefully when either current/last state are missing


### PR DESCRIPTION
This changes a few things about our event handling:

1. This updates the "missing state" check to match only if the actual "state" data was missing from the pod event, rather than also matching when "state" existed but "terminated" state data was missing.  Because we safely attempt to extract the "terminated" state with a valid empty default value if it's not found, this should not impact any later logic. 

If a terminal event was sent, but the main container 'state' did not include 'terminated', this PR adds a new condition to check for this and assumes we encounted a node scaledown (likely the only way the pod was terminal but container did not fully terminate), and so we return EXIT_KUBERNETES_NODE_SCALEDOWN.

Also added a test for this condition

2. Our default exit code was `1`, which seems confusing since we couldn't determine if it was our own hardcoded default or the application exiting 1, so I've changed this to treat it as our generic `EXIT_KUBERNETES_ABNORMAL` - if the pod `failed` due to application failure, kubernetes should include the application's exit code in the `state` data, and our code would still set the action's exit_code appropriately from there.  

So we should only ever return EXIT_KUBERNETES_ABNORMAL in the case of the event missing `state` information entirely, or if the pod did not match our other exit code conditions and `state` information did not include any `exitCode`.

I've added a test to confirm we exit abnormal with missing state, and we exit with provided exitCode in case of `failure`. 

3. We still reported that we were "assuming success" when state was missing from a terminal event, which was no longer the case for `failed` and `killed` event types since [this change](https://github.com/Yelp/Tron/pull/886/files#diff-397e18ba5c3dfd6a640d6ef42ea9547c50ad2bb24172b59b00623c53a42c9382L141-R145).  This now changes the log line based on `exit_code`, reporting success only if `exit_code==0`. 

