### PR TITLE
Print raw output in scribereader fallback command

### DIFF
--- a/tron/utils/scribereader.py
+++ b/tron/utils/scribereader.py
@@ -214,11 +214,11 @@ def read_log_stream_for_action_run(
         location_selector = f"-s {paasta_cluster}"
     truncation_message = (
         [
-            f"This output is truncated. Use this command to view all lines: scribereader {location_selector} {stream_name} --min-date {min_date.date()} --max-date {max_date.date()} | jq 'select(.tron_run_number=={int(run_num)}) | .message'"
+            f"This output is truncated. Use this command to view all lines: scribereader {location_selector} {stream_name} --min-date {min_date.date()} --max-date {max_date.date()} | jq --raw-output 'select(.tron_run_number=={int(run_num)}) | .message'"
         ]
         if max_date
         else [
-            f"This output is truncated. Use this command to view all lines: scribereader {location_selector} {stream_name} --min-date {min_date.date()} | jq 'select(.tron_run_number=={int(run_num)}) | .message'"
+            f"This output is truncated. Use this command to view all lines: scribereader {location_selector} {stream_name} --min-date {min_date.date()} | jq --raw-output 'select(.tron_run_number=={int(run_num)}) | .message'"
         ]
     )
     truncated = truncation_message if truncated_output else []


### PR DESCRIPTION
The current shell pipeline prints out every line surrounded by quotes, which is a bit annoying when sharing logs (or snippets of logs) with other people since you either need to manually clean up the logs to strip the quotes or live with the shame of sending someone ugly-looking text :p