### PR TITLE
Update to the latest task_proc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ s3transfer==0.2.1
 setuptools==41.4.0
 six==1.14.0
 sshpubkeys==3.1.0
-task-processing==0.12.1
+task-processing==0.12.2
 traitlets==4.3.3
 Twisted==20.3.0
 typing-extensions==3.10.0.0


### PR DESCRIPTION
This version pulls in a fix that stops pods from being launched with a null request. This has been running fine in infrastage where I've verified that Pods are indeed being launched with the correct metadata

I've verified this as well with unit tests in task_proc :)