### PR TITLE
Update to PyYAML==6.0.1

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,7 @@ override_dh_virtualenv:
 	echo $(PIP_INDEX_URL)
 	dh_virtualenv --index-url $(PIP_INDEX_URL) \
                 --python=/usr/bin/python3.6 \
-		--preinstall cython==0.29.36 \
+                --preinstall cython==0.29.36 \
                 --preinstall pip-custom-platform \
                 --preinstall pip==9.0.1 \
                 --preinstall setuptools==46.1.3 \

--- a/debian/rules
+++ b/debian/rules
@@ -19,8 +19,7 @@ override_dh_virtualenv:
 	echo $(PIP_INDEX_URL)
 	dh_virtualenv --index-url $(PIP_INDEX_URL) \
                 --python=/usr/bin/python3.6 \
-                --preinstall no-manylinux1 \
-                --preinstall cython \
+		--preinstall cython==0.29.36 \
                 --preinstall pip-custom-platform \
                 --preinstall pip==9.0.1 \
                 --preinstall setuptools==46.1.3 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ python-dateutil==2.8.1
 python-jose==3.0.1
 pytimeparse==1.1.8
 pytz==2019.3
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.22.0
 requests-oauthlib==1.2.0
 responses==0.10.6


### PR DESCRIPTION
This is to handle the recent breakage caused by us not always using pre-built wheels for our dependencies.

Switching off of pip-custom-platform would be a better fix but, just like in PaaSTA, this is likely to be quite a bit of work so for now we can simply upgrade our PyYAML.