### PR TITLE
Don't hard-code yelpcorp PyPI registry

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,12 +18,11 @@ override_dh_auto_test:
 override_dh_virtualenv:
 	echo $(PIP_INDEX_URL)
 	dh_virtualenv --index-url $(PIP_INDEX_URL) \
+	            --extra-pip-arg  --trusted-host=169.254.255.254 \
                 --python=/usr/bin/python3.6 \
                 --preinstall cython==0.29.36 \
-                --preinstall pip-custom-platform \
                 --preinstall pip==9.0.1 \
-                --preinstall setuptools==46.1.3 \
-                --pip-tool pip-custom-platform \
+                --preinstall setuptools==46.1.3
 
 override_dh_installinit:
 	dh_installinit --noscripts

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py36
-tox_pip_extensions_ext_pip_custom_platform = true
 tox_pip_extensions_ext_venv_update = true
 
 [testenv]
@@ -9,7 +8,7 @@ deps =
     --requirement={toxinidir}/requirements.txt
     --requirement={toxinidir}/requirements-dev.txt
 usedevelop = true
-passenv = USER PIP_INDEX_URL
+passenv = USER
 setenv =
     YARN_REGISTRY = {env:NPM_CONFIG_REGISTRY:https://registry.npmjs.org/}
 whitelist_externals=
@@ -27,7 +26,7 @@ commands =
     check-requirements
     # optionally install yelpy requirements - this is after check-requirements since
     # check-requirements doesn't understand these extra requirements
-    -pip install --index-url https://pypi.yelpcorp.com/simple -r yelp_package/extra_requirements_yelp.txt
+    -pip install -r yelp_package/extra_requirements_yelp.txt
     # we then run tests at the very end so that we can run tests with yelpy requirements
     py.test -s {posargs:tests}
 

--- a/yelp_package/bionic/Dockerfile
+++ b/yelp_package/bionic/Dockerfile
@@ -36,5 +36,5 @@ RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list
 RUN echo "deb http://deb.nodesource.com/node_10.x bionic main" > /etc/apt/sources.list.d/nodesource.list
 RUN apt-get -q update && apt-get -q install -y --no-install-recommends yarn nodejs
 
-RUN pip3 install --index-url ${PIP_INDEX_URL} virtualenv==16.7.5
+RUN pip3 install --trusted-host 169.254.255.254 --index-url ${PIP_INDEX_URL} virtualenv==16.7.5
 WORKDIR /work


### PR DESCRIPTION
This is controlled via the `/etc/pip.conf` file which is managed by Puppet on yelpcorp hosts.

This should also get rid of the need to use pip-custom-platform.