### PR TITLE
Fix item assignment issue with ConfigSecretVolume

### DIFF
--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -218,6 +218,12 @@ class ConfigSecretVolume(_ConfigSecretVolume):
         d = super()._asdict().copy()
         items = d.get("items", [])
         if items is not None and items:
+            # the config parsing code appears to be turning arrays into tuples - however, updating the
+            # code we think is at fault breaks a non-trivial amount of tests. in the interest of time, we're
+            # just casting to a list here, but we should eventually circle back here
+            # and either ensure that we always get a list from the config parse code OR document that we're
+            # expecting Tron's config parsing code to return immutable data if this is behavior we want to depend on.
+            d["items"] = list(d["items"])
             for i, item in enumerate(items):
                 if isinstance(item, ConfigSecretVolumeItem):
                     d["items"][i] = item._asdict()


### PR DESCRIPTION
This PR fixes the schema assumption that configsecretVolume's "items" field is an array. I did not find the source of the array to tuple transformation, but this is the only place in the code that assume it's a writable array, so this also resolve the problem.

This [test job was used](https://github.yelpcorp.com/sysgit/yelpsoa-configs/pull/33389/files) with a locally modified version of tron in infrastage.

BEFORE change: https://fluffy.yelpcorp.com/i/7h1Tdwvblkf4KKKxz74V4T83XSbDxfsL.html
run successfully on infrastage: https://fluffy.yelpcorp.com/i/RWBcgXWqVfcsrFVXf9rtwfN6B9N7RpT4.html
retries successfully on infrastage: https://fluffy.yelpcorp.com/i/0d9hRM3hQ3KWv0nSDcHtTKGDLK7phXpt.html

The (currently) failing itest is also present for working commits in master. I don't know what this is about.