### PR TITLE
Stop backing up Tron EventBus events

### DIFF
--- a/tests/eventbus_test.py
+++ b/tests/eventbus_test.py
@@ -94,12 +94,12 @@ class EventBusTestCase(TestCase):
         time.time = mock.Mock(return_value=1.0)
         self.eventbus.sync_save_log("test")
         current_link = os.readlink(self.eventbus.log_current)
-        assert_equal(current_link, os.path.join(self.log_dir.name, "1.pickle"))
+        assert_equal(current_link, os.path.join(self.log_dir.name, "events.pickle"))
 
         time.time = mock.Mock(return_value=2.0)
         self.eventbus.sync_save_log("test")
         new_link = os.readlink(self.eventbus.log_current)
-        assert_equal(new_link, os.path.join(self.log_dir.name, "2.pickle"))
+        assert_equal(new_link, os.path.join(self.log_dir.name, "events.pickle"))
         assert os.path.exists(current_link)
         assert os.path.exists(new_link)
 


### PR DESCRIPTION
In the last N years, we've never had to do anything with the historical files - since they're just eating up disk space, let's just go to using a single file