### PR TITLE
TRON-2035: Fix public docs w/ new RTDv2 config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,39 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# RTD defaults as of 2023-11-08
+build:
+  # TODO: Bump to jammy+3.8 once master branch updated
+  os: ubuntu-20.04
+  tools:
+    python: "3.6"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Also provide downloadable zip
+formats: [htmlzip]
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: requirements-docs.txt


### PR DESCRIPTION
Similar to https://github.com/Yelp/paasta/pull/3745 , we need to add the new RTD v2 config file.  

They thankfully still support py3.6 on focal, and the build seems to work as expected on a personal fork + rtd project:
https://test-jfong-tron.readthedocs.io/en/latest/man_tronctl.html
https://readthedocs.org/projects/test-jfong-tron/builds/22836317/

Latest passing build of our public docs seems to have run nearly the exact same set of commands (although curiously ran on py3.7 instead of 3.6! I think it's fine to stick w/ 36 to match the service repo + bump to 3.8 when we do everything tho):
https://readthedocs.org/projects/tron/builds/19664551/
