### PR TITLE
Stop keeping old copies of eventbus files

### DIFF
--- a/tests/eventbus_test.py
+++ b/tests/eventbus_test.py
@@ -100,7 +100,10 @@ class EventBusTestCase(TestCase):
         self.eventbus.sync_save_log("test")
         new_link = os.readlink(self.eventbus.log_current)
         assert_equal(new_link, os.path.join(self.log_dir.name, "2.pickle"))
-        assert os.path.exists(current_link)
+        # we clean up the previous link so as not to have a million pickles
+        # on disk
+        assert not os.path.exists(current_link)
+        # so at this point, we should only have the new link
         assert os.path.exists(new_link)
 
     @mock.patch("tron.eventbus.time", autospec=True)

--- a/tron/eventbus.py
+++ b/tron/eventbus.py
@@ -147,7 +147,7 @@ class EventBus:
     def sync_save_log(self, reason: str) -> bool:
         started = time.time()
         new_file = os.path.join(self.log_dir, f"{int(started)}.pickle")
-        previous_file = os.path.realpath(os.path.join(self.log_dir, "current.pickle"))
+        previous_file = os.path.realpath(os.path.join(self.log_dir, "current"))
         try:
             with open(new_file, "xb") as f:
                 pickle.dump(self.event_log, f)


### PR DESCRIPTION
We've never restored from these "backups", and as long as we ensure that the current file points to a fully written file, it's fine to only keep at most 2 files around: the actual current file and a temporary "new" file.

To ensure that we're not pointing at a half-written file, we continue using the age-old pattern for atomic file updates: write to another file and swap a symlink once the write is complete