### PR TITLE
Use Underscores HTML escaped interpolation in template for log and command outputs

### DIFF
--- a/tronweb/coffee/actionrun.coffee
+++ b/tronweb/coffee/actionrun.coffee
@@ -169,12 +169,12 @@ class module.ActionRunView extends Backbone.View
                     <tr><td>Node</td>
                         <td><%= displayNode(node) %></td></tr>
                     <tr><td>Raw original command</td>
-                        <td><code class="command"><%= original_command %></code></td></tr>
+                        <td><code class="command"><%- original_command %></code></td></tr>
                     <tr><td>Config command</td>
-                        <td><code class="command"><%= raw_command %></code></td></tr>
+                        <td><code class="command"><%- raw_command %></code></td></tr>
                     <% if (command) { %>
                     <tr><td>Last run command</td>
-                        <td><code class="command"><%= command %></code></td></tr>
+                        <td><code class="command"><%- command %></code></td></tr>
                     <% } %>
                     <tr><td>Exit codes</td>
                         <td>
@@ -211,15 +211,15 @@ class module.ActionRunView extends Backbone.View
             </div>
             <div class="span12 outline-block">
                 <h2>meta</h2>
-                <pre class="meta" style="display: none;"><%= meta.join('\\n') %></pre>
+                <pre class="meta" style="display: none;"><%- meta.join('\\n') %></pre>
             </div>
             <div class="span12 outline-block">
                 <h2>stdout</h2>
-                <pre class="stdout"><%= stdout.join('\\n') %></pre>
+                <pre class="stdout"><%- stdout.join('\\n') %></pre>
             </div>
             <div class="span12 outline-block">
                 <h2>stderr</h2>
-                <pre class="stderr"><%= stderr.join('\\n') %></pre>
+                <pre class="stderr"><%- stderr.join('\\n') %></pre>
             </div>
 
             <div id="action-run-history">

--- a/tronweb/coffee/models.coffee
+++ b/tronweb/coffee/models.coffee
@@ -34,7 +34,7 @@ class window.RefreshModel extends Backbone.Model
             @scheduleRefresh()
 
     disableRefresh: =>
-        console.log("Disableing refresh ")
+        console.log("Disabling refresh")
         @enabled = false
         @clear()
 


### PR DESCRIPTION
Escape HTML in command, stdout, and stderr

[Before](https://fluffy.yelpcorp.com/i/sZ2x8dNzwmpp5DbZxv1fHfSf6qGDhDzf.png) and [after](https://fluffy.yelpcorp.com/i/MHgSkHnPs614l2djCr7T7ZCFJ1f02FxB.png).