### PR TITLE
Specify stdout or stderr in the scribereader command

### DIFF
--- a/tron/utils/scribereader.py
+++ b/tron/utils/scribereader.py
@@ -223,11 +223,11 @@ def read_log_stream_for_action_run(
         location_selector = f"-s {paasta_cluster}"
     truncation_message = (
         [
-            f"This output is truncated. Use this command to view all lines: scribereader {location_selector} {stream_name} --min-date {min_date.date()} --max-date {max_date.date()} | jq --raw-output 'select(.tron_run_number=={int(run_num)}) | .message'"
+            f"This output is truncated. Use this command to view all lines: scribereader {location_selector} {stream_name} --min-date {min_date.date()} --max-date {max_date.date()} | jq --raw-output 'select(.tron_run_number=={int(run_num)} and .component == \"{component}\") | .message'"
         ]
         if max_date
         else [
-            f"This output is truncated. Use this command to view all lines: scribereader {location_selector} {stream_name} --min-date {min_date.date()} | jq --raw-output 'select(.tron_run_number=={int(run_num)}) | .message'"
+            f"This output is truncated. Use this command to view all lines: scribereader {location_selector} {stream_name} --min-date {min_date.date()} | jq --raw-output 'select(.tron_run_number=={int(run_num)} and .component == \"{component}\") | .message'"
         ]
     )
     truncated = truncation_message if truncated_output else []


### PR DESCRIPTION
To filter stdout/stderr logs in the scribereader command, which users are adviced to run.

![image](https://github.com/Yelp/Tron/assets/8851038/5daeca58-2ce7-49b1-a2dd-2fa074ef1639)

=> change to

```
scribereader -e pnw stream_paasta_app_output_spark_spark_driver_test_redshift__test_redshift --min-date 2024-02-23 | jq --raw-output 'select(.tron_run_number==0 and .component=="stdout") | .message'
```