### PR TITLE
Local package index is outdated. Add update to ci to avoid this

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      # Update package lists to ensure we have the latest information
+      - run: sudo apt-get update
       # the container provided by GitHub doesn't include utilities
       # needed for dpkg building, so we need to install `devscripts`
       # to bring those in


### PR DESCRIPTION
My last release failed with `E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/g/gpgme1.0/python3-gpg_1.13.1-7ubuntu2.1_amd64.deb  404  Not Found [IP: 52.252.75.106 80]`

Following the handy suggestion:
`Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?`