### PR TITLE
Adding yelp_clog S3LogsReader

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,3 +12,9 @@ warn_unused_ignores = True
 
 [mypy-clusterman_metrics.*]
 ignore_missing_imports = True
+
+[mypy-clog.*]
+ignore_missing_imports = True
+
+[mypy-scribereader.*]
+ignore_missing_imports = True

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -8,5 +8,5 @@ pytest
 pytest-asyncio
 requirements-tools
 types-PyYAML
-types-requests<2.31.0.7
+types-requests<2.31.0.7 # newer types-requests requires urllib3>=2
 types-simplejson

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -7,3 +7,6 @@ pylint
 pytest
 pytest-asyncio
 requirements-tools
+types-PyYAML
+types-requests<2.31.0.7
+types-simplejson

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,8 +10,8 @@ iniconfig==1.1.1
 isort==4.3.18
 lazy-object-proxy==1.9.0
 mccabe==0.7.0
-mypy==0.812
-mypy-extensions==0.4.3
+mypy==1.9.0
+mypy-extensions==1.0.0
 nodeenv==1.3.3
 packaging==19.2
 platformdirs==2.5.2
@@ -28,5 +28,8 @@ requirements-tools==1.2.1
 toml==0.10.2
 tomli==2.0.1
 tomlkit==0.11.6
-typed-ast==1.4.0
+types-PyYAML==6.0.12
+types-requests==2.31.0.5
+types-simplejson==3.19.0.20240310
+types-urllib3==1.26.25.14
 virtualenv==20.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ aws-sam-translator==1.15.1
 aws-xray-sdk==2.4.2
 backcall==0.1.0
 boto==2.49.0
-boto3==1.26.85
-botocore==1.29.86
+boto3==1.34.80
+botocore==1.34.80
 bsddb3==6.2.7
 cachetools==4.2.1
 certifi==2022.12.7
@@ -75,7 +75,7 @@ requests==2.25.0
 requests-oauthlib==1.2.0
 responses==0.10.6
 rsa==4.9
-s3transfer==0.6.0
+s3transfer==0.10.1
 setuptools==65.5.1
 six==1.15.0
 sshpubkeys==3.1.0

--- a/tests/utils/scribereader_test.py
+++ b/tests/utils/scribereader_test.py
@@ -3,13 +3,89 @@ from unittest import mock
 
 import pytest
 
+import tron.utils.scribereader
 from tron.utils.scribereader import read_log_stream_for_action_run
 
 try:
     import scribereader  # noqa: F401
+    from clog.readers import S3LogsReader
 except ImportError:
-    pytest.skip("scribereader not available, skipping tests", allow_module_level=True)
+    pytest.skip("yelp logs readers not available, skipping tests", allow_module_level=True)
 
+
+def static_conf_patch(args={}):
+    return lambda arg, namespace, default=None: args.get(arg)  
+
+
+def test_read_log_stream_for_action_run_not_available():    
+    orig_scribereader = tron.utils.scribereader.scribereader
+    orig_S3LogsReader = tron.utils.scribereader.S3LogsReader
+    tron.utils.scribereader.scribereader = None
+    tron.utils.scribereader.S3LogsReader = None
+    try:
+        output =  tron.utils.scribereader.read_log_stream_for_action_run(
+            "namespace.job.1234.action",
+            component='stdout',
+            min_date=datetime.datetime.now(),
+            max_date=datetime.datetime.now(),
+            paasta_cluster='fake'
+        )
+    finally:
+        tron.utils.scribereader.scribereader = orig_scribereader
+        tron.utils.scribereader.S3LogsReader = orig_S3LogsReader
+    assert 'unable to display logs' in output[0]
+
+
+def test_read_log_stream_for_action_run_yelp_clog():
+    with mock.patch(
+        "staticconf.read", autospec=True, side_effect=static_conf_patch({
+            "logging.use_s3_reader": True,
+            "logging.max_lines_to_display": 1000
+        })
+    ), mock.patch(
+        "tron.config.static_config.build_configuration_watcher",
+        autospec=True,
+    ), mock.patch(
+        "tron.config.static_config.load_yaml_file",
+        autospec=True,
+    ), mock.patch(
+        "tron.utils.scribereader.S3LogsReader", autospec=True
+    ) as mock_s3_reader:
+        
+        mock_s3_reader.return_value.get_log_reader.return_value = iter(
+            [
+                """{
+                "tron_run_number": 1234,
+                "component": "stdout",
+                "message": "line 1",
+                "timestamp": "2021-01-02T18:10:09.169421619Z",
+                "cluster": "fake"
+            }""",
+                """{
+                "tron_run_number": 1234,
+                "component": "stdout",
+                "message": "line 2",
+                "timestamp": "2021-01-02T18:11:09.169421619Z",
+                "cluster": "fake"
+            }""",
+                """{
+                "tron_run_number": 1234,
+                "component": "stderr",
+                "message": "line 3",
+                "timestamp": "2021-01-02T18:12:09.169421619Z",
+                "cluster": "fake"
+            }""",
+            ]
+        )
+
+        output = read_log_stream_for_action_run(
+            "namespace.job.1234.action",
+            component='stdout',
+            min_date=datetime.datetime.now(),
+            max_date=datetime.datetime.now(),
+            paasta_cluster='fake'
+        )
+    assert output == ["line 1", "line 2"]
 
 def test_read_log_stream_for_action_run_min_date_and_max_date_today():
     # NOTE: these tests don't actually depend on the current time apart from
@@ -35,7 +111,7 @@ def test_read_log_stream_for_action_run_min_date_and_max_date_today():
         "tron.config.static_config.build_configuration_watcher",
         autospec=True,
     ), mock.patch(
-        "staticconf.read", autospec=True, return_value=1000
+        "staticconf.read", autospec=True, side_effect=static_conf_patch({"logging.max_lines_to_display": 1000})
     ), mock.patch(
         "tron.config.static_config.load_yaml_file",
         autospec=True,
@@ -111,7 +187,7 @@ def test_read_log_stream_for_action_run_min_date_and_max_date_different_days():
         "tron.config.static_config.build_configuration_watcher",
         autospec=True,
     ), mock.patch(
-        "staticconf.read", autospec=True, return_value=1000
+        "staticconf.read", autospec=True, side_effect=static_conf_patch({"logging.max_lines_to_display": 1000})
     ), mock.patch(
         "tron.config.static_config.load_yaml_file",
         autospec=True,
@@ -209,7 +285,7 @@ def test_read_log_stream_for_action_run_min_date_and_max_date_in_past():
         "tron.config.static_config.build_configuration_watcher",
         autospec=True,
     ), mock.patch(
-        "staticconf.read", autospec=True, return_value=1000
+        "staticconf.read", autospec=True, side_effect=static_conf_patch({"logging.max_lines_to_display": 1000})
     ), mock.patch(
         "tron.config.static_config.load_yaml_file",
         autospec=True,
@@ -275,7 +351,7 @@ def test_read_log_stream_for_action_run_min_date_and_max_date_for_long_output():
         "tron.config.static_config.build_configuration_watcher",
         autospec=True,
     ), mock.patch(
-        "staticconf.read", autospec=True, return_value=1000
+        "staticconf.read", autospec=True, side_effect=static_conf_patch({"logging.max_lines_to_display": 1000})
     ), mock.patch(
         "tron.config.static_config.load_yaml_file",
         autospec=True,

--- a/tests/utils/scribereader_test.py
+++ b/tests/utils/scribereader_test.py
@@ -18,10 +18,8 @@ def static_conf_patch(args={}):
 
 
 def test_read_log_stream_for_action_run_not_available():
-    orig_scribereader = tron.utils.scribereader.scribereader
-    orig_S3LogsReader = tron.utils.scribereader.S3LogsReader
-    tron.utils.scribereader.scribereader = None
-    tron.utils.scribereader.S3LogsReader = None
+    tron.utils.scribereader.scribereader_available = False
+    tron.utils.scribereader.s3reader_available = False
     try:
         output = tron.utils.scribereader.read_log_stream_for_action_run(
             "namespace.job.1234.action",
@@ -31,8 +29,8 @@ def test_read_log_stream_for_action_run_not_available():
             paasta_cluster="fake",
         )
     finally:
-        tron.utils.scribereader.scribereader = orig_scribereader
-        tron.utils.scribereader.S3LogsReader = orig_S3LogsReader
+        tron.utils.scribereader.scribereader_available = True
+        tron.utils.scribereader.s3reader_available = True
     assert "unable to display logs" in output[0]
 
 

--- a/tests/utils/scribereader_test.py
+++ b/tests/utils/scribereader_test.py
@@ -13,14 +13,15 @@ except ImportError:
     pytest.skip("yelp logs readers not available, skipping tests", allow_module_level=True)
 
 
-def static_conf_patch(args={}):
+# used for an explicit patch of staticconf.read return value for an arbitrary namespace
+def static_conf_patch(args):
     return lambda arg, namespace, default=None: args.get(arg)
 
 
 def test_read_log_stream_for_action_run_not_available():
-    tron.utils.scribereader.scribereader_available = False
-    tron.utils.scribereader.s3reader_available = False
-    try:
+    with mock.patch("tron.utils.scribereader.scribereader_available", False), mock.patch(
+        "tron.utils.scribereader.s3reader_available", False
+    ):
         output = tron.utils.scribereader.read_log_stream_for_action_run(
             "namespace.job.1234.action",
             component="stdout",
@@ -28,9 +29,6 @@ def test_read_log_stream_for_action_run_not_available():
             max_date=datetime.datetime.now(),
             paasta_cluster="fake",
         )
-    finally:
-        tron.utils.scribereader.scribereader_available = True
-        tron.utils.scribereader.s3reader_available = True
     assert "unable to display logs" in output[0]
 
 

--- a/tron/commands/backfill.py
+++ b/tron/commands/backfill.py
@@ -112,7 +112,7 @@ class BackfillRun:
             match = re.match(r"^Created JobRun:([-.\w]+)$", result)
 
             if match:
-                self.run_name = match.groups(0)[0]
+                self.run_name = match.groups(0)[0]  # type: ignore[assignment] # mypy wrongly identifies self.run_name type as "Union[str, int]"
                 self.run_state = ActionRun.STARTING
                 print(f"Job run '{self.run_name}' for {self.run_time_str} created")
             else:

--- a/tron/commands/display.py
+++ b/tron/commands/display.py
@@ -269,7 +269,7 @@ class DisplayJobRuns(TableDisplay):
     colors = {
         "id": partial(Color.set, "yellow"),
         "state": add_color_for_state,
-        "manual": lambda value: Color.set("cyan" if value else None, value),  # type: ignore  # can't type a lambda
+        "manual": lambda value: Color.set("cyan" if value else None, value),
     }
 
     def format_value(self, field_idx, value):

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -19,7 +19,7 @@ from tron import node
 from tron.actioncommand import ActionCommand
 from tron.actioncommand import NoActionRunnerFactory
 from tron.actioncommand import SubprocessActionRunnerFactory
-from tron.bin.action_runner import build_environment  # type: ignore # mypy can't find library stub
+from tron.bin.action_runner import build_environment
 from tron.bin.action_runner import build_labels
 from tron.config.config_utils import StringFormatter
 from tron.config.schema import ExecutorTypes

--- a/tron/utils/scribereader.py
+++ b/tron/utils/scribereader.py
@@ -16,15 +16,15 @@ from tron.config.static_config import NAMESPACE
 
 
 try:
-    from scribereader import scribereader  # type: ignore
-    from scribereader.clog.readers import StreamTailerSetupError  # type: ignore
+    from scribereader import scribereader
+    from scribereader.clog.readers import StreamTailerSetupError
 
     scribereader_available = True
 except ImportError:
     scribereader_available = False  # sorry folks, you'll need to add your own way to retrieve logs
 
 try:
-    from clog.readers import S3LogsReader  # type: ignore[unused-ignore]
+    from clog.readers import S3LogsReader
 
     s3reader_available = True
 except ImportError:

--- a/tron/utils/scribereader.py
+++ b/tron/utils/scribereader.py
@@ -4,6 +4,7 @@ import logging
 import operator
 import socket
 from functools import lru_cache
+from typing import Any
 from typing import Iterator
 from typing import List
 from typing import Optional
@@ -15,6 +16,8 @@ from tron.config.static_config import get_config_watcher
 from tron.config.static_config import NAMESPACE
 
 
+S3LogsReader: Optional[Any]
+
 try:
     from scribereader import scribereader  # type: ignore
     from scribereader.clog.readers import StreamTailerSetupError  # type: ignore
@@ -22,9 +25,9 @@ except ImportError:
     scribereader = None  # sorry folks, you'll need to add your own way to retrieve logs
 
 try:
-    from clog.readers import S3LogsReader
+    from clog.readers import S3LogsReader  # type: ignore
 except ImportError:
-    S3LogsReader = None  # type: ignore
+    S3LogsReader = None
 
 
 log = logging.getLogger(__name__)
@@ -144,7 +147,7 @@ def read_log_stream_for_action_run(
         config_watcher = get_config_watcher()
         config_watcher.reload_if_changed()
         use_s3_reader = staticconf.read("logging.use_s3_reader", namespace=NAMESPACE, default=False)
-    elif scribereader is None:  # type: ignore
+    elif scribereader is None:
         return ["Neither scribereader nor yelp_clog (internal Yelp packages) are available - unable to display logs."]
 
     if max_lines == USE_SRV_CONFIGS:

--- a/tron/utils/scribereader.py
+++ b/tron/utils/scribereader.py
@@ -4,7 +4,7 @@ import logging
 import operator
 import socket
 from functools import lru_cache
-from typing import List
+from typing import Iterator, List
 from typing import Optional
 from typing import Tuple
 
@@ -19,6 +19,11 @@ try:
     from scribereader.clog.readers import StreamTailerSetupError  # type: ignore
 except ImportError:
     scribereader = None  # sorry folks, you'll need to add your own way to retrieve logs
+    
+try:
+    from clog.readers import S3LogsReader  # type: ignore
+except ImportError:
+    S3LogsReader = None  # sorry folks, you'll need to add your own way to retrieve logs
 
 
 log = logging.getLogger(__name__)
@@ -59,15 +64,7 @@ def get_ecosystem() -> str:
 
 
 @lru_cache(maxsize=1)
-def get_scribereader_host_and_port() -> Optional[Tuple[str, int]]:
-    try:
-        ecosystem = get_ecosystem()
-        superregion = get_superregion()
-        region = get_region()
-    except OSError:
-        log.warning("Unable to read location mapping files from disk, not returning scribereader host/port")
-        return None
-
+def get_scribereader_host_and_port(ecosystem, superregion, region: str) -> Optional[Tuple[str, int]]:
     # NOTE: Passing in an ecosystem of prod is not supported by scribereader
     # as there's no mapping of ecosystem->scribe-kafka-services discovery hosts
     # for this ecosystem
@@ -77,6 +74,54 @@ def get_scribereader_host_and_port() -> Optional[Tuple[str, int]]:
         superregion=superregion,
     )
     return host, port
+
+
+class PaaSTALogsIterator():
+    def __init__(self, component, paasta_cluster, action_run_id: str) -> None:
+        self.component = component
+        self.paasta_cluster = paasta_cluster
+        self.action_run_id = action_run_id
+        namespace, job_name, run_num, action = action_run_id.split(".")
+        # in our logging infra, things are logged to per-instance streams - but
+        # since Tron PaaSTA instances are of the form `job_name.action`, we need
+        # to escape the period since some parts of our infra will reject streams
+        # containing them - thus, the "weird" __ separator
+        self.stream_name = f"stream_paasta_app_output_{namespace}_{job_name}__{action}"
+        self.run_num = int(run_num)
+        self.num_lines = 0
+        self.malformed_lines = 0
+        self.output: List[Tuple[str, str]] = []
+        self.truncated_output = False
+    
+    def iterate_logs(self, stream: Iterator[str], max_lines: int) -> None:
+        for line in stream:
+            if self.num_lines == max_lines:
+                self.truncated_output = True
+                break
+            # it's possible for jobs to run multiple times a day and have obscenely large amounts of output
+            # so we can't just truncate after seeing X number of lines for the run number in question - we
+            # need to count how many total lines we've seen and bail out early to preserve tron's uptime
+            self.num_lines += 1
+
+            try:
+                payload = json.loads(line)
+            except json.decoder.JSONDecodeError:
+                log.error(f"Unable to decode log line from stream ({self.stream_name}) for {self.action_run_id}: {line}")
+                self.malformed_lines += 1
+                continue
+
+            if (
+                int(payload.get("tron_run_number",-1)) == self.run_num
+                and payload.get("component") == self.component
+                and payload.get("message") is not None
+                and payload.get("timestamp") is not None
+                and payload.get("cluster") == self.paasta_cluster
+            ):
+                self.output.append((payload["timestamp"], payload["message"]))
+    
+    def sort_log_lines(self) -> List[str]:
+        self.output.sort(key=operator.itemgetter(0))
+        return [line for _, line in self.output]
 
 
 def read_log_stream_for_action_run(
@@ -89,147 +134,115 @@ def read_log_stream_for_action_run(
 ) -> List[str]:
     if min_date is None:
         return [f"{action_run_id} has not started yet."]
-
+    
+    use_s3_reader = False
+    
+    if S3LogsReader:
+        config_watcher = get_config_watcher()
+        config_watcher.reload_if_changed()
+        use_s3_reader = staticconf.read("logging.use_s3_reader", namespace=NAMESPACE, default=False)
+    elif scribereader is None:
+        return ["Neither scribereader nor yelp_clog (internal Yelp packages) are available - unable to display logs."]
+    
     if max_lines == USE_SRV_CONFIGS:
         config_watcher = get_config_watcher()
         config_watcher.reload_if_changed()
         max_lines = staticconf.read("logging.max_lines_to_display", namespace=NAMESPACE)
 
-    if scribereader is None:
-        return ["Scribereader (an internal Yelp package) is not available - unable to display logs."]
-    if get_scribereader_host_and_port() is None:
+    try:
+        ecosystem = get_ecosystem()
+        superregion = get_superregion()
+        region = get_region()
+    except OSError:
+        log.warning("Unable to read location mapping files from disk, not returning scribereader host/port")
         return [
             "Unable to determine where Tron is located. If you're seeing this inside Yelp, report this to #compute-infra"
         ]
-    host, port = get_scribereader_host_and_port()  # type: ignore  # the None case is covered by the check above
-
-    # this should never fail since get_scribereader_host_and_port() will have also called get_superregion() and we've ensured that
-    # that file exists by getting to this point
+    
     if paasta_cluster is None:
-        paasta_cluster = get_superregion()
+        paasta_cluster = superregion
 
+    paasta_logs = PaaSTALogsIterator(component, paasta_cluster, action_run_id)
+    stream_name = paasta_logs.stream_name
     today = datetime.date.today()
-    start_date = min_date.date()
-    end_date = max_date.date() if max_date else None
-
-    use_tailer = today in {start_date, end_date}
-    use_reader = start_date != today and end_date is not None
-
-    if end_date is not None and end_date == today:
-        end_date -= datetime.timedelta(days=1)
-
-    namespace, job_name, run_num, action = action_run_id.split(".")
-    # in our logging infra, things are logged to per-instance streams - but
-    # since Tron PaaSTA instances are of the form `job_name.action`, we need
-    # to escape the period since some parts of our infra will reject streams
-    # containing them - thus, the "weird" __ separator
-    stream_name = f"stream_paasta_app_output_{namespace}_{job_name}__{action}"
-    output: List[Tuple[str, str]] = []
-
-    malformed_lines = 0
-    num_lines = 0
-    truncated_output = False
-
-    # We'll only use a stream reader for logs from not-today.
-    # that said, it's possible that an action spans more than a single day - in this case, we'll first read "historical" data from
-    # the reader and then follow-up with today's logs from a stream tailer.
-    # NOTE: this is more-or-less what our internal `scribereader` binary does
-    if use_reader:
-        with scribereader.get_stream_reader(
-            stream_name=stream_name,
-            min_date=min_date,
-            max_date=max_date,
-            reader_host=host,
-            reader_port=port,
-        ) as stream:
-            for line in stream:
-                if max_lines is not None and num_lines == max_lines:
-                    truncated_output = True
-                    break
-                # it's possible for jobs to run multiple times a day and have obscenely large amounts of output
-                # so we can't just truncate after seeing X number of lines for the run number in question - we
-                # need to count how many total lines we've seen and bail out early to preserve tron's uptime
-                num_lines += 1
-
-                try:
-                    payload = json.loads(line)
-                except json.decoder.JSONDecodeError:
-                    log.error(f"Unable to decode log line from stream ({stream_name}) for {action_run_id}: {line}")
-                    malformed_lines += 1
-                    continue
-
-                if (
-                    payload.get("tron_run_number") == int(run_num)
-                    and payload.get("component") == component
-                    and payload.get("message") is not None
-                    and payload.get("timestamp") is not None
-                    and payload.get("cluster") == paasta_cluster
-                ):
-                    output.append((payload["timestamp"], payload["message"]))
-
-    if use_tailer:
-        stream = scribereader.get_stream_tailer(
-            stream_name=stream_name,
-            tailing_host=host,
-            tailing_port=port,
-            lines=-1,
+        
+    # yelp_clog S3LogsReader is a newer reader that is supposed to replace scribe readers eventually. 
+    if use_s3_reader:
+        start_date = min_date.date()
+        end_date = max_date.date() if max_date else today
+        
+        log.debug("Using S3LogsReader to retrieve logs")
+        s3_reader = S3LogsReader(get_ecosystem()).get_log_reader(
+            log_name=stream_name,
+            min_date=start_date,
+            max_date=end_date
         )
-        try:
-            for line in stream:
-                if num_lines == max_lines:
-                    truncated_output = True
-                    break
-                # it's possible for jobs to run multiple times a day and have obscenely large amounts of output
-                # so we can't just truncate after seeing X number of lines for the run number in question - we
-                # need to count how many total lines we've seen and bail out early to preserve tron's uptime
-                num_lines += 1
+        paasta_logs.iterate_logs(s3_reader, max_lines)          
+    else:
+        start_date = min_date.date()
+        end_date = max_date.date() if max_date else None    
+        use_tailer = today in {start_date, end_date}
+        use_reader = start_date != today and end_date is not None
 
-                try:
-                    payload = json.loads(line)
-                except json.decoder.JSONDecodeError:
-                    log.error(f"Unable to decode log line from stream ({stream_name}) for {action_run_id}: {line}")
-                    malformed_lines += 1
-                    continue
+        if end_date is not None and end_date == today:
+            end_date -= datetime.timedelta(days=1)
 
-                if (
-                    payload.get("tron_run_number") == int(run_num)
-                    and payload.get("component") == component
-                    and payload.get("message") is not None
-                    and payload.get("timestamp") is not None
-                    and payload.get("cluster") == paasta_cluster
-                ):
-                    output.append((payload["timestamp"], payload["message"]))
-        except StreamTailerSetupError:
-            return [
-                f"No data in stream {stream_name} - if this is the first time this action has run and you expected "
-                "output, please wait a couple minutes and refresh."
-            ]
-        except socket.timeout:
-            return [
-                f"Unable to connect to stream {stream_name} - if this is the first time this action has run and you "
-                "expected output, please wait a couple minutes and refresh."
-            ]
-        finally:
-            stream.close()
+        host, port = get_scribereader_host_and_port(ecosystem, superregion, region)  # type: ignore  # the None case is covered by the check above
+        
 
-    # XXX: for some reason, we're occasionally getting data out of order from scribereader - so we'll sort based on
-    # timestamp until we can figure out what's causing this.
-    output.sort(key=operator.itemgetter(0))
-    lines = [line for _, line in output]
-    malformed = [f"{malformed_lines} encountered while retrieving logs"] if malformed_lines else []
+        # We'll only use a stream reader for logs from not-today.
+        # that said, it's possible that an action spans more than a single day - in this case, we'll first read "historical" data from
+        # the reader and then follow-up with today's logs from a stream tailer.
+        # NOTE: this is more-or-less what our internal `scribereader` binary does
+        if use_reader:
+            with scribereader.get_stream_reader(
+                stream_name=stream_name,
+                min_date=min_date,
+                max_date=max_date,
+                reader_host=host,
+                reader_port=port,
+            ) as stream:
+                paasta_logs.iterate_logs(stream, max_lines)
+
+        if use_tailer:
+            stream = scribereader.get_stream_tailer(
+                stream_name=stream_name,
+                tailing_host=host,
+                tailing_port=port,
+                lines=-1,
+            )
+            try:
+                paasta_logs.iterate_logs(stream, max_lines)
+            except StreamTailerSetupError:
+                return [
+                    f"No data in stream {stream_name} - if this is the first time this action has run and you expected "
+                    "output, please wait a couple minutes and refresh."
+                ]
+            except socket.timeout:
+                return [
+                    f"Unable to connect to stream {stream_name} - if this is the first time this action has run and you "
+                    "expected output, please wait a couple minutes and refresh."
+                ]
+            finally:
+                stream.close()
+
+    # for logs that use Kafka topics with multiple partitions underneath or retrieved by S3LogsReader,
+    # data ordering is not guarantied - so we'll sort based on log timestamp set by producer.
+    lines = paasta_logs.sort_log_lines()
+    malformed = [f"{paasta_logs.malformed_lines} encountered while retrieving logs"] if paasta_logs.malformed_lines else []
     try:
         location_selector = f"-s {paasta_cluster}" if "prod" in paasta_cluster else f'-e {paasta_cluster.split("-")[1]}'
     except IndexError:
         location_selector = f"-s {paasta_cluster}"
     truncation_message = (
         [
-            f"This output is truncated. Use this command to view all lines: scribereader {location_selector} {stream_name} --min-date {min_date.date()} --max-date {max_date.date()} | jq --raw-output 'select(.tron_run_number=={int(run_num)} and .component == \"{component}\") | .message'"
+            f"This output is truncated. Use this command to view all lines: scribereader {location_selector} {stream_name} --min-date {min_date.date()} --max-date {max_date.date()} | jq --raw-output 'select(.tron_run_number=={int(paasta_logs.run_num)} and .component == \"{component}\") | .message'"
         ]
         if max_date
         else [
-            f"This output is truncated. Use this command to view all lines: scribereader {location_selector} {stream_name} --min-date {min_date.date()} | jq --raw-output 'select(.tron_run_number=={int(run_num)} and .component == \"{component}\") | .message'"
+            f"This output is truncated. Use this command to view all lines: scribereader {location_selector} {stream_name} --min-date {min_date.date()} | jq --raw-output 'select(.tron_run_number=={int(paasta_logs.run_num)} and .component == \"{component}\") | .message'"
         ]
     )
-    truncated = truncation_message if truncated_output else []
+    truncated = truncation_message if paasta_logs.truncated_output else []
 
     return lines + malformed + truncated

--- a/tron/utils/scribereader.py
+++ b/tron/utils/scribereader.py
@@ -16,7 +16,7 @@ from tron.config.static_config import NAMESPACE
 
 try:
     from scribereader import scribereader  # type: ignore
-    from clog.readers import StreamTailerSetupError  # type: ignore
+    from scribereader.clog.readers import StreamTailerSetupError  # type: ignore
 except ImportError:
     scribereader = None  # sorry folks, you'll need to add your own way to retrieve logs
 

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,5 +1,5 @@
 clusterman-metrics==2.2.1  # used by tron for pre-scaling for Spark runs
-scribereader==0.14.1  # used by tron to get tronjob logs
-yelp-clog==5.2.3  # scribereader dependency
+scribereader==1.1.1  # used by tron to get tronjob logs
+yelp-clog==7.1.0  # scribereader dependency
 yelp-logging==4.17.0  # scribereader dependency
 yelp-meteorite==2.1.1  # used by task-processing to emit metrics, clusterman-metrics dependency

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,5 +1,14 @@
 clusterman-metrics==2.2.1  # used by tron for pre-scaling for Spark runs
+dateglob==1.1.1 # required by yelp-logging
+geogrid==2.1.0  # required by yelp-logging
+monk==3.0.4     # required by yelp-clog
+ply==3.11   # required by thriftpy2
 scribereader==1.1.1  # used by tron to get tronjob logs
-yelp-clog==7.1.0  # scribereader dependency
+simplejson==3.19.2  # required by yelp-logging
+srv-configs==1.3.4  # required by monk
+tenacity==8.2.3 # required by yelp-logging
+thriftpy2==0.4.20   # required by monk
+yelp-cgeom==1.3.1   # required by geogrid
+yelp-clog==7.1.1  # scribereader dependency
 yelp-logging==4.17.0  # scribereader dependency
 yelp-meteorite==2.1.1  # used by task-processing to emit metrics, clusterman-metrics dependency


### PR DESCRIPTION
Enabling `S3LogsReader` from yelp_clog as an alternative method for reading tron Paasta logs.