### PR TITLE
Deleting Mesos code from the Master Control Program - TRON-2182

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -328,7 +328,6 @@ def make_tron_config(
     nodes=None,
     node_pools=None,
     jobs=None,
-    mesos_options=None,
     k8s_options=None,
 ):
     return schema.TronConfig(
@@ -341,7 +340,6 @@ def make_tron_config(
         nodes=nodes or make_nodes(),
         node_pools=node_pools or make_node_pools(),
         jobs=jobs or make_master_jobs(),
-        mesos_options=mesos_options or make_mesos_options(),
         k8s_options=k8s_options or make_k8s_options(),
     )
 
@@ -479,7 +477,6 @@ class ConfigTestCase(TestCase):
 
         assert test_config.command_context == expected.command_context
         assert test_config.ssh_options == expected.ssh_options
-        assert test_config.mesos_options == expected.mesos_options
         assert test_config.time_zone == expected.time_zone
         assert test_config.nodes == expected.nodes
         assert test_config.node_pools == expected.node_pools
@@ -1521,31 +1518,6 @@ class TestValidateVolume(TestCase):
         assert_equal(
             schema.ConfigVolume(**config),
             config_parse.valid_volume.validate(config, self.context),
-        )
-
-    def test_mesos_default_volumes(self):
-        mesos_options = {"master_address": "mesos_master"}
-        mesos_options["default_volumes"] = [
-            {
-                "container_path": "/nail/srv",
-                "host_path": "/tmp",
-                "mode": "RO",
-            },
-            {
-                "container_path": "/nail/srv",
-                "host_path": "/tmp",
-                "mode": "invalid",
-            },
-        ]
-
-        with pytest.raises(ConfigError):
-            config_parse.valid_mesos_options.validate(mesos_options, self.context)
-
-        # After we fix the error, expect error to go away.
-        mesos_options["default_volumes"][1]["mode"] = "RW"
-        assert config_parse.valid_mesos_options.validate(
-            mesos_options,
-            self.context,
         )
 
     def test_k8s_default_volumes(self):

--- a/tests/mcp_test.py
+++ b/tests/mcp_test.py
@@ -76,9 +76,8 @@ class TestMasterControlProgram:
         ],
     )
     @mock.patch("tron.mcp.KubernetesClusterRepository", autospec=True)
-    @mock.patch("tron.mcp.MesosClusterRepository", autospec=True)
     @mock.patch("tron.mcp.node.NodePoolRepository", autospec=True)
-    def test_apply_config(self, mock_repo, mock_cluster_repo, mock_k8s_cluster_repo, reconfigure, namespace):
+    def test_apply_config(self, mock_repo, mock_k8s_cluster_repo, reconfigure, namespace):
         config_container = mock.create_autospec(config_parse.ConfigContainer)
         master_config = config_container.get_master.return_value
         autospec_method(self.mcp.jobs.update_from_config)
@@ -93,9 +92,6 @@ class TestMasterControlProgram:
             master_config.nodes,
             master_config.node_pools,
             master_config.ssh_options,
-        )
-        mock_cluster_repo.configure.assert_called_with(
-            master_config.mesos_options,
         )
         mock_k8s_cluster_repo.configure.assert_called_with(
             master_config.k8s_options,

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -896,7 +896,6 @@ class ValidateConfig(Validator):
         },
         "node_pools": {},
         "jobs": (),
-        "mesos_options": ConfigMesos(**ValidateMesos.defaults),
         "k8s_options": ConfigKubernetes(**ValidateKubernetes.defaults),
         "eventbus_enabled": None,
     }
@@ -911,7 +910,6 @@ class ValidateConfig(Validator):
         "state_persistence": valid_state_persistence,
         "nodes": nodes,
         "node_pools": node_pools,
-        "mesos_options": valid_mesos_options,
         "k8s_options": valid_kubernetes_options,
         "eventbus_enabled": valid_bool,
     }

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -44,7 +44,6 @@ TronConfig = config_object_factory(
         "nodes",  # dict of ConfigNode
         "node_pools",  # dict of ConfigNodePool
         "jobs",  # dict of ConfigJob
-        "mesos_options",  # ConfigMesos
         "k8s_options",  # ConfigKubernetes
         "eventbus_enabled",  # bool or None
     ],

--- a/tron/mcp.py
+++ b/tron/mcp.py
@@ -13,7 +13,6 @@ from tron.core.job_scheduler import JobSchedulerFactory
 from tron.core.jobgraph import JobGraph
 from tron.eventbus import EventBus
 from tron.kubernetes import KubernetesClusterRepository
-from tron.mesos import MesosClusterRepository
 from tron.serialize.runstate import statemanager
 
 log = logging.getLogger(__name__)
@@ -106,14 +105,12 @@ class MasterControlProgram:
                 "node_pools",
                 "ssh_options",
             ),
-            (MesosClusterRepository.configure, "mesos_options"),
             (KubernetesClusterRepository.configure, "k8s_options"),
             (self.configure_eventbus, "eventbus_enabled"),
         ]
         master_config = config_container.get_master()
         apply_master_configuration(master_config_directives, master_config)
 
-        self.state_watcher.watch(MesosClusterRepository)
         self.state_watcher.watch(KubernetesClusterRepository)
 
         # If the master namespace was updated, we should update jobs in all namespaces


### PR DESCRIPTION
This PR deletes the "mesos_options" flag from the MCP, next will delete the Mesos code from files that restore Tron's state