### PR TITLE
update to jammy and fix docs build on 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: tron-ci
 on: [push, release]
 jobs:
   tox:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -27,7 +27,7 @@ jobs:
       - run: sudo apt-get install --quiet --assume-yes libyaml-dev
       - run: tox -e ${{ matrix.toxenv }}
   build_debs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,10 +6,9 @@ version: 2
 
 # RTD defaults as of 2023-11-08
 build:
-  # TODO: Bump to jammy+3.8 once master branch updated
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.6"
+    python: "3.8"
     # You can also specify other tool versions:
     # nodejs: "20"
     # rust: "1.70"


### PR DESCRIPTION
Ever since we upgraded Tron to python 3.8 on Tron version 1.28.0 the doc builds have been failing. This should fix the docs