### PR TITLE
Handling exceptions thrown from threads span by ThreadPoolExecutor - TRON-2202

### DIFF
--- a/tests/serialize/runstate/dynamodb_state_store_test.py
+++ b/tests/serialize/runstate/dynamodb_state_store_test.py
@@ -266,3 +266,19 @@ class TestDynamoDBStateStore:
                 store.restore(keys)
             except Exception:
                 assert_equal(mock_failed_read.call_count, 11)
+
+    def test_result_exception(self, store, small_object):
+        # This test is to check if the result() function raises an exception
+        keys = [store.build_key("thing", i) for i in range(3)]
+        value = pickle.loads(small_object)
+        pairs = zip(keys, (value for i in range(len(keys))))
+        store.save(pairs)
+        store._consume_save_queue()
+
+        mock_future = mock.MagicMock()
+        mock_future.result.side_effect = Exception("mocked exception")
+        with mock.patch("concurrent.futures.Future", return_value=mock_future):
+            with mock.patch("concurrent.futures.as_completed", return_value=[mock_future]):
+                with pytest.raises(Exception) as exec_info:
+                    store.restore(keys)
+                assert str(exec_info.value) == "mocked exception"

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -85,9 +85,9 @@ class DynamoDBStateStore:
                 # request otherwise
                 cand_keys_list = []
             for resp in concurrent.futures.as_completed(responses):
-                items.extend(resp.result()["Responses"][self.name])
-                # add any potential unprocessed keys to the thread pool
                 try:
+                    items.extend(resp.result()["Responses"][self.name])
+                    # add any potential unprocessed keys to the thread pool
                     if resp.result()["UnprocessedKeys"].get(self.name) and attempts_to_retrieve_keys < MAX_ATTEMPTS:
                         cand_keys_list.append(resp.result()["UnprocessedKeys"][self.name]["Keys"])
                     elif attempts_to_retrieve_keys >= MAX_ATTEMPTS:
@@ -97,7 +97,7 @@ class DynamoDBStateStore:
                         )
                         raise error
                 except Exception as e:
-                    log.error(repr(e))
+                    log.exception(f"Error: {e}")
                     raise e
             attempts_to_retrieve_keys += 1
         return items

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -87,14 +87,18 @@ class DynamoDBStateStore:
             for resp in concurrent.futures.as_completed(responses):
                 items.extend(resp.result()["Responses"][self.name])
                 # add any potential unprocessed keys to the thread pool
-                if resp.result()["UnprocessedKeys"].get(self.name) and attempts_to_retrieve_keys < MAX_ATTEMPTS:
-                    cand_keys_list.append(resp.result()["UnprocessedKeys"][self.name]["Keys"])
-                elif attempts_to_retrieve_keys >= MAX_ATTEMPTS:
-                    failed_keys = resp.result()["UnprocessedKeys"][self.name]["Keys"]
-                    error = Exception(
-                        f"tron_dynamodb_restore_failure: failed to retrieve items with keys \n{failed_keys}\n from dynamodb\n{resp.result()}"
-                    )
-                    raise error
+                try:
+                    if resp.result()["UnprocessedKeys"].get(self.name) and attempts_to_retrieve_keys < MAX_ATTEMPTS:
+                        cand_keys_list.append(resp.result()["UnprocessedKeys"][self.name]["Keys"])
+                    elif attempts_to_retrieve_keys >= MAX_ATTEMPTS:
+                        failed_keys = resp.result()["UnprocessedKeys"][self.name]["Keys"]
+                        error = Exception(
+                            f"tron_dynamodb_restore_failure: failed to retrieve items with keys \n{failed_keys}\n from dynamodb\n{resp.result()}"
+                        )
+                        raise error
+                except Exception as e:
+                    log.error(repr(e))
+                    raise e
             attempts_to_retrieve_keys += 1
         return items
 

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -97,7 +97,7 @@ class DynamoDBStateStore:
                         )
                         raise error
                 except Exception as e:
-                    log.exception(f"Error: {e}")
+                    log.exception("Encountered issues retrieving data from DynamoDB")
                     raise e
             attempts_to_retrieve_keys += 1
         return items

--- a/tron/serialize/runstate/statemanager.py
+++ b/tron/serialize/runstate/statemanager.py
@@ -7,7 +7,6 @@ import time
 from contextlib import contextmanager
 from typing import Dict
 
-from tron.commands.cmd_utils import ExitCode
 from tron.config import schema
 from tron.core import job
 from tron.core import jobrun
@@ -167,7 +166,7 @@ class PersistentStateManager:
                     jobs[results[result]]["runs"] = result.result()
                 except Exception:
                     log.exception(f"Unable to restore state for {results[result]} - exiting to avoid corrupting data.")
-                    sys.exit(ExitCode.fail)
+                    sys.exit(1)
 
         state = {
             runstate.JOB_STATE: jobs,

--- a/tron/serialize/runstate/statemanager.py
+++ b/tron/serialize/runstate/statemanager.py
@@ -165,10 +165,8 @@ class PersistentStateManager:
             for result in concurrent.futures.as_completed(results):
                 try:
                     jobs[results[result]]["runs"] = result.result()
-                except Exception as e:
-                    log.exception(
-                        f"Unable to restore state for {results[result]} - exiting to avoid corrupting data. Exception: {e}"
-                    )
+                except Exception:
+                    log.exception(f"Unable to restore state for {results[result]} - exiting to avoid corrupting data.")
                     sys.exit(ExitCode.fail)
 
         state = {

--- a/tron/serialize/runstate/statemanager.py
+++ b/tron/serialize/runstate/statemanager.py
@@ -2,10 +2,12 @@ import concurrent.futures
 import copy
 import itertools
 import logging
+import sys
 import time
 from contextlib import contextmanager
 from typing import Dict
 
+from tron.commands.cmd_utils import ExitCode
 from tron.config import schema
 from tron.core import job
 from tron.core import jobrun
@@ -164,8 +166,10 @@ class PersistentStateManager:
                 try:
                     jobs[results[result]]["runs"] = result.result()
                 except Exception as e:
-                    log.error(f"Failed to restore runs for {results[result]}: {e}")
-                    raise SystemExit(f"Error: {e}")
+                    log.exception(
+                        f"Unable to restore state for {results[result]} - exiting to avoid corrupting data. Exception: {e}"
+                    )
+                    sys.exit(ExitCode.fail)
 
         state = {
             runstate.JOB_STATE: jobs,

--- a/tron/serialize/runstate/statemanager.py
+++ b/tron/serialize/runstate/statemanager.py
@@ -161,7 +161,11 @@ class PersistentStateManager:
                 for job_name, job_state in jobs.items()
             }
             for result in concurrent.futures.as_completed(results):
-                jobs[results[result]]["runs"] = result.result()
+                try:
+                    jobs[results[result]]["runs"] = result.result()
+                except Exception as e:
+                    log.error(f"Failed to restore runs for {results[result]}: {e}")
+                    raise SystemExit(f"Error: {e}")
 
         state = {
             runstate.JOB_STATE: jobs,


### PR DESCRIPTION
This PR adds a try/except block to where we call result() to catch any exceptions that might happen in the threads span by ThreadPoolExecutor.

### Testing
I tested if with this change we now catch an exception thrown by "_restore_runs_for_job" and exit the trond process. This works so I added it to the BatchGetItem call as well where we call result()