### PR TITLE
Add warnings about tronctl disable not being permanent

### DIFF
--- a/bin/tronctl
+++ b/bin/tronctl
@@ -36,6 +36,7 @@ from tron.commands.client import RequestError
 from tron.commands.cmd_utils import ExitCode
 from tron.commands.cmd_utils import suggest_possibilities
 from tron.commands.cmd_utils import tron_jobs_completer
+from tron.commands.cmd_utils import warning_output
 from tron.commands.retry import parse_deps_timeout
 from tron.commands.retry import print_retries_table
 from tron.commands.retry import retry_actions
@@ -64,7 +65,11 @@ COMMAND_HELP = (
         "job name",
         "Start job runs for a particular date range",
     ),
-    ("disable", "job name", "Disable selected job and cancel any outstanding runs"),
+    (
+        "disable",
+        "job name",
+        "Disable selected job and cancel any outstanding runs. WARNING: you *must* disable the job in yelpsoa-configs to guarantee it will not be re-enabled.",
+    ),
     ("enable", "job name", "Enable the selected job and schedule the next run"),
     (
         "fail",
@@ -332,6 +337,13 @@ def control_objects(args: argparse.Namespace):
             if args.command == "start" and args.run_date:
                 data["run_time"] = str(args.run_date)
             yield request(urljoin(args.server, tron_id.url), data)
+            # NOTE: ideally we'd add this message in the JobController handle_command() function, but having the API return terminal escape codes
+            # sounds like a bad idea, so we're doing it here instead
+            print(
+                warning_output(
+                    "WARNING: jobs disabled with tronctl disable are *NOT* guaranteed to stay disabled. You must disable the job in yelpsoa-configs to guarantee it will not be re-enabled."
+                )
+            )
 
 
 def retry(args):

--- a/tron/commands/cmd_utils.py
+++ b/tron/commands/cmd_utils.py
@@ -40,6 +40,9 @@ DEFAULT_CONFIG = {
 
 TAB_COMPLETE_FILE = "/var/cache/tron_tab_completions"
 
+COLOR_RED = "\033[31m"
+COLOR_DEFAULT = "\033[0m"
+
 opener = open
 
 
@@ -213,3 +216,8 @@ def suggest_possibilities(word, possibilities, max_suggestions=6):
         return f"\nDid you mean one of: {', '.join(suggestions)}?"
     else:
         return ""
+
+
+def warning_output(text: str) -> str:
+    """Return the passed-in string colored in red. Suitable for warning messages."""
+    return f"{COLOR_RED}{text}{COLOR_DEFAULT}"


### PR DESCRIPTION
As we learned in a recent incident, if there are any issues with the DynamoDB data, it's possible for us to end up re-enabling jobs. We've previously warned folks in the past (in Slack/IRC/etc) that to permanently disable jobs it's recommended that they do so in soaconfigs, but this is easy to forget and not everyone will reach out before disabling a job that they don't expect to re-enable any time soon.