### PR TITLE
Add warnings to files that deal with serialized models

### DIFF
--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -1,6 +1,9 @@
 """
 Parse a dictionary structure and return an immutable structure that
 contain a validated configuration.
+
+
+WARNING: it is *NOT* safe to delete classes that are being validated (or their attributes) if there are any references to them in DynamoDB! (See DAR-2328)
 """
 import datetime
 import getpass

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -1,5 +1,6 @@
 """
  Immutable config schema objects.
+ WARNING: it is *NOT* safe to delete these classes (or their attributes) if there are any references to them in DynamoDB! (See DAR-2328)
 """
 from collections import namedtuple
 from enum import Enum
@@ -316,3 +317,5 @@ ActionRunnerTypes = Enum("ActionRunnerTypes", dict(none="none", subprocess="subp
 VolumeModes = Enum("VolumeModes", dict(RO="RO", RW="RW"))  # type: ignore
 
 ActionOnRerun = Enum("ActionOnRerun", dict(rerun="rerun"))  # type: ignore
+
+# WARNING: it is *NOT* safe to delete these classes (or their attributes) if there are any references to them in DynamoDB! (See DAR-2328)


### PR DESCRIPTION
In DAR-2328, we learned that if Tron reads from a DynamoDB that has data that references deleted classes (or attributes), we'll run into deserialization issues (i.e., pickle will fail to resolve the serialized class in the first place or fail to reconstruct the serialized class)