### PR TITLE
pass around projected SA configs properly

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -302,6 +302,13 @@ def make_master_jobs():
                             items=(schema.ConfigSecretVolumeItem(key="secret1", path="abcd", mode="777"),),
                         ),
                     ),
+                    projected_sa_volumes=(
+                        schema.ConfigProjectedSAVolume(
+                            container_path="/var/secrets/whatever",
+                            audience="foo.bar",
+                            expiration_seconds=1800,
+                        ),
+                    ),
                     node_selectors={"yelp.com/pool": "default"},
                     node_affinities=(
                         ConfigNodeAffinity(
@@ -449,6 +456,13 @@ class ConfigTestCase(TestCase):
                                 items=[
                                     dict(key="secret1", path="abcd", mode="777"),
                                 ],
+                            ),
+                        ],
+                        projected_sa_volumes=[
+                            dict(
+                                container_path="/var/secrets/whatever",
+                                audience="foo.bar",
+                                expiration_seconds=1800,
                             ),
                         ],
                         cap_add=["KILL"],

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -51,6 +51,7 @@ from tron.config.schema import ConfigKubernetes
 from tron.config.schema import ConfigMesos
 from tron.config.schema import ConfigNodeAffinity
 from tron.config.schema import ConfigParameter
+from tron.config.schema import ConfigProjectedSAVolume
 from tron.config.schema import ConfigSecretSource
 from tron.config.schema import ConfigSecretVolume
 from tron.config.schema import ConfigSecretVolumeItem
@@ -345,6 +346,22 @@ class ValidateSecretVolume(Validator):
 valid_secret_volume = ValidateSecretVolume()
 
 
+class ValidateProjectedSAVolume(Validator):
+    config_class = ConfigProjectedSAVolume
+    optional = True
+    defaults = {
+        "expiration_seconds": 1800,
+    }
+    validators = {
+        "container_path": valid_string,
+        "audience": valid_string,
+        "expiration_seconds": valid_int,
+    }
+
+
+valid_projected_sa_volume = ValidateProjectedSAVolume()
+
+
 class ValidateFieldSelectorSource(Validator):
     config_class = ConfigFieldSelectorSource
     validators = {
@@ -536,6 +553,7 @@ class ValidateAction(Validator):
         "env": None,
         "secret_env": None,
         "secret_volumes": None,
+        "projected_sa_volumes": None,
         "field_selector_env": None,
         "extra_volumes": None,
         "trigger_downstreams": None,
@@ -576,6 +594,7 @@ class ValidateAction(Validator):
         "env": valid_dict,
         "secret_env": build_dict_value_validator(valid_secret_source),
         "secret_volumes": build_list_of_type_validator(valid_secret_volume, allow_empty=True),
+        "projected_sa_volumes": build_list_of_type_validator(valid_projected_sa_volume, allow_empty=True),
         "field_selector_env": build_dict_value_validator(valid_field_selector_source),
         "extra_volumes": build_list_of_type_validator(valid_volume, allow_empty=True),
         "trigger_downstreams": valid_trigger_downstreams,
@@ -625,6 +644,7 @@ class ValidateCleanupAction(Validator):
         "env": None,
         "secret_env": None,
         "secret_volumes": None,
+        "projected_sa_volumes": None,
         "field_selector_env": None,
         "extra_volumes": None,
         "trigger_downstreams": None,
@@ -660,6 +680,7 @@ class ValidateCleanupAction(Validator):
         "env": valid_dict,
         "secret_env": build_dict_value_validator(valid_secret_source),
         "secret_volumes": build_list_of_type_validator(valid_secret_volume, allow_empty=True),
+        "projected_sa_volumes": build_list_of_type_validator(valid_projected_sa_volume, allow_empty=True),
         "field_selector_env": build_dict_value_validator(valid_field_selector_source),
         "extra_volumes": build_list_of_type_validator(valid_volume, allow_empty=True),
         "trigger_downstreams": valid_trigger_downstreams,

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -92,6 +92,7 @@ class Action:
             env=config.env or {},
             secret_env=config.secret_env or {},
             secret_volumes=config.secret_volumes or [],
+            projected_sa_volumes=config.projected_sa_volumes or [],
             field_selector_env=config.field_selector_env or {},
             cap_add=config.cap_add or [],
             cap_drop=config.cap_drop or [],


### PR DESCRIPTION
Follow up to https://github.com/Yelp/Tron/pull/975, where it looks like I missed a couple of places in the call stack to get the action configuration passed downstream.

Honestly, the amount of yak-shaving required to get a new setting going is concerning.