### PR TITLE
Update yelp_clog and use datetime range for S3 logs

### DIFF
--- a/tron/utils/scribereader.py
+++ b/tron/utils/scribereader.py
@@ -175,18 +175,18 @@ def read_log_stream_for_action_run(
 
     # yelp_clog S3LogsReader is a newer reader that is supposed to replace scribe readers eventually.
     if use_s3_reader:
-        # S3 reader uses UTC as a standard timezone
+        # S3 reader accepts datetime objects and respects timezone information
         # if min_date and max_date timezone is missing, astimezone() will assume local timezone and convert it to UTC
-        start_date = min_date.astimezone(datetime.timezone.utc).date()
-        end_date = (
-            max_date.astimezone(datetime.timezone.utc).date()
+        start_datetime = min_date.astimezone(datetime.timezone.utc)
+        end_datetime = (
+            max_date.astimezone(datetime.timezone.utc)
             if max_date
-            else datetime.datetime.now().astimezone(datetime.timezone.utc).date()
+            else datetime.datetime.now().astimezone(datetime.timezone.utc)
         )
 
         log.debug("Using S3LogsReader to retrieve logs")
-        s3_reader = S3LogsReader(ecosystem, superregion).get_log_reader(
-            log_name=stream_name, min_date=start_date, max_date=end_date
+        s3_reader = S3LogsReader(superregion).get_log_reader(
+            log_name=stream_name, start_datetime=start_datetime, end_datetime=end_datetime
         )
         paasta_logs.fetch(s3_reader, max_lines)
     else:

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -9,6 +9,6 @@ srv-configs==1.3.4  # required by monk
 tenacity==8.2.3 # required by yelp-logging
 thriftpy2==0.4.20   # required by monk
 yelp-cgeom==1.3.1   # required by geogrid
-yelp-clog==7.1.2  # scribereader dependency
+yelp-clog==7.1.4  # scribereader dependency
 yelp-logging==4.17.0  # scribereader dependency
 yelp-meteorite==2.1.1  # used by task-processing to emit metrics, clusterman-metrics dependency


### PR DESCRIPTION
yelp_clog 7.1.3 also drops `ecosystem` parameter from `S3LogsReader` interface 