### PR TITLE
Add clarification around reverting changes that touch DynamoDB data

### DIFF
--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -4,6 +4,7 @@ contain a validated configuration.
 
 
 WARNING: it is *NOT* safe to delete classes that are being validated (or their attributes) if there are any references to them in DynamoDB! (See DAR-2328)
+NOTE: this means that reverting a change that adds a new attribute is not safe :)
 """
 import datetime
 import getpass

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -3,7 +3,7 @@ Parse a dictionary structure and return an immutable structure that
 contain a validated configuration.
 
 
-WARNING: it is *NOT* safe to delete classes that are being validated (or their attributes) if there are any references to them in DynamoDB! (See DAR-2328)
+WARNING: it is *NOT* safe to delete classes that are being validated (or their attributes) if there are any references to them in DynamoDB until TRON-2200 is complete! (See DAR-2328)
 NOTE: this means that reverting a change that adds a new attribute is not safe :)
 """
 import datetime

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -1,6 +1,7 @@
 """
  Immutable config schema objects.
  WARNING: it is *NOT* safe to delete these classes (or their attributes) if there are any references to them in DynamoDB! (See DAR-2328)
+ NOTE: this means that reverting a change that adds a new attribute is not safe :)
 """
 from collections import namedtuple
 from enum import Enum
@@ -326,3 +327,4 @@ VolumeModes = Enum("VolumeModes", dict(RO="RO", RW="RW"))  # type: ignore
 ActionOnRerun = Enum("ActionOnRerun", dict(rerun="rerun"))  # type: ignore
 
 # WARNING: it is *NOT* safe to delete these classes (or their attributes) if there are any references to them in DynamoDB! (See DAR-2328)
+# NOTE: this means that reverting a change that adds a new attribute is not safe :)

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -1,6 +1,6 @@
 """
  Immutable config schema objects.
- WARNING: it is *NOT* safe to delete these classes (or their attributes) if there are any references to them in DynamoDB! (See DAR-2328)
+ WARNING: it is *NOT* safe to delete these classes (or their attributes) if there are any references to them in DynamoDB until TRON-2200 is complete! (See DAR-2328)
  NOTE: this means that reverting a change that adds a new attribute is not safe :)
 """
 from collections import namedtuple
@@ -326,5 +326,5 @@ VolumeModes = Enum("VolumeModes", dict(RO="RO", RW="RW"))  # type: ignore
 
 ActionOnRerun = Enum("ActionOnRerun", dict(rerun="rerun"))  # type: ignore
 
-# WARNING: it is *NOT* safe to delete these classes (or their attributes) if there are any references to them in DynamoDB! (See DAR-2328)
+# WARNING: it is *NOT* safe to delete these classes (or their attributes) if there are any references to them in DynamoDB until TRON-2200 is complete! (See DAR-2328)
 # NOTE: this means that reverting a change that adds a new attribute is not safe :)


### PR DESCRIPTION
A revert is essentially a delete, but I don't think many of us would treat one the same as an explicit delete given that generally reverting code is a safe operation :)