### PR TITLE
TRON-2210: Add a tool that can sync from pod state to tron w/ tronctl

### DIFF
--- a/tests/tools/sync_tron_state_from_k8s_test.py
+++ b/tests/tools/sync_tron_state_from_k8s_test.py
@@ -1,0 +1,221 @@
+from typing import Dict
+from unittest import mock
+
+import pytest
+from kubernetes.client import V1ObjectMeta
+from kubernetes.client import V1Pod
+from kubernetes.client import V1PodStatus
+
+from tools.sync_tron_state_from_k8s import get_matching_pod
+from tools.sync_tron_state_from_k8s import get_tron_state_from_api
+from tools.sync_tron_state_from_k8s import update_tron_from_pods
+
+
+def create_mock_pod(name: str, phase: str, labels: Dict[str, str], creation_timestamp: str):
+    metadata = V1ObjectMeta(name=name, creation_timestamp=creation_timestamp, labels=labels)
+    status = V1PodStatus(phase=phase)
+    return V1Pod(metadata=metadata, status=status)
+
+
+class TestSyncTronStateFromK8s:
+    @pytest.fixture(autouse=True)
+    def setup_test_data(self):
+        # oops why did I make this a dict
+        self.pods = {
+            p.metadata.name: p
+            for p in [
+                create_mock_pod(
+                    "service.job.2.action",
+                    "Succeeded",
+                    {
+                        "paasta.yelp.com/service": "service",
+                        "paasta.yelp.com/instance": "job.action",
+                        "tron.yelp.com/run_num": "2",
+                    },
+                    "2024-01-01T00:00:00",
+                ),
+                create_mock_pod(
+                    "service.job.3.action-nomatch",
+                    "Failed",
+                    {
+                        "paasta.yelp.com/service": "service",
+                        "paasta.yelp.com/instance": "job.action",
+                        "tron.yelp.com/run_num": "3",
+                    },
+                    "2024-01-01T00:00:00",
+                ),
+                create_mock_pod(
+                    "service.job.4.action-nomatch",
+                    "Failed",
+                    {
+                        "paasta.yelp.com/service": "service",
+                        "paasta.yelp.com/instance": "job.action",
+                        "tron.yelp.com/run_num": "4",
+                    },
+                    "2024-01-01T00:00:00",
+                ),
+                create_mock_pod(
+                    "service.job.4.action-nomatch-retry2",
+                    "Succeeded",
+                    {
+                        "paasta.yelp.com/service": "service",
+                        "paasta.yelp.com/instance": "job.action",
+                        "tron.yelp.com/run_num": "4",
+                    },
+                    "2024-01-01T01:00:00",
+                ),
+                create_mock_pod(
+                    "service.job2.10.action",
+                    "Failed",
+                    {
+                        "paasta.yelp.com/service": "service",
+                        "paasta.yelp.com/instance": "job2.action",
+                        "tron.yelp.com/run_num": "10",
+                    },
+                    "2024-01-01T01:00:00",
+                ),
+                create_mock_pod(
+                    "service.job2.10.action",
+                    "Running",
+                    {
+                        "paasta.yelp.com/service": "service",
+                        "paasta.yelp.com/instance": "job2.action",
+                        "tron.yelp.com/run_num": "10",
+                    },
+                    "2024-01-01T01:05:00",
+                ),
+            ]
+        }
+
+    # 1 matching pod by labels
+    # 2 matching pod by labels
+    # no matching pod
+    @pytest.mark.parametrize(
+        "job_name,run_num,expected_pod_name",
+        [
+            ("service.job", "3", "service.job.3.action-nomatch"),
+            ("service.job", "4", "service.job.4.action-nomatch-retry2"),
+            ("service.job2", "10", None),
+            ("service2.job", "1", None),
+        ],
+    )
+    def test_get_matching_pod(self, job_name, run_num, expected_pod_name):
+        test_action_run = {"action_name": "action", "job_name": f"{job_name}", "run_num": run_num}
+        matching_pod = get_matching_pod(test_action_run, self.pods)
+        assert matching_pod == self.pods.get(expected_pod_name)
+
+    # verify we send correct num_runs
+    # verify we are sending request for jobs + one for each job
+    @mock.patch("tools.sync_tron_state_from_k8s.get_client_config", autospec=True)
+    @mock.patch("tools.sync_tron_state_from_k8s.Client", autospec=True)
+    def test_get_tron_state_from_api(self, mock_client, mock_get_client_config):
+        mock_client.return_value = mock.Mock()
+        mock_client.return_value.jobs.return_value = [{"url": "/uri", "name": "some job"}]
+        mock_client.return_value.job.return_value = {"runs": []}
+        mock_get_client_config.return_value = {"server": "https://localhost:8888"}
+        get_tron_state_from_api(None, num_runs=10)
+
+        mock_client.assert_called_with("https://localhost:8888")
+        mock_client.return_value.jobs.assert_called_with(
+            include_job_runs=False, include_action_runs=False, include_action_graph=False, include_node_pool=False
+        )
+
+        mock_client.return_value.job.assert_called_with("/api/uri", include_action_runs=True, count=10)
+
+    @mock.patch("tools.sync_tron_state_from_k8s.subprocess.run", autospec=True)
+    def test_update_tron(self, mock_subprocess_run):
+        # sorry for the blob of test data
+        tron_state = [
+            {
+                "name": "service.job",
+                "runs": [
+                    {
+                        "runs": [
+                            {
+                                "id": "service.job.2.action",
+                                "action_name": "action",
+                                "run_num": "2",
+                                "job_name": "service.job",
+                                "state": "unknown",
+                            }
+                        ]
+                    },
+                    {
+                        "runs": [
+                            {
+                                "id": "service.job.3.action",
+                                "action_name": "action",
+                                "run_num": "3",
+                                "job_name": "service.job",
+                                "state": "running",
+                            },
+                            {
+                                "id": "service.job.3.action2",
+                                "action_name": "action2",
+                                "run_num": "3",
+                                "job_name": "service.job",
+                                "state": "running",
+                            },
+                        ]
+                    },
+                    {
+                        "runs": [
+                            {
+                                "id": "service.job.4.action",
+                                "action_name": "action",
+                                "run_num": "4",
+                                "job_name": "service.job",
+                                "state": "starting",
+                            }
+                        ]
+                    },
+                    {
+                        "runs": [
+                            {
+                                "id": "service.job.5.action",
+                                "action_name": "action",
+                                "run_num": "5",
+                                "job_name": "service.job",
+                                "state": "starting",
+                            }
+                        ]
+                    },
+                ],
+            },
+            {
+                "name": "service.job2",
+                "runs": [
+                    {
+                        "runs": [
+                            {
+                                "id": "service.job2.10.action",
+                                "action_name": "action",
+                                "run_num": "10",
+                                "job_name": "service.job2",
+                                "state": "succeeded",
+                            },
+                        ]
+                    },
+                ],
+            },
+        ]
+
+        good_subprocess_run = mock.Mock(returncode=0)
+        bad_subprocess_run = mock.Mock(returncode=1)
+
+        expected_calls = [
+            mock.call(["tronctl", "success", "service.job.2.action"], capture_output=True, text=True),
+            mock.call(["tronctl", "fail", "service.job.3.action"], capture_output=True, text=True),
+            mock.call(["tronctl", "success", "service.job.4.action"], capture_output=True, text=True),
+        ]
+        mock_subprocess_run.return_value = good_subprocess_run
+
+        result = update_tron_from_pods(tron_state, self.pods, tronctl_wrapper="tronctl", do_work=True)
+
+        assert result["updated"] == ["service.job.2.action", "service.job.3.action", "service.job.4.action"]
+        assert result["error"] == []
+        mock_subprocess_run.assert_has_calls(expected_calls, any_order=True)
+
+        mock_subprocess_run.return_value = bad_subprocess_run
+        result = update_tron_from_pods(tron_state, self.pods, tronctl_wrapper="tronctl", do_work=True)
+        assert result["error"] == ["service.job.2.action", "service.job.3.action", "service.job.4.action"]

--- a/tools/sync_tron_state_from_k8s.py
+++ b/tools/sync_tron_state_from_k8s.py
@@ -7,7 +7,9 @@ Update tron state from k8s api if tron has not yet updated correctly
 This will search for completed pods in the cluster specified in the kubeconfig in the `tron` namespace and use tronctl to transition any whose states do not match.
 """
 import argparse
+import logging
 import subprocess
+import sys
 from typing import Any
 from typing import Dict
 from typing import List
@@ -32,6 +34,8 @@ TRON_MODIFIABLE_STATES = [
     "lost",
 ]
 
+log = logging.getLogger("sync_tron_from_k8s")
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -51,23 +55,41 @@ def parse_args():
         help="Tronctl wrapper to use (will not use wrapper by default)",
     )
     parser.add_argument("-n", "--num-runs", dest="num_runs", default=100, help="Maximum number of job runs to retrieve")
+    parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", default=False, help="Verbose logging")
     args = parser.parse_args()
+
+    # tron's base level is critical, not info, adjust accoringly
+    if args.verbose:
+        level = logging.DEBUG
+        tron_level = logging.WARN
+    else:
+        level = logging.INFO
+        tron_level = logging.CRITICAL
+
+    logging.basicConfig(level=level, stream=sys.stdout)
+
+    tron_client_logger = logging.getLogger("tron.commands.client")
+    tron_client_logger.setLevel(tron_level)
+
+    # We also don't want kube_client debug logs
+    kube_logger = logging.getLogger("kubernetes.client.rest")
+    kube_logger.setLevel(logging.INFO)
 
     return args
 
 
-def fetch_completed_pods(kubeconfig_path: str) -> Dict[str, V1Pod]:
+def fetch_pods(kubeconfig_path: str) -> Dict[str, V1Pod]:
     kube_client = KubeClient(kubeconfig_path=kubeconfig_path, user_agent="sync_tron_state_from_k8s")
 
     # Bit of a hack, no helper to fetch pods so reach into core api
     completed_pod_list = kube_client.core.list_namespaced_pod(
-        namespace="tron", field_selector="status.phase!=Running,status.phase!=Pending"
+        namespace="tron",
     )
 
     return {pod.metadata.name: pod for pod in completed_pod_list.items}
 
 
-def get_tron_state_from_api(tron_server: str, num_runs: int = 100) -> Dict[str, Dict[any, any]]:
+def get_tron_state_from_api(tron_server: str, num_runs: int = 100) -> List[Dict[str, Dict[Any, Any]]]:
     if not tron_server:
         client_config = get_client_config()
         tron_server = client_config.get("server", "http://localhost:8089")
@@ -83,20 +105,17 @@ def get_tron_state_from_api(tron_server: str, num_runs: int = 100) -> Dict[str, 
     for job in jobs:
         # What am I doing wrong here, why do I have to append /api
         url = f'/api{job["url"]}'
-        print(f'Fetching job {job["name"]} at {url}')
-        try:
-            job_runs = client.job(
-                url,
-                include_action_runs=True,  # action runs
-                count=num_runs,  # TODO: fetch job run_limit and use that for count ?
-            )
-            job["runs"] = job_runs["runs"]
-        except Exception as e:
-            print(f"Hit exception: {e}")
+        log.debug(f'Fetching job {job["name"]} at {url}')
+        job_runs = client.job(
+            url,
+            include_action_runs=True,
+            count=num_runs,  # TODO: fetch job run_limit and use that for count ?
+        )
+        job["runs"] = job_runs["runs"]
     return jobs
 
 
-def get_matching_pod(action_run: Dict[str, any], pods: Dict[str, V1Pod]) -> Optional[V1Pod]:
+def get_matching_pod(action_run: Dict[str, Any], pods: Dict[str, V1Pod]) -> Optional[V1Pod]:
     """Given a tron action_run, try to find the right pod that matches."""
     action_name = action_run["action_name"]
     job_name = action_run["job_name"]
@@ -105,7 +124,6 @@ def get_matching_pod(action_run: Dict[str, any], pods: Dict[str, V1Pod]) -> Opti
     service, job = job_name.split(".")
     # TODO:  how to fetch k8s shortened instance name to match labels?
     instance_name = f"{job}.{action_name}"
-    # If action has retries, there will be multiple pods w/ same job_run; we only want the latest
     matching_pods = sorted(
         [
             pod
@@ -114,10 +132,13 @@ def get_matching_pod(action_run: Dict[str, any], pods: Dict[str, V1Pod]) -> Opti
             and pod.metadata.labels["paasta.yelp.com/instance"] == instance_name
             and pod.metadata.labels["tron.yelp.com/run_num"] == run_num
         ],
+        # If action has retries, there will be multiple pods w/ same job_run; we only want the latest
         key=lambda pod: pod.metadata.creation_timestamp,
         reverse=True,
     )
-    return matching_pods[0] if matching_pods else None
+    return (
+        matching_pods[0] if matching_pods and matching_pods[0].status.phase in POD_STATUS_TO_TRON_STATE.keys() else None
+    )
 
 
 def get_desired_state_from_pod(pod: V1Pod) -> str:
@@ -130,11 +151,11 @@ def update_tron_from_pods(
 ):
     updated = []
     error = []
-    # todo: calculate whether there are more jobs in pnw-prod than completed pods
     for job in jobs:
         if job["runs"]:
             # job_runs
             for job_run in job["runs"]:
+                # actions for this job_run
                 for action in job_run.get("runs", []):
                     action_run_id = action["id"]
                     if action["state"] in TRON_MODIFIABLE_STATES:
@@ -142,30 +163,30 @@ def update_tron_from_pods(
                         if pod:
                             desired_state = get_desired_state_from_pod(pod)
                             if action["state"] != desired_state:
-                                print(f'{action_run_id} state {action["state"]} needs updating to {desired_state}')
+                                log.debug(f'{action_run_id} state {action["state"]} needs updating to {desired_state}')
                                 cmd = [tronctl_wrapper, desired_state, action_run_id]
                                 if do_work:
                                     # tronctl-$cluster success/fail svc.job.run.action
                                     try:
-                                        print(f"Running {cmd}")
+                                        log.info(f"Running {cmd}")
                                         proc = subprocess.run(cmd, capture_output=True, text=True)
                                         if proc.returncode != 0:
-                                            print(f"Got non-zero exit code: {proc.returncode}")
-                                            print(f"\t{proc.stderr}")
+                                            log.error(f"Got non-zero exit code: {proc.returncode}")
+                                            log.error(f"\t{proc.stderr}")
                                             error.append(action_run_id)
                                         updated.append(action_run_id)
-                                    except Exception as e:
-                                        print(f"ERROR: Hit exception: {repr(e)}")
+                                    except Exception:
+                                        log.exception("ERROR: Hit exception:")
                                         error.append(action_run_id)
                                 else:
-                                    print(f"Dry-Run: Would run {cmd}")
+                                    log.info(f"Dry-Run: Would run {cmd}")
                                     updated.append(action_run_id)
                         else:
-                            print(f"action run {action_run_id} not found in list of finished pods, no action taken")
+                            log.debug(f"action run {action_run_id} not found in list of finished pods, no action taken")
                     else:
-                        print(f'Action state {action["state"]} for {action_run_id} not modifiable, no action taken')
-    print(f"Updated {len(updated)} actions: {','.join(updated)}")
-    print(f"Hit {len(error)} errors on actions: {','.join(error)}")
+                        log.debug(f'Action state {action["state"]} for {action_run_id} not modifiable, no action taken')
+    log.info(f"Updated {len(updated)} actions: {','.join(updated)}")
+    log.info(f"Hit {len(error)} errors on actions: {','.join(error)}")
     return {"updated": updated, "error": error}
 
 
@@ -173,8 +194,9 @@ if __name__ == "__main__":
     args = parse_args()
 
     jobs = get_tron_state_from_api(args.tron_url, args.num_runs)
-    print(f"Found {len(jobs)} jobs.")
+    log.debug(f"Found {len(jobs)} jobs.")
 
-    pods = fetch_completed_pods(args.kubeconfig_path)
+    pods = fetch_pods(args.kubeconfig_path)
+    log.debug(f"Found {len(pods.keys())} pods.")
 
     update_tron_from_pods(jobs, pods, args.tronctl_wrapper, args.do_work)

--- a/tools/sync_tron_state_from_k8s.py
+++ b/tools/sync_tron_state_from_k8s.py
@@ -165,7 +165,7 @@ def get_desired_state_from_pod(pod: V1Pod) -> str:
 
 
 def update_tron_from_pods(
-    jobs: List[Dict[str, Any]], pods: Dict[str, V1Pod], tronctl_wrapper: str = "tronctl", do_work: bool = True
+    jobs: List[Dict[str, Any]], pods: Dict[str, V1Pod], tronctl_wrapper: str = "tronctl", do_work: bool = False
 ):
     updated = []
     error = []

--- a/tools/sync_tron_state_from_k8s.py
+++ b/tools/sync_tron_state_from_k8s.py
@@ -1,0 +1,180 @@
+"""
+Update tron state from k8s api if tron has not yet updated correctly
+
+ Usage:
+    python tools/sync_tron_state_from_k8s.py -c <kubeconfig_path> (--do-work|--num-runs N|--tronctl-wrapper tronctl-pnw-devc)
+
+This will search for completed pods in the cluster specified in the kubeconfig in the `tron` namespace and use tronctl to transition any whose states do not match.
+"""
+import argparse
+import subprocess
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from kubernetes.client import V1Pod
+from task_processing.plugins.kubernetes.kube_client import KubeClient
+
+from tron.commands.client import Client
+from tron.commands.cmd_utils import get_client_config
+
+POD_STATUS_TO_TRON_STATE = {
+    "Succeeded": "success",
+    "Failed": "fail",
+    "Unknown": "Unknown",  # This should never really happen
+}
+
+TRON_MODIFIABLE_STATES = [
+    "starting",  # stuck jobs
+    "running",  # stuck jobs
+    "unknown",
+    "lost",
+]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kubeconfig-path", dest="kubeconfig_path", help="KUBECONFIG path")
+    parser.add_argument(
+        "--do-work",
+        dest="do_work",
+        action="store_true",
+        default=False,
+        help="Actually modify tron actions that need updating; without this flag we will only print those that would be updated",
+    )
+    parser.add_argument("--tron-url", default=None, help="Tron url (default will read from paasta tron config)")
+    parser.add_argument(
+        "--tronctl-wrapper",
+        default="tronctl",
+        dest="tronctl_wrapper",
+        help="Tronctl wrapper to use (will not use wrapper by default)",
+    )
+    parser.add_argument("-n", "--num-runs", dest="num_runs", default=100, help="Maximum number of job runs to retrieve")
+    args = parser.parse_args()
+
+    return args
+
+
+def fetch_completed_pods(kubeconfig_path: str) -> Dict[str, V1Pod]:
+    kube_client = KubeClient(kubeconfig_path=kubeconfig_path, user_agent="sync_tron_state_from_k8s")
+
+    # Bit of a hack, no helper to fetch pods so reach into core api
+    completed_pod_list = kube_client.core.list_namespaced_pod(
+        namespace="tron", field_selector="status.phase!=Running,status.phase!=Pending"
+    )
+
+    return {pod.metadata.name: pod for pod in completed_pod_list.items}
+
+
+def get_tron_state_from_api(tron_server: str, num_runs: int = 100) -> Dict[str, Dict[any, any]]:
+    if not tron_server:
+        client_config = get_client_config()
+        tron_server = client_config.get("server", "http://localhost:8089")
+    client = Client(tron_server)
+    # /jobs returns only the latest 5 runs, we'll need to request all runs instead ourselves
+    jobs = client.jobs(
+        include_job_runs=False,
+        include_action_runs=False,
+        include_action_graph=False,
+        include_node_pool=False,
+    )
+
+    for job in jobs:
+        # What am I doing wrong here, why do I have to append /api
+        url = f'/api{job["url"]}'
+        print(f'Fetching job {job["name"]} at {url}')
+        try:
+            job_runs = client.job(
+                url,
+                include_action_runs=True,  # action runs
+                count=num_runs,  # TODO: fetch job run_limit and use that for count ?
+            )
+            job["runs"] = job_runs["runs"]
+        except Exception as e:
+            print(f"Hit exception: {e}")
+    return jobs
+
+
+def get_matching_pod(action_run: Dict[str, any], pods: Dict[str, V1Pod]) -> Optional[V1Pod]:
+    """Given a tron action_run, try to find the right pod that matches."""
+    action_name = action_run["action_name"]
+    job_name = action_run["job_name"]
+    run_num = action_run["run_num"]
+
+    service, job = job_name.split(".")
+    # TODO:  how to fetch k8s shortened instance name to match labels?
+    instance_name = f"{job}.{action_name}"
+    # If action has retries, there will be multiple pods w/ same job_run; we only want the latest
+    matching_pods = sorted(
+        [
+            pod
+            for pod in pods.values()
+            if pod.metadata.labels["paasta.yelp.com/service"] == service
+            and pod.metadata.labels["paasta.yelp.com/instance"] == instance_name
+            and pod.metadata.labels["tron.yelp.com/run_num"] == run_num
+        ],
+        key=lambda pod: pod.metadata.creation_timestamp,
+        reverse=True,
+    )
+    return matching_pods[0] if matching_pods else None
+
+
+def get_desired_state_from_pod(pod: V1Pod) -> str:
+    k8s_state = pod.status.phase
+    return POD_STATUS_TO_TRON_STATE.get(k8s_state, "NoMatch")
+
+
+def update_tron_from_pods(
+    jobs: List[Dict[str, Any]], pods: Dict[str, V1Pod], tronctl_wrapper: str = "tronctl", do_work: bool = True
+):
+    updated = []
+    error = []
+    # todo: calculate whether there are more jobs in pnw-prod than completed pods
+    for job in jobs:
+        if job["runs"]:
+            # job_runs
+            for job_run in job["runs"]:
+                for action in job_run.get("runs", []):
+                    action_run_id = action["id"]
+                    if action["state"] in TRON_MODIFIABLE_STATES:
+                        pod = get_matching_pod(action, pods)
+                        if pod:
+                            desired_state = get_desired_state_from_pod(pod)
+                            if action["state"] != desired_state:
+                                print(f'{action_run_id} state {action["state"]} needs updating to {desired_state}')
+                                cmd = [tronctl_wrapper, desired_state, action_run_id]
+                                if do_work:
+                                    # tronctl-$cluster success/fail svc.job.run.action
+                                    try:
+                                        print(f"Running {cmd}")
+                                        proc = subprocess.run(cmd, capture_output=True, text=True)
+                                        if proc.returncode != 0:
+                                            print(f"Got non-zero exit code: {proc.returncode}")
+                                            print(f"\t{proc.stderr}")
+                                            error.append(action_run_id)
+                                        updated.append(action_run_id)
+                                    except Exception as e:
+                                        print(f"ERROR: Hit exception: {repr(e)}")
+                                        error.append(action_run_id)
+                                else:
+                                    print(f"Dry-Run: Would run {cmd}")
+                                    updated.append(action_run_id)
+                        else:
+                            print(f"action run {action_run_id} not found in list of finished pods, no action taken")
+                    else:
+                        print(f'Action state {action["state"]} for {action_run_id} not modifiable, no action taken')
+    print(f"Updated {len(updated)} actions: {','.join(updated)}")
+    print(f"Hit {len(error)} errors on actions: {','.join(error)}")
+    return {"updated": updated, "error": error}
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    jobs = get_tron_state_from_api(args.tron_url, args.num_runs)
+    print(f"Found {len(jobs)} jobs.")
+
+    pods = fetch_completed_pods(args.kubeconfig_path)
+
+    update_tron_from_pods(jobs, pods, args.tronctl_wrapper, args.do_work)


### PR DESCRIPTION
This adds a pretty simple script that will:

1. search for any completed pods in the tron namespace given a KUBECONFIG
2. attempt to match those pods with any existing action runs that are in a state that can be updated
3. update the state w/ `tronctl` if the pod & tron's states do not match.

Tron will only allow us to transition from a few known states, so this script only allows using `tronctl fail` or `tronctl succeed`  if the tron action run was either lost/unknown or 'stuck' at `running` or `starting`. 

Right now, I allow passing both a tron-url + tronctl-wrapper so that this could be run from outside the tron server itself, but defaults assume we'll be running on a local tron server. 

Still adding some tests but thought I should get feedback now in case I need to shift gears. 

## Validation
Currently, one reliable way to get an actual tron action run into an `unknown` state is to restart tron w/in a short period of the pod having been started. 

Forcing a few of these cases in tron-spark-pnw-devc, the script correctly updates the 'unknown' action runs' states:
```
Action state scheduled for paasta-contract-monitor.k8s_bad.41.sleep_with_retries not modifiable, no action taken
Action state failed for paasta-contract-monitor.k8s_bad.40.sleep not modifiable, no action taken
paasta-contract-monitor.k8s_bad.40.sleep_with_retries state unknown needs updating to fail
Dry-Run: Would run ['tronctl', 'fail', 'paasta-contract-monitor.k8s_bad.40.sleep_with_retries']
Action state failed for paasta-contract-monitor.k8s_bad.39.sleep not modifiable, no action taken
paasta-contract-monitor.k8s_bad.39.sleep_with_retries state unknown needs updating to fail
Dry-Run: Would run ['tronctl', 'fail', 'paasta-contract-monitor.k8s_bad.39.sleep_with_retries']
Action state failed for paasta-contract-monitor.k8s_bad.38.sleep not modifiable, no action taken
paasta-contract-monitor.k8s_bad.38.sleep_with_retries state running needs updating to fail
Dry-Run: Would run ['tronctl', 'fail', 'paasta-contract-monitor.k8s_bad.38.sleep_with_retries']
Action state failed for paasta-contract-monitor.k8s_bad.37.sleep not modifiable, no action taken
paasta-contract-monitor.k8s_bad.37.sleep_with_retries state running needs updating to fail
Dry-Run: Would run ['tronctl', 'fail', 'paasta-contract-monitor.k8s_bad.37.sleep_with_retries']
Action state failed for paasta-contract-monitor.k8s_bad.36.sleep not modifiable, no action taken
paasta-contract-monitor.k8s_bad.36.sleep_with_retries state running needs updating to fail
Dry-Run: Would run ['tronctl', 'fail', 'paasta-contract-monitor.k8s_bad.36.sleep_with_retries']
Action state cancelled for paasta-contract-monitor.k8s_bad.35.sleep not modifiable, no action taken
```

