### PR TITLE
Fix docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ import os
 import sys
 from unittest.mock import MagicMock
 
-sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("../.."))
 
 import tron  # noqa
 


### PR DESCRIPTION
ReadTheDocs has been failing for ~6 weeks with the following [logs](https://readthedocs.org/api/v2/build/24821933.txt).

The error appears to indicate that the Sphinx build process cannot find the tron module. This change should adjust the Python path in conf.py to include the directory where tron is located. Since #960 moved `docs/conf.py` to `docs/source/conf.py` this is no longer located directly one level above.