### PR TITLE
TRON-2208: Add toggle in tron config to disable retries on LOST k8s jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tron.egg-info
 docs/_build/
 .idea
 .vscode
+.fleet
 tron.iml
 docs/images/
 *.dot

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -1,4 +1,5 @@
 asynctest
+debugpy
 flake8
 mock
 mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 astroid==2.13.3
 asynctest==0.12.0
 cfgv==2.0.1
+debugpy==1.8.1
 dill==0.3.6
 distlib==0.3.6
 filelock==3.4.1

--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -116,7 +116,7 @@ def make_mesos_options():
 
 
 def make_k8s_options():
-    return schema.ConfigKubernetes(enabled=False, default_volumes=())
+    return schema.ConfigKubernetes(enabled=False, non_retryable_exit_codes=(), default_volumes=())
 
 
 def make_action(**kwargs):

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -447,7 +447,6 @@ def test_handle_event_lost(mock_kubernetes_task):
         )
     )
 
-    assert mock_kubernetes_task.is_unknown
     assert mock_kubernetes_task.exit_status == exitcode.EXIT_KUBERNETES_TASK_LOST
 
 

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -447,7 +447,7 @@ def test_handle_event_lost(mock_kubernetes_task):
         )
     )
 
-    assert mock_kubernetes_task.is_unknown
+    assert mock_kubernetes_task.exit_status == exitcode.EXIT_KUBERNETES_TASK_LOST
 
 
 def test_create_task_disabled():

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -447,6 +447,7 @@ def test_handle_event_lost(mock_kubernetes_task):
         )
     )
 
+    assert mock_kubernetes_task.is_unknown
     assert mock_kubernetes_task.exit_status == exitcode.EXIT_KUBERNETES_TASK_LOST
 
 

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -866,12 +866,14 @@ class ValidateKubernetes(Validator):
     defaults = {
         "kubeconfig_path": None,
         "enabled": False,
+        "disable_retries_on_lost": False,
         "default_volumes": (),
     }
 
     validators = {
         "kubeconfig_path": valid_string,
         "enabled": valid_bool,
+        "disable_retries_on_lost": valid_bool,
         "default_volumes": build_list_of_type_validator(valid_volume, allow_empty=True),
     }
 

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -867,14 +867,14 @@ class ValidateKubernetes(Validator):
     defaults = {
         "kubeconfig_path": None,
         "enabled": False,
-        "disable_retries_on_lost": False,
+        "non_retryable_exit_codes": (),
         "default_volumes": (),
     }
 
     validators = {
         "kubeconfig_path": valid_string,
         "enabled": valid_bool,
-        "disable_retries_on_lost": valid_bool,
+        "non_retryable_exit_codes": build_list_of_type_validator(valid_int, allow_empty=True),
         "default_volumes": build_list_of_type_validator(valid_volume, allow_empty=True),
     }
 

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -118,6 +118,7 @@ ConfigKubernetes = config_object_factory(
     optional=[
         "kubeconfig_path",
         "enabled",
+        "disable_retries_on_lost",
         "default_volumes",
     ],
 )

--- a/tron/config/schema.py
+++ b/tron/config/schema.py
@@ -119,7 +119,7 @@ ConfigKubernetes = config_object_factory(
     optional=[
         "kubeconfig_path",
         "enabled",
-        "disable_retries_on_lost",
+        "non_retryable_exit_codes",
         "default_volumes",
     ],
 )

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -591,7 +591,7 @@ class ActionRun(Observable):
         return self._done("fail", exit_status)
 
     def _exit_unsuccessful(
-        self, exit_status=None, retry_original_command=True, non_retryable_exit_codes=()
+        self, exit_status=None, retry_original_command=True, non_retryable_exit_codes=[]
     ) -> Optional[Union[bool, ActionCommand]]:
         if self.is_done:
             log.info(
@@ -1320,11 +1320,11 @@ class KubernetesActionRun(ActionRun, Observer):
         return "\n".join(msgs)
 
     def _exit_unsuccessful(
-        self, exit_status=None, retry_original_command=True, non_retryable_exit_codes=()
+        self, exit_status=None, retry_original_command=True, non_retryable_exit_codes=[]
     ) -> Optional[Union[bool, ActionCommand]]:
 
         k8s_cluster = KubernetesClusterRepository.get_cluster()
-        non_retryable_exit_codes = () if not k8s_cluster else k8s_cluster.non_retryable_exit_codes
+        non_retryable_exit_codes = [] if not k8s_cluster else k8s_cluster.non_retryable_exit_codes
 
         return super()._exit_unsuccessful(
             exit_status=exit_status,

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -602,6 +602,7 @@ class ActionRun(Observable):
             self.last_attempt.exit(exit_status)
         if self.retries_remaining is not None:
             if exit_status in non_retryable_exit_codes:
+                self.retries_remaining = 0
                 log.info(f"{self} skipping auto-retries, received non-retryable exit code ({exit_status}).")
             else:
                 if self.retries_remaining > 0:

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -591,7 +591,7 @@ class ActionRun(Observable):
         return self._done("fail", exit_status)
 
     def _exit_unsuccessful(
-        self, exit_status=None, retry_original_command=True, non_retryable_exit_codes=[]
+        self, exit_status=None, retry_original_command=True, non_retryable_exit_codes=()
     ) -> Optional[Union[bool, ActionCommand]]:
         if self.is_done:
             log.info(
@@ -1320,14 +1320,16 @@ class KubernetesActionRun(ActionRun, Observer):
         return "\n".join(msgs)
 
     def _exit_unsuccessful(
-        self, exit_status=None, retry_original_command=True, non_retryable_exit_codes=[]
+        self, exit_status=None, retry_original_command=True, non_retryable_exit_codes=()
     ) -> Optional[Union[bool, ActionCommand]]:
 
         k8s_cluster = KubernetesClusterRepository.get_cluster()
         non_retryable_exit_codes = () if not k8s_cluster else k8s_cluster.non_retryable_exit_codes
 
         return super()._exit_unsuccessful(
-            exit_status=None, retry_original_command=True, non_retryable_exit_codes=non_retryable_exit_codes
+            exit_status=exit_status,
+            retry_original_command=retry_original_command,
+            non_retryable_exit_codes=non_retryable_exit_codes,
         )
 
     def handle_action_command_state_change(

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -602,7 +602,7 @@ class ActionRun(Observable):
             self.last_attempt.exit(exit_status)
         if self.retries_remaining is not None:
             if exit_status in non_retryable_exit_codes:
-                log.info(f"{self} skipping auto-retries due to non-retryable exit code was recieved.")
+                log.info(f"{self} skipping auto-retries, received non-retryable exit code ({exit_status}).")
             else:
                 if self.retries_remaining > 0:
                     self.retries_remaining -= 1

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -281,7 +281,7 @@ class KubernetesCluster:
         default_volumes: Optional[List[ConfigVolume]] = None,
         pod_launch_timeout: Optional[int] = None,
         watcher_kubeconfig_paths: Optional[List[str]] = None,
-        non_retryable_exit_codes: Optional[List[int, ...]] = [],
+        non_retryable_exit_codes: Optional[List[int]] = [],
     ):
         # general k8s config
         self.kubeconfig_path = kubeconfig_path
@@ -623,7 +623,7 @@ class KubernetesCluster:
 class KubernetesClusterRepository:
     # Kubernetes config
     kubernetes_enabled: bool = False
-    kubernetes_non_retryable_exit_codes: Optional[List[int, ...]] = []
+    kubernetes_non_retryable_exit_codes: Optional[List[int]] = []
     kubeconfig_path: Optional[str] = None
     pod_launch_timeout: Optional[int] = None
     default_volumes: Optional[List[ConfigVolume]] = None

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -5,6 +5,7 @@ from typing import Collection
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Set
 from typing import TYPE_CHECKING
 
 from task_processing.interfaces.event import Event
@@ -280,12 +281,12 @@ class KubernetesCluster:
         enabled: bool = True,
         default_volumes: Optional[List[ConfigVolume]] = None,
         pod_launch_timeout: Optional[int] = None,
-        disable_retries_on_lost: bool = False,
+        non_retryable_exit_codes: Optional[Set[int]] = (),
     ):
         # general k8s config
         self.kubeconfig_path = kubeconfig_path
         self.enabled = enabled
-        self.disable_retries_on_lost = disable_retries_on_lost
+        self.non_retryable_exit_codes = non_retryable_exit_codes
         self.default_volumes: Optional[List[ConfigVolume]] = default_volumes or []
         self.pod_launch_timeout = pod_launch_timeout or DEFAULT_POD_LAUNCH_TIMEOUT_S
         # creating a task_proc executor has a couple steps:
@@ -620,7 +621,7 @@ class KubernetesCluster:
 class KubernetesClusterRepository:
     # Kubernetes config
     kubernetes_enabled: bool = False
-    kubernetes_disable_retries_on_lost: bool = False
+    kubernetes_non_retryable_exit_codes: Set[int] = ()
     kubeconfig_path: Optional[str] = None
     pod_launch_timeout: Optional[int] = None
     default_volumes: Optional[List[ConfigVolume]] = None
@@ -661,7 +662,7 @@ class KubernetesClusterRepository:
     def configure(cls, kubernetes_options: ConfigKubernetes) -> None:
         cls.kubeconfig_path = kubernetes_options.kubeconfig_path
         cls.kubernetes_enabled = kubernetes_options.enabled
-        cls.kubernetes_disable_retries_on_lost = kubernetes_options.disable_retries_on_lost
+        cls.kubernetes_non_retryable_exit_codes = kubernetes_options.non_retryable_exit_codes
         cls.default_volumes = kubernetes_options.default_volumes
 
         for cluster in cls.clusters.values():

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -5,7 +5,7 @@ from typing import Collection
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Set
+from typing import Tuple
 from typing import TYPE_CHECKING
 
 from task_processing.interfaces.event import Event
@@ -281,7 +281,7 @@ class KubernetesCluster:
         enabled: bool = True,
         default_volumes: Optional[List[ConfigVolume]] = None,
         pod_launch_timeout: Optional[int] = None,
-        non_retryable_exit_codes: Optional[Set[int]] = (),
+        non_retryable_exit_codes: Optional[Tuple[int]] = (),
     ):
         # general k8s config
         self.kubeconfig_path = kubeconfig_path
@@ -621,7 +621,7 @@ class KubernetesCluster:
 class KubernetesClusterRepository:
     # Kubernetes config
     kubernetes_enabled: bool = False
-    kubernetes_non_retryable_exit_codes: Set[int] = ()
+    kubernetes_non_retryable_exit_codes: Tuple[int] = ()
     kubeconfig_path: Optional[str] = None
     pod_launch_timeout: Optional[int] = None
     default_volumes: Optional[List[ConfigVolume]] = None

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -5,7 +5,6 @@ from typing import Collection
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Tuple
 from typing import TYPE_CHECKING
 
 from task_processing.interfaces.event import Event
@@ -282,7 +281,7 @@ class KubernetesCluster:
         default_volumes: Optional[List[ConfigVolume]] = None,
         pod_launch_timeout: Optional[int] = None,
         watcher_kubeconfig_paths: Optional[List[str]] = None,
-        non_retryable_exit_codes: Optional[Tuple[int, ...]] = (),
+        non_retryable_exit_codes: Optional[List[int, ...]] = [],
     ):
         # general k8s config
         self.kubeconfig_path = kubeconfig_path
@@ -624,7 +623,7 @@ class KubernetesCluster:
 class KubernetesClusterRepository:
     # Kubernetes config
     kubernetes_enabled: bool = False
-    kubernetes_non_retryable_exit_codes: Tuple[int, ...] = ()
+    kubernetes_non_retryable_exit_codes: Optional[List[int, ...]] = []
     kubeconfig_path: Optional[str] = None
     pod_launch_timeout: Optional[int] = None
     default_volumes: Optional[List[ConfigVolume]] = None

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -68,8 +68,6 @@ class KubernetesTask(ActionCommand):
 
         self.log.info(f"Kubernetes task {self.get_kubernetes_id()} created with config {self.get_config()}")
 
-        self.is_lost_task = False
-
     def get_event_logger(self) -> Logger:
         """
         Get or create a logger for a the action run associated with this task.
@@ -254,8 +252,7 @@ class KubernetesTask(ActionCommand):
                 self.log.warning(f"    tronctl skip {self.id}")
                 self.log.warning("If you want Tron to NOT run it and consider it as a failure, fail it with:")
                 self.log.warning(f"    tronctl fail {self.id}")
-                self.is_lost_task = True
-                self.exited(None)
+                self.exited(exitcode.EXIT_KUBERNETES_TASK_LOST)
             else:
                 self.log.info(
                     f"Did not handle unknown kubernetes event type: {event}",

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -281,7 +281,7 @@ class KubernetesCluster:
         enabled: bool = True,
         default_volumes: Optional[List[ConfigVolume]] = None,
         pod_launch_timeout: Optional[int] = None,
-        non_retryable_exit_codes: Optional[Tuple[int]] = (),
+        non_retryable_exit_codes: Optional[Tuple[int, ...]] = (),
     ):
         # general k8s config
         self.kubeconfig_path = kubeconfig_path
@@ -621,7 +621,7 @@ class KubernetesCluster:
 class KubernetesClusterRepository:
     # Kubernetes config
     kubernetes_enabled: bool = False
-    kubernetes_non_retryable_exit_codes: Tuple[int] = ()
+    kubernetes_non_retryable_exit_codes: Tuple[int, ...] = ()
     kubeconfig_path: Optional[str] = None
     pod_launch_timeout: Optional[int] = None
     default_volumes: Optional[List[ConfigVolume]] = None

--- a/tron/utils/exitcode.py
+++ b/tron/utils/exitcode.py
@@ -10,6 +10,7 @@ EXIT_KUBERNETES_TASK_INVALID = -8
 EXIT_KUBERNETES_ABNORMAL = -9
 EXIT_KUBERNETES_SPOT_INTERRUPTION = -10
 EXIT_KUBERNETES_NODE_SCALEDOWN = -11
+EXIT_KUBERNETES_TASK_LOST = -12
 
 EXIT_REASONS = {
     EXIT_INVALID_COMMAND: "Invalid command",
@@ -23,4 +24,5 @@ EXIT_REASONS = {
     EXIT_KUBERNETES_ABNORMAL: "Kubernetes task failed in an unexpected manner",
     EXIT_KUBERNETES_SPOT_INTERRUPTION: "Kubernetes task failed due to spot interruption",
     EXIT_KUBERNETES_NODE_SCALEDOWN: "Kubernetes task failed due to the autoscaler scaling down a node",
+    EXIT_KUBERNETES_TASK_LOST: "Tron lost track of a pod it already thought it had started for a job.",
 }


### PR DESCRIPTION
## Summary

This PR addresses [TRON-2208](http://y/TRON-2208) by adding a toggle in the Tron configuration to disable automatic retries for Kubernetes jobs that are marked as "LOST". This is particularly useful for non-idempotent jobs where retries can be dangerous.

## Changes

### Configuration
- **`tron/config/config_parse.py`**: Added `non_retryable_exit_codes` to the Kubernetes configuration schema.
- **`tron/config/schema.py`**: Updated the schema to include `non_retryable_exit_codes`.

### Core Logic
- **`tron/core/actionrun.py`**: 
  - Modified the `_exit_unsuccessful` method to check for `non_retryable_exit_codes` and skip retries if the exit code is in this list.
  - Refactored `non_retryable_exit_codes` to use a list instead of a tuple.
- **`tron/kubernetes.py`**: 
  - Updated the `handle_event` method to set the exit code to `EXIT_KUBERNETES_TASK_LOST` for lost tasks.
  - Added `non_retryable_exit_codes` to the Kubernetes configuration.
- **`tron/utils/exitcode.py`**: Added a new exit code `EXIT_KUBERNETES_TASK_LOST` with a value of `-12`.

### Tests
- **`tests/config/config_parse_test.py`**: Updated tests to include `non_retryable_exit_codes`.
- **`tests/kubernetes_test.py`**: Updated tests to check for the new exit code and ensure the correct behavior when a task is marked as lost.

### Miscellaneous
- **`.gitignore`**: Added `.fleet` to the ignore list.
- **`requirements-dev-minimal.txt`**: Added `debugpy`.
- **`requirements-dev.txt`**: Added `debugpy`.

## Motivation

Given that "LOST" means Tron has lost track of a pod it already thought it had started for a job, attempting to retry/start a replacement can be dangerous for non-idempotent jobs. In the current state, these will consume retries, but with some of our EKS migration methods, LOST tasks are more likely. Therefore, we should have a way to temporarily pause retries on these.

## Testing

- Unit tests have been updated and added to cover the new configuration option and its effects on job retry behavior.

## Related Issues

- [TRON-2208](http://y/TRON-2208): Add toggle in Tron config to disable retries on LOST k8s jobs

## Notes

- Ensure to update your Tron configuration to include the new `non_retryable_exit_codes` option if you wish to use this feature.
- This change is backward compatible; if the new configuration option is not set, the default behavior remains unchanged.
