### PR TITLE
Support multiple clusters in sync_tron_from_k8s

### DIFF
--- a/tools/sync_tron_state_from_k8s.py
+++ b/tools/sync_tron_state_from_k8s.py
@@ -91,7 +91,7 @@ def parse_args():
 
     # We can only have multiple kubeconfigs, or multiple contexts with a single config
     if len(args.kubeconfig_path) > 1 and args.kubecontext:
-        parser.error("You can only specify a single --kubeconfig-path if specifying multiple --kubecontext arguments.")
+        parser.error("You can only specify a single --kubeconfig-path if specifying --kubecontext arguments.")
 
     # tron's base level is critical, not info, adjust accoringly
     if args.verbose:

--- a/tools/sync_tron_state_from_k8s.py
+++ b/tools/sync_tron_state_from_k8s.py
@@ -58,7 +58,12 @@ def limit_size_with_hash(name: str, limit: int = 63, suffix: int = 4) -> str:
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--kubeconfig-path", dest="kubeconfig_path", help="KUBECONFIG path")
+    parser.add_argument(
+        "--kubeconfig-path",
+        dest="kubeconfig_path",
+        help="KUBECONFIG path; multiple can be specified to find pods in multiple clusters",
+        nargs="+",
+    )
     parser.add_argument(
         "--do-work",
         dest="do_work",
@@ -214,7 +219,9 @@ if __name__ == "__main__":
     jobs = get_tron_state_from_api(args.tron_url, args.num_runs)
     log.debug(f"Found {len(jobs)} jobs.")
 
-    pods = fetch_pods(args.kubeconfig_path)
+    pods = {}
+    for kubeconfig in args.kubeconfig_path:
+        pods.update(fetch_pods(kubeconfig))
     log.debug(f"Found {len(pods.keys())} pods.")
 
     update_tron_from_pods(jobs, pods, args.tronctl_wrapper, args.do_work)


### PR DESCRIPTION
If an action supports retries then we migrate to a new cluster while a job is ongoing, some attempts for this action could live on the old cluster and others on the new. 

In order to catch this situation, sync_tron_from_k8s needs to be able to inspect pods in both old & new clusters to determine the correct tron state. 

This simply allows specifying multiple kubeconfigs and gathering _all_ pods from all clusters in order to compare against potentially-updateable actions.

This has been verified to work with multiple kubeconfigs for both eks and non-eks infrastage, and I've verified the metadata.creationTimestamps appear to be in UTC so will be consistent across clusters so we are comparing timestamps appropriately. 

(Note that this means running from the devbox is not quite as convenient since our kubeconfigs are shared in a single file; I figured just forcing folks to run this somewhere with multiple files [such as the servers themselves, or by asking folks to extract each cluster to its own kubeconfig] would be easier than adding some custom method of specifying file+context combinations in the args) 