### PR TITLE
Update tronweb.less

### DIFF
--- a/tronweb/css/tronweb.less
+++ b/tronweb/css/tronweb.less
@@ -1,6 +1,6 @@
 
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:300,400,700,800);
-@import url(http://fonts.googleapis.com/css?family=Droid+Sans+Mono);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:300,400,700,800);
+@import url(//fonts.googleapis.com/css?family=Droid+Sans+Mono);
 
 @font-face {
 }


### PR DESCRIPTION
fixes import of fonts when using https
<img width="2236" alt="image" src="https://github.com/user-attachments/assets/da17abc3-1cdf-4df9-9533-d6390a30934b">


Before/after
<img width="178" alt="image" src="https://github.com/user-attachments/assets/10b81b0b-ab78-49d1-aada-7fc857822e53">
<img width="120" alt="image" src="https://github.com/user-attachments/assets/dfd8b4b6-1120-499b-8d07-97164f7236e7">
