### PR TITLE
Fix negative value check for non-retryable exit codes in Kubernetes configuration

### DIFF
--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -34,6 +34,7 @@ from tron.config.config_utils import PartialConfigContext
 from tron.config.config_utils import StringFormatter
 from tron.config.config_utils import valid_bool
 from tron.config.config_utils import valid_dict
+from tron.config.config_utils import valid_exit_code
 from tron.config.config_utils import valid_float
 from tron.config.config_utils import valid_identifier
 from tron.config.config_utils import valid_int
@@ -874,7 +875,7 @@ class ValidateKubernetes(Validator):
     validators = {
         "kubeconfig_path": valid_string,
         "enabled": valid_bool,
-        "non_retryable_exit_codes": build_list_of_type_validator(valid_int, allow_empty=True),
+        "non_retryable_exit_codes": build_list_of_type_validator(valid_exit_code, allow_empty=True),
         "default_volumes": build_list_of_type_validator(valid_volume, allow_empty=True),
         "watcher_kubeconfig_paths": build_list_of_type_validator(valid_string, allow_empty=True),
     }

--- a/tron/config/config_utils.py
+++ b/tron/config/config_utils.py
@@ -80,7 +80,7 @@ def valid_number(type_func, value, config_context):
         name = type_func.__name__
         raise ConfigError(f"Value at {path} is not an {name}: {value}")
 
-    if value < 0:
+    if value < 0 and path != "MASTER.Tron.k8s_options.Kubernetes.non_retryable_exit_codes":
         raise ConfigError("%s must be a positive int." % path)
 
     return value

--- a/tron/config/config_utils.py
+++ b/tron/config/config_utils.py
@@ -72,7 +72,7 @@ def build_type_validator(validator, error_fmt):
     return f
 
 
-def valid_number(type_func, value, config_context):
+def valid_number(type_func, value, config_context, allow_negative=False):
     path = config_context.path
     try:
         value = type_func(value)
@@ -80,12 +80,13 @@ def valid_number(type_func, value, config_context):
         name = type_func.__name__
         raise ConfigError(f"Value at {path} is not an {name}: {value}")
 
-    if value < 0 and path != "MASTER.Tron.k8s_options.Kubernetes.non_retryable_exit_codes":
+    if value < 0 and not allow_negative:
         raise ConfigError("%s must be a positive int." % path)
 
     return value
 
 
+valid_exit_code = functools.partial(valid_number, int, allow_negative=True)
 valid_int = functools.partial(valid_number, int)
 valid_float = functools.partial(valid_number, float)
 


### PR DESCRIPTION
This pull request fixes a bug in the Kubernetes configuration where a negative value was not properly checked for non-retryable exit codes.