### PR TITLE
Attempt to batch config loading for deployments

### DIFF
--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -385,12 +385,9 @@ class ConfigResource(resource.Resource):
     def render_GET(self, request):
         config_name = requestargs.get_string(request, "name")
         if not config_name:
-            return respond(
-                request=request,
-                response={"error": "'name' for config is required."},
-                code=http.BAD_REQUEST,
-            )
-        response = self.controller.read_config(config_name)
+            response = self.controller.read_all_configs()
+        else:
+            response = self.controller.read_config(config_name)
         return respond(request=request, response=response)
 
     @AsyncResource.exclusive

--- a/tron/config/manager.py
+++ b/tron/config/manager.py
@@ -35,7 +35,7 @@ def write_raw(path, content):
         fh.write(maybe_decode(content))
 
 
-def read_raw(path):
+def read_raw(path) -> str:
     with open(path) as fh:
         return fh.read()
 
@@ -98,7 +98,7 @@ class ConfigManager:
         name = name.replace(".", "_").replace(os.path.sep, "_")
         return os.path.join(self.config_path, "%s.yaml" % name)
 
-    def read_raw_config(self, name=schema.MASTER_NAMESPACE):
+    def read_raw_config(self, name=schema.MASTER_NAMESPACE) -> str:
         """Read the config file without converting to yaml."""
         filename = self.manifest.get_file_name(name)
         return read_raw(filename)
@@ -157,7 +157,7 @@ class ConfigManager:
         name_mapping = self.get_config_name_mapping()
         return config_parse.ConfigContainer.create(name_mapping)
 
-    def get_hash(self, name):
+    def get_hash(self, name) -> str:
         """Return a hash of the configuration contents for name."""
         if name not in self:
             return self.DEFAULT_HASH
@@ -166,7 +166,7 @@ class ConfigManager:
     def __contains__(self, name):
         return name in self.manifest
 
-    def get_namespaces(self):
+    def get_namespaces(self) -> str:
         return self.manifest.get_file_mapping().keys()
 
 


### PR DESCRIPTION
Right now we make at most 2N calls to the Tron API during config deployments: N to get the current configs and at most N if all services have changes.

To start, I'd like to reduce this to N by allowing GET /api/config to return all the configs so that the only requests needed are POSTs for changed configs.

Depending on how this goes, we can look into batching up the POSTs so that we can also do that in a single request.

In terms of speed, it looks like loading all the configs from pnw-prod (on my devbox) with this new behavior takes ~3s - which isn't great, but there's a decent bit of file IO going on here :(