### PR TITLE
TRON-2277: Pass along non_retryable_exit_codes to KubernetesCluster objects

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -1778,6 +1778,20 @@ class TestValidKubeconfigPaths:
         with pytest.raises(ConfigError):
             config_parse.valid_kubernetes_options.validate(k8s_options, self.context)
 
+    def test_nonretry(self):
+        k8s_options = {
+            "enabled": True,
+            "kubeconfig_path": "/some/valid/path",
+            "watcher_kubeconfig_paths": [],
+            "non_retryable_exit_codes": 1,
+        }
+        with pytest.raises(ConfigError):
+            config_parse.valid_kubernetes_options.validate(k8s_options, self.context)
+
+        k8s_options["non_retryable_exit_codes"] = [-12, 1]
+
+        assert config_parse.valid_kubernetes_options.validate(k8s_options, self.context)
+
 
 if __name__ == "__main__":
     run()

--- a/tron/kubernetes.py
+++ b/tron/kubernetes.py
@@ -628,6 +628,7 @@ class KubernetesClusterRepository:
     pod_launch_timeout: Optional[int] = None
     default_volumes: Optional[List[ConfigVolume]] = None
     watcher_kubeconfig_paths: Optional[List[str]] = None
+    non_retryable_exit_codes: Optional[List[int]] = None
 
     # metadata config
     clusters: Dict[str, KubernetesCluster] = {}
@@ -654,6 +655,7 @@ class KubernetesClusterRepository:
                 enabled=cls.kubernetes_enabled,
                 default_volumes=cls.default_volumes,
                 watcher_kubeconfig_paths=cls.watcher_kubeconfig_paths,
+                non_retryable_exit_codes=cls.non_retryable_exit_codes,
             )
             cls.clusters[kubeconfig_path] = cluster
 
@@ -671,6 +673,7 @@ class KubernetesClusterRepository:
         cls.kubernetes_non_retryable_exit_codes = kubernetes_options.non_retryable_exit_codes
         cls.default_volumes = kubernetes_options.default_volumes
         cls.watcher_kubeconfig_paths = kubernetes_options.watcher_kubeconfig_paths
+        cls.non_retryable_exit_codes = kubernetes_options.non_retryable_exit_codes
 
         for cluster in cls.clusters.values():
             cluster.set_enabled(cls.kubernetes_enabled)


### PR DESCRIPTION
Looks like we missed one place where we need to pass along the k8s_options from MASTER configs, when we instantiate our `KubernetesCluster`s from `KubernetesClusterRepository`.

Applying this change to a local instance and infrastage now do what we expect and do not retry failed actions if their exit codes are in non_retryable_exit_codes, plus logs what we expect:
```
2024-09-25 17:00:22,786 tron.core.actionrun INFO ActionRun: MASTER.testjob0.14.zeroth skipping auto-retries, received non-retryable exit code (72).
2024-09-25 17:00:22,786 tron.core.actionrun INFO ActionRun: MASTER.testjob0.14.zeroth completed with fail, transitioned to running, exit status: 72
2024-09-25 17:00:22,786 tron.utils.state DEBUG transitioning from running to failed
2024-09-25 17:00:22,786 tron.utils.observer DEBUG Notifying 1 listeners for new event 'failed'
2024-09-25 17:00:22,786 tron.core.jobrun INFO JobRun:MASTER.testjob0.14 got an event: failed
```
(i.e. no retries after the `non-retryable exit code` line + goes to jobrun failed)

This also adds 2 fairly dumb tests (the actionrun test alone wouldn't have caught the fix since we're mocking get_cluster's result itself, hence why I also added a really dumb KubernetesClusterRepository->KubernetesCluster one to make sure we don't skip passing along new configs here in the future. 

Let me know if you have a better idea for any tests!