### PR TITLE
TRON-2208: Update non_retryable_exit_code behavior to treat as UNKNOWN

### DIFF
--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -612,7 +612,7 @@ class ActionRun(Observable):
                     log.info(
                         f"Reached maximum number of retries: {len(self.attempts)}",
                     )
-        if exit_status is None:
+        if exit_status is None or exit_status in non_retryable_exit_codes:
             return self._done("fail_unknown", exit_status)
         else:
             return self._done("fail", exit_status)


### PR DESCRIPTION
This keeps things as UNKNOWN if we happen to match a non_retryable_exit_code rather than straight to FAILED, since we are primarily using this feature to capture things which have gone LOST on kubernetes and as such, we can then use our sync_tron_state_from_k8s script to update the action state based on pod state, which would not be possible if we already marked it as FAIL. 

This has been tested on infrastage and the [test run](http://tron-infrastage.yelpcorp.com:8089/web/#job/paasta-contract-monitor.test_no_retries/12/run) that exited with a non_retryable_exit_code successfully got marked as `unknown` and did not attempt any retries, plus the sync_tron_state_from_k8s script reported it would be able to correct the state:
```
DEBUG:sync_tron_from_k8s:paasta-contract-monitor.test_no_retries.12.run state unknown needs updating to fail
INFO:sync_tron_from_k8s:Dry-Run: Would run ['tronctl-infrastage', 'fail', 'paasta-contract-monitor.test_no_retries.12.run']
```
