### PR TITLE
Fixing Tron logs for jobs using other services images

### DIFF
--- a/tests/utils/scribereader_test.py
+++ b/tests/utils/scribereader_test.py
@@ -5,7 +5,7 @@ import pytest
 import yaml
 
 import tron.utils.scribereader
-from tron.utils.scribereader import get_log_namespace
+from tron.utils.scribereader import decompose_action_id
 from tron.utils.scribereader import read_log_stream_for_action_run
 
 try:
@@ -424,7 +424,7 @@ def test_read_log_stream_for_action_run_min_date_and_max_date_for_long_output():
     assert len(output) == max_lines + 1
 
 
-def test_get_log_namespace_yml_file_found():
+def test_decompose_action_id_yml_file_found():
     action_run_id = "namespace.job.1234.action"
     paasta_cluster = "fake_cluster"
     config_content = """
@@ -436,39 +436,51 @@ def test_get_log_namespace_yml_file_found():
     with mock.patch("builtins.open", mock.mock_open(read_data=config_content)), mock.patch(
         "yaml.safe_load", return_value=yaml.safe_load(config_content)
     ):
-        result = get_log_namespace(action_run_id, paasta_cluster)
-        assert result == "test_service"
+        namespace, job_name, run_num, action = decompose_action_id(action_run_id, paasta_cluster)
+        assert namespace == "test_service"
+        assert job_name == "job"
+        assert run_num == "1234"
+        assert action == "action"
 
 
-def test_get_log_namespace_file_not_found():
+def test_decompose_action_id_file_not_found():
     action_run_id = "namespace.job.1234.action"
     paasta_cluster = "fake_cluster"
     with mock.patch("builtins.open", side_effect=FileNotFoundError):
-        result = get_log_namespace(action_run_id, paasta_cluster)
-        assert result == "namespace"
+        namespace, job_name, run_num, action = decompose_action_id(action_run_id, paasta_cluster)
+        assert namespace == "namespace"
+        assert job_name == "job"
+        assert run_num == "1234"
+        assert action == "action"
 
 
-def test_get_log_namespace_yaml_error():
+def test_decompose_action_id_yaml_error():
     action_run_id = "namespace.job.1234.action"
     paasta_cluster = "fake_cluster"
     with mock.patch("builtins.open", mock.mock_open(read_data="invalid_yaml")), mock.patch(
         "yaml.safe_load", side_effect=yaml.YAMLError
     ):
-        result = get_log_namespace(action_run_id, paasta_cluster)
-        assert result == "namespace"
+        namespace, job_name, run_num, action = decompose_action_id(action_run_id, paasta_cluster)
+        assert namespace == "namespace"
+        assert job_name == "job"
+        assert run_num == "1234"
+        assert action == "action"
 
 
-def test_get_log_namespace_generic_error():
+def test_decompose_action_id_generic_error():
     action_run_id = "namespace.job.1234.action"
     paasta_cluster = "fake_cluster"
     with mock.patch("builtins.open", mock.mock_open(read_data="some_data")), mock.patch(
         "yaml.safe_load", side_effect=Exception
     ):
-        result = get_log_namespace(action_run_id, paasta_cluster)
-        assert result == "namespace"
+        namespace, job_name, run_num, action = decompose_action_id(action_run_id, paasta_cluster)
+        assert namespace == "namespace"
+        assert job_name == "job"
+        assert run_num == "1234"
+        assert action == "action"
 
 
-def test_get_log_namespace_service_not_found():
+def test_decompose_action_id_service_not_found():
     action_run_id = "namespace.job.1234.action"
     paasta_cluster = "fake_cluster"
     config_content = """
@@ -480,5 +492,8 @@ def test_get_log_namespace_service_not_found():
     with mock.patch("builtins.open", mock.mock_open(read_data=config_content)), mock.patch(
         "yaml.safe_load", return_value=yaml.safe_load(config_content)
     ):
-        result = get_log_namespace(action_run_id, paasta_cluster)
-        assert result == "namespace"
+        namespace, job_name, run_num, action = decompose_action_id(action_run_id, paasta_cluster)
+        assert namespace == "namespace"
+        assert job_name == "job"
+        assert run_num == "1234"
+        assert action == "action"

--- a/tron/utils/scribereader.py
+++ b/tron/utils/scribereader.py
@@ -87,7 +87,7 @@ def get_log_namespace(action_run_id: str, paasta_cluster: str) -> str:
     for ext in ["yaml", "yml"]:
         try:
             with open(f"/nail/etc/services/{namespace}/tron-{paasta_cluster}.{ext}") as f:
-                config = yaml.safe_load(f)
+                config = yaml.load(f, Loader=yaml.CSafeLoader)
                 service: Optional[str] = (
                     config.get(job_name, {}).get("actions", {}).get(action, {}).get("service", None)
                 )

--- a/tron/utils/scribereader.py
+++ b/tron/utils/scribereader.py
@@ -95,11 +95,11 @@ def decompose_action_id(action_run_id: str, paasta_cluster: str) -> Tuple[str, s
                     return service, job_name, run_num, action
         except FileNotFoundError:
             log.warning(f"yelp-soaconfig file tron-{paasta_cluster}.{ext} not found for action_run_id {action_run_id}.")
-        except yaml.YAMLError as e:
-            log.error(f"Error parsing YAML file tron-{paasta_cluster}.{ext} for action_run_id {action_run_id}: {e}")
-        except Exception as e:
-            log.error(
-                f"Error reading service for action_run_id {action_run_id} from file tron-{paasta_cluster}.{ext}: {e}"
+        except yaml.YAMLError:
+            log.exception(f"Error parsing YAML file tron-{paasta_cluster}.yaml for {action_run_id} - will default to using current namespace:")
+        except Exception:
+            log.exception(
+                f"Error reading service for {action_run_id} from file tron-{paasta_cluster}.yaml - will default to using current namespace:"
             )
 
     return namespace, job_name, run_num, action

--- a/tron/utils/scribereader.py
+++ b/tron/utils/scribereader.py
@@ -96,7 +96,9 @@ def decompose_action_id(action_run_id: str, paasta_cluster: str) -> Tuple[str, s
         except FileNotFoundError:
             log.warning(f"yelp-soaconfig file tron-{paasta_cluster}.{ext} not found for action_run_id {action_run_id}.")
         except yaml.YAMLError:
-            log.exception(f"Error parsing YAML file tron-{paasta_cluster}.yaml for {action_run_id} - will default to using current namespace:")
+            log.exception(
+                f"Error parsing YAML file tron-{paasta_cluster}.yaml for {action_run_id} - will default to using current namespace:"
+            )
         except Exception:
             log.exception(
                 f"Error reading service for {action_run_id} from file tron-{paasta_cluster}.yaml - will default to using current namespace:"

--- a/tron/utils/scribereader.py
+++ b/tron/utils/scribereader.py
@@ -9,7 +9,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
-import staticconf
+import staticconf  # type: ignore
 import yaml
 
 from tron.config.static_config import get_config_watcher

--- a/tron/utils/scribereader.py
+++ b/tron/utils/scribereader.py
@@ -10,7 +10,7 @@ from typing import Optional
 from typing import Tuple
 
 import staticconf
-import yaml  # type: ignore
+import yaml
 
 from tron.config.static_config import get_config_watcher
 from tron.config.static_config import NAMESPACE
@@ -88,7 +88,9 @@ def get_log_namespace(action_run_id: str, paasta_cluster: str) -> str:
         try:
             with open(f"/nail/etc/services/{namespace}/tron-{paasta_cluster}.{ext}") as f:
                 config = yaml.safe_load(f)
-                service = config.get(job_name, {}).get("actions", {}).get(action, {}).get("service", None)
+                service: Optional[str] = (
+                    config.get(job_name, {}).get("actions", {}).get(action, {}).get("service", None)
+                )
                 if service:
                     return service
         except FileNotFoundError:


### PR DESCRIPTION
This PR introduces a new function, get_log_namespace, which retrieves the log namespace from yelpsoa-configs. The function is used in the PaaSTALogs class in scribereader.py to set the namespace for logging. 

The PR also includes unit tests for the get_log_namespace function.

Closes TRON-2275


........tested manually and seems to work fine