### PR TITLE
Use total_seconds for timedeltas. Log job and jobrun names/runnums on serialization

### DIFF
--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -761,7 +761,7 @@ class ActionRun(Observable, Persistable):
                     "attempts": [ActionRunAttempt.to_json(attempt) for attempt in state_data["attempts"]],
                     "retries_remaining": state_data["retries_remaining"],
                     "retries_delay": state_data["retries_delay"].total_seconds()
-                    if state_data["retries_delay"]
+                    if state_data["retries_delay"] is not None
                     else None,
                     "action_runner": action_runner_json,
                     "executor": state_data["executor"],

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -740,6 +740,7 @@ class ActionRun(Observable, Persistable):
     @staticmethod
     def to_json(state_data: dict) -> Optional[str]:
         """Serialize the ActionRun instance to a JSON string."""
+
         action_runner = state_data.get("action_runner")
         if action_runner is None:
             action_runner_json = NoActionRunnerFactory.to_json()
@@ -759,7 +760,9 @@ class ActionRun(Observable, Persistable):
                     "exit_status": state_data["exit_status"],
                     "attempts": [ActionRunAttempt.to_json(attempt) for attempt in state_data["attempts"]],
                     "retries_remaining": state_data["retries_remaining"],
-                    "retries_delay": state_data["retries_delay"],
+                    "retries_delay": state_data["retries_delay"].total_seconds()
+                    if state_data["retries_delay"]
+                    else None,
                     "action_runner": action_runner_json,
                     "executor": state_data["executor"],
                     "trigger_downstreams": state_data["trigger_downstreams"],

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -204,8 +204,10 @@ class DynamoDBStateStore:
     def _serialize_item(self, key: Literal[runstate.JOB_STATE, runstate.JOB_RUN_STATE], state: Dict[str, Any]) -> Optional[str]:  # type: ignore
         try:
             if key == runstate.JOB_STATE:
+                log.info(f"Serializing Job: {state.get('job_name')}")
                 return Job.to_json(state)
             elif key == runstate.JOB_RUN_STATE:
+                log.info(f"Serializing JobRun: {state.get('job_name')}.{state.get('run_num')}")
                 return JobRun.to_json(state)
             else:
                 raise ValueError(f"Unknown type: key {key}")


### PR DESCRIPTION
I think total_seconds is the easiest to convert back to timedelta later. I added some logging that might be noisier than we want longterm, but should make debugging these a lot easier.

Recreated the errors in infrastage and this does appear to resolve things.

Sidenote, I'm happy to leave this unmerged while doing more testing in dev/stage to maybe minimize the number of patch releases. 