### PR TITLE
Add default CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# NOTE: "we" in this file will refer to the Compute Infrastructure team at Yelp
+* @Yelp/paasta
+#
+# prevent cheeky modifications :)
+CODEOWNERS @Yelp/paasta


### PR DESCRIPTION
To start, we can add ourselves as CODEOWNERS for the entire repo since (at least for the time being), we probably want to be aware of/sign-off any changes to Tron