### PR TITLE
Disable the tooltip animation that is causing a strange problem where you can't get a tooltip when entering from the top of an object

### DIFF
--- a/tronweb/coffee/views.coffee
+++ b/tronweb/coffee/views.coffee
@@ -63,7 +63,9 @@ window.isSelected = (current, value) ->
     if current == value then "selected" else ""
 
 window.makeTooltips = (root) ->
-    root.find('.tt-enable').tooltip()
+    root.find('.tt-enable').tooltip({
+        animation: false
+    })
 
 
 window.formatName = (name) =>

--- a/tronweb/coffee/views.coffee
+++ b/tronweb/coffee/views.coffee
@@ -64,6 +64,9 @@ window.isSelected = (current, value) ->
 
 window.makeTooltips = (root) ->
     root.find('.tt-enable').tooltip({
+        # There is some strange behaviour with the tooltip animation in Bootstrap 2
+        # that causes the object to get into a bad state and not appear as expected.
+        # Disabling animation is a workaround until we upgrade to Bootstrap 3 (or 4...or 5)
         animation: false
     })
 


### PR DESCRIPTION
## Context
Working my way through some UI bugs that I've stumbled upon. This was pretty tricky to solve because we use an ancient version of bootstrap. 

>  We choose to fix Tron. We choose to fix Tron... We choose to fix Tron in this decade and do the other things, not because they are easy, but because they are hard! 
> \- John F. Kennedy

## Solution
- [Before](https://fluffy.yelpcorp.com/i/RH33zkzJmSZrrqXn8rgQDmGg6nm8DzT5.gif)
- [After](https://fluffy.yelpcorp.com/i/QB5pnhZzHCqNdK4598HLznJ9RNJ1pFQT.gif)