### PR TITLE
Add default behaviour for jobs that dont have some keys and handle the non-existent of some json_vals

### DIFF
--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -115,6 +115,13 @@ class ActionCommandConfig(Persistable):
             return obj
 
         try:
+            # NOTE: you'll notice that there's a lot of get() accesses of state_data for
+            # pretty common fields - this is because ActionCommandConfig is used by more
+            # than one type of ActionRun (Kubernetes, Mesos, SSH) and these generally look
+            # different. Alternatively, some of these fields are used by KubernetesActionRun
+            # but are relatively new and older runs do not have data for them.
+            # Once we get rid of the SSH and Mesos code as well as older runs in DynamoDB,
+            # we'll likely be able to clean this up.
             return json.dumps(
                 {
                     "command": state_data["command"],

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -117,37 +117,42 @@ class ActionCommandConfig(Persistable):
         try:
             return json.dumps(
                 {
-                    "command": state_data["command"],
-                    "cpus": state_data["cpus"],
-                    "mem": state_data["mem"],
-                    "disk": state_data["disk"],
-                    "cap_add": state_data["cap_add"],
-                    "cap_drop": state_data["cap_drop"],
+                    "command": state_data.get("command"),
+                    "cpus": state_data.get("cpus"),
+                    "mem": state_data.get("mem"),
+                    "disk": state_data.get("disk"),
+                    "cap_add": state_data.get("cap_add", []),
+                    "cap_drop": state_data.get("cap_drop", []),
                     "constraints": [
-                        serialize_namedtuple(constraint) for constraint in state_data["constraints"]
+                        serialize_namedtuple(constraint) for constraint in state_data.get("constraints", [])
                     ],  # convert each ConfigConstraint to dictionary, so it would be a list of dicts
-                    "docker_image": state_data["docker_image"],
+                    "docker_image": state_data.get("docker_image"),
                     "docker_parameters": [
-                        serialize_namedtuple(parameter) for parameter in state_data["docker_parameters"]
+                        serialize_namedtuple(parameter) for parameter in state_data.get("docker_parameters", [])
                     ],
-                    "env": state_data["env"],
-                    "secret_env": {key: serialize_namedtuple(val) for key, val in state_data["secret_env"].items()},
-                    "secret_volumes": [serialize_namedtuple(volume) for volume in state_data["secret_volumes"]],
+                    "env": state_data.get("env", {}),
+                    "secret_env": {
+                        key: serialize_namedtuple(val) for key, val in state_data.get("secret_env", {}).items()
+                    },
+                    "secret_volumes": [serialize_namedtuple(volume) for volume in state_data.get("secret_volumes", [])],
                     "projected_sa_volumes": [
-                        serialize_namedtuple(volume) for volume in state_data["projected_sa_volumes"]
+                        serialize_namedtuple(volume) for volume in state_data.get("projected_sa_volumes", [])
                     ],
                     "field_selector_env": {
-                        key: serialize_namedtuple(val) for key, val in state_data["field_selector_env"].items()
+                        key: serialize_namedtuple(val) for key, val in state_data.get("field_selector_env", {}).items()
                     },
-                    "extra_volumes": [serialize_namedtuple(volume) for volume in state_data["extra_volumes"]],
-                    "node_selectors": state_data["node_selectors"],
-                    "node_affinities": [serialize_namedtuple(affinity) for affinity in state_data["node_affinities"]],
-                    "labels": state_data["labels"],
-                    "annotations": state_data["annotations"],
-                    "service_account_name": state_data["service_account_name"],
-                    "ports": state_data["ports"],
+                    "extra_volumes": [serialize_namedtuple(volume) for volume in state_data.get("extra_volumes", [])],
+                    "node_selectors": state_data.get("node_selectors", {}),
+                    "node_affinities": [
+                        serialize_namedtuple(affinity) for affinity in state_data.get("node_affinities", [])
+                    ],
+                    "labels": state_data.get("labels", {}),
+                    "annotations": state_data.get("annotations", {}),
+                    "service_account_name": state_data.get("service_account_name"),
+                    "ports": state_data.get("ports", []),
                     "topology_spread_constraints": [
-                        serialize_namedtuple(constraint) for constraint in state_data["topology_spread_constraints"]
+                        serialize_namedtuple(constraint)
+                        for constraint in state_data.get("topology_spread_constraints", [])
                     ],
                 }
             )

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -118,15 +118,15 @@ class ActionCommandConfig(Persistable):
             return json.dumps(
                 {
                     "command": state_data["command"],
-                    "cpus": state_data.get("cpus"),
-                    "mem": state_data.get("mem"),
-                    "disk": state_data.get("disk"),
+                    "cpus": state_data["cpus"],
+                    "mem": state_data["mem"],
+                    "disk": state_data["disk"],
                     "cap_add": state_data["cap_add"],
                     "cap_drop": state_data["cap_drop"],
                     "constraints": [
                         serialize_namedtuple(constraint) for constraint in state_data.get("constraints", [])
                     ],  # convert each ConfigConstraint to dictionary, so it would be a list of dicts
-                    "docker_image": state_data.get("docker_image"),
+                    "docker_image": state_data["docker_image"],
                     "docker_parameters": [
                         serialize_namedtuple(parameter) for parameter in state_data.get("docker_parameters", [])
                     ],

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -117,7 +117,7 @@ class ActionCommandConfig(Persistable):
         try:
             return json.dumps(
                 {
-                    "command": state_data.get("command"),
+                    "command": state_data["command"],
                     "cpus": state_data.get("cpus"),
                     "mem": state_data.get("mem"),
                     "disk": state_data.get("disk"),

--- a/tron/core/action.py
+++ b/tron/core/action.py
@@ -121,8 +121,8 @@ class ActionCommandConfig(Persistable):
                     "cpus": state_data.get("cpus"),
                     "mem": state_data.get("mem"),
                     "disk": state_data.get("disk"),
-                    "cap_add": state_data.get("cap_add", []),
-                    "cap_drop": state_data.get("cap_drop", []),
+                    "cap_add": state_data["cap_add"],
+                    "cap_drop": state_data["cap_drop"],
                     "constraints": [
                         serialize_namedtuple(constraint) for constraint in state_data.get("constraints", [])
                     ],  # convert each ConfigConstraint to dictionary, so it would be a list of dicts

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -185,6 +185,11 @@ class ActionRunAttempt(Persistable):
                     "end_time": state_data["end_time"].isoformat() if state_data["end_time"] else None,
                     "rendered_command": state_data["rendered_command"],
                     "exit_status": state_data["exit_status"],
+                    # NOTE: mesos_task_id can be deleted once we delete all Mesos
+                    # code and run data - and kubernetes_task_id can then be
+                    # accessed unconditionally :)
+                    # (see note in ActionCommandConfig::to_json() for more
+                    # information about why we do this)
                     "mesos_task_id": state_data.get("mesos_task_id"),
                     "kubernetes_task_id": state_data.get("kubernetes_task_id"),
                 }

--- a/tron/core/actionrun.py
+++ b/tron/core/actionrun.py
@@ -185,8 +185,8 @@ class ActionRunAttempt(Persistable):
                     "end_time": state_data["end_time"].isoformat() if state_data["end_time"] else None,
                     "rendered_command": state_data["rendered_command"],
                     "exit_status": state_data["exit_status"],
-                    "mesos_task_id": state_data["mesos_task_id"],
-                    "kubernetes_task_id": state_data["kubernetes_task_id"],
+                    "mesos_task_id": state_data.get("mesos_task_id"),
+                    "kubernetes_task_id": state_data.get("kubernetes_task_id"),
                 }
             )
         except KeyError:
@@ -811,12 +811,12 @@ class ActionRun(Observable, Persistable):
                     "job_run_id": state_data["job_run_id"],
                     "action_name": state_data["action_name"],
                     "state": state_data["state"],
-                    "original_command": state_data["original_command"],
+                    "original_command": state_data.get("original_command"),
                     "start_time": state_data["start_time"].isoformat() if state_data["start_time"] else None,
                     "end_time": state_data["end_time"].isoformat() if state_data["end_time"] else None,
                     "node_name": state_data["node_name"],
                     "exit_status": state_data["exit_status"],
-                    "attempts": [ActionRunAttempt.to_json(attempt) for attempt in state_data["attempts"]],
+                    "attempts": [ActionRunAttempt.to_json(attempt) for attempt in state_data.get("attempts", [])],
                     "retries_remaining": state_data["retries_remaining"],
                     "retries_delay": (
                         state_data["retries_delay"].total_seconds() if state_data["retries_delay"] is not None else None

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -169,13 +169,7 @@ class DynamoDBStateStore:
                 raw_items[key] += bytes(val["val"]["B"])
             if read_json:
                 for json_val in item:
-                    try:
-                        json_items[key] = json_val["json_val"]["S"]
-                    except Exception:
-                        log.exception(f"json_val not found for key {key}")
-                        # fallback to pickled data if json_val fails to exist for any key
-                        # TODO: it would be nice if we can read the pickled data only for this failed key instead of all keys
-                        read_json = False
+                    json_items[key] = json_val["json_val"]["S"]
         if read_json:
             try:
                 log.info("read_json is enabled. Deserializing JSON items to restore them instead of pickled data.")

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -169,7 +169,13 @@ class DynamoDBStateStore:
                 raw_items[key] += bytes(val["val"]["B"])
             if read_json:
                 for json_val in item:
-                    json_items[key] = json_val["json_val"]["S"]
+                    try:
+                        json_items[key] = json_val["json_val"]["S"]
+                    except Exception:
+                        log.exception(f"json_val not found for key {key}")
+                        # fallback to pickled data if json_val fails to exist for any key
+                        # TODO: it would be nice if we can read the pickled data only for this failed key instead of all keys
+                        read_json = False
         if read_json:
             try:
                 log.info("read_json is enabled. Deserializing JSON items to restore them instead of pickled data.")


### PR DESCRIPTION
In this PR, we add the .get to some keys that we have seen error out when running the migration script in stage and that's because these jobs were too old and they didnt have some of these keys specified. If a key errors out, then there is no json val written for that action run. Thus, this PR sets a default value for those keys. It also adds a try/except to catch the scenario where a json_val doesnt exist for a key, otherwise I think it would fail silently and reset jobs to 0.

Note: I didn't change all keys to use .get instead, I wanted to change whatever was necessary as I think some keys should still error out on missing key if they are not optional? thoughts on this.