### PR TITLE
Bump task_processing to v1.3.1 for capability fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ setuptools==65.5.1
 six==1.15.0
 sshpubkeys==3.1.0
 stack-data==0.6.2
-task-processing==1.3.0
+task-processing==1.3.1
 traitlets==5.0.0
 Twisted==22.10.0
 typing-extensions==4.5.0


### PR DESCRIPTION
Just like Yelp/paasta#3972 and Yelp/paasta#3973, we need to ensure that there are no duplicates between cap_add and cap_drop - otherwise, the cap_drop entry will "win" and the duplicate capability will not be added.