### PR TITLE
Use localize instead of replace when writing tz info

### DIFF
--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -114,9 +114,9 @@ class JobRun(Observable, Observer, Persistable):
         """Deserialize the JobRun instance from a JSON string."""
         try:
             json_data = json.loads(state_data)
-            run_time_str = json_data["run_time"]
-            if run_time_str:
-                run_time = datetime.datetime.fromisoformat(run_time_str)
+            raw_run_time = json_data["run_time"]
+            if raw_run_time:
+                run_time = datetime.datetime.fromisoformat(raw_run_time)
                 if json_data["time_zone"]:
                     tz = pytz.timezone(json_data["time_zone"])
                     run_time = tz.localize(run_time)

--- a/tron/core/jobrun.py
+++ b/tron/core/jobrun.py
@@ -111,13 +111,15 @@ class JobRun(Observable, Observer, Persistable):
 
     @staticmethod
     def from_json(state_data: str):
-        """Deserialize the JobRun instance to a JSON string."""
+        """Deserialize the JobRun instance from a JSON string."""
         try:
             json_data = json.loads(state_data)
-            if json_data["run_time"]:
-                run_time = datetime.datetime.fromisoformat(json_data["run_time"])
+            run_time_str = json_data["run_time"]
+            if run_time_str:
+                run_time = datetime.datetime.fromisoformat(run_time_str)
                 if json_data["time_zone"]:
-                    run_time = run_time.replace(tzinfo=pytz.timezone(json_data["time_zone"]))
+                    tz = pytz.timezone(json_data["time_zone"])
+                    run_time = tz.localize(run_time)
             else:
                 run_time = None
             deserialized_data = {


### PR DESCRIPTION
We recently encountered an issue where the `run_time` for JobRun instances was consistently offset by 7 minutes *earlier* than the expected time. This was causing scheduled Jobs to execute earlier than intended, leading to incorrect Job executions. 

This issue looks to related to our use of `run_time.replace(tzinfo=...)` which incorrectly handles timezone writing. This misuse resulted in the run_time being assigned a tzinfo with an unexpected offset, such as `<DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>`, which has an offset of -7 minutes from the expected timezone offset.

Note: I do think adding tests would be ideal, but I haven't gotten that far.