### PR TITLE
TRON-1797: Put tronweb in a python-version-agnostic location

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,1 +1,2 @@
 tron/logging.conf var/lib/tron
+tronweb/ opt/venvs/tron/


### PR DESCRIPTION
This copies our generated tronweb files to `/opt/venvs/tron/tronweb` instead of referencing it under the installed tron package in the venv as we do now (`/opt/venvs/tron/lib/python${python_version}/site-packages/tronweb/`).

This version was tested on infrastage w/ local modifications to the nginx config to point to the new location, and tronweb UI appeared to be unaffected.  As I am simply making a _copy_ at the new path, the old path will continue to work as expected, allowing us to roll this out per cluster. 

I'm pretty open to putting this in an alternate location (`/var/www/tronweb`?) than still under `/opt/venvs/tron` but seemed fine to do it this way, given we're already pointing there today. 