### PR TITLE
Update task_processing to 1.3.4 for watch backoff

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ setuptools==65.5.1
 six==1.15.0
 sshpubkeys==3.1.0
 stack-data==0.6.2
-task-processing==1.3.3
+task-processing==1.3.4
 traitlets==5.0.0
 Twisted==22.10.0
 typing-extensions==4.5.0


### PR DESCRIPTION
This includes https://github.com/Yelp/task_processing/pull/225, which should add some backoff to watch restarts to avoid slamming the apiserver