### PR TITLE
Reduce transact size to avoid cap

### DIFF
--- a/tests/serialize/runstate/dynamodb_state_store_test.py
+++ b/tests/serialize/runstate/dynamodb_state_store_test.py
@@ -327,7 +327,7 @@ class TestDynamoDBStateStore:
             for _ in side_effects:
                 store._consume_save_queue()
 
-            assert mock_transact_write.call_count == len(side_effects)
+            assert mock_transact_write.called
             assert store.save_errors == expected_save_errors
             assert len(store.save_queue) == expected_queue_length
 

--- a/tests/serialize/runstate/dynamodb_state_store_test.py
+++ b/tests/serialize/runstate/dynamodb_state_store_test.py
@@ -303,7 +303,7 @@ class TestDynamoDBStateStore:
             ("large_object", [KeyError("foo")] * 3, 3, 1),
             # Failure followed by success
             ("small_object", [KeyError("foo"), {}], 0, 0),
-            ("large_object", [KeyError("foo"), {}], 0, 0),
+            ("large_object", [KeyError("foo")] + [{}] * 10, 0, 0),
         ],
     )
     def test_retry_saving(

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -42,6 +42,7 @@ MAX_SAVE_QUEUE = 500
 # infinite loops in the case where a key is truly unprocessable. We allow for more retries than it should
 # ever take to avoid failing restores due to transient issues.
 MAX_UNPROCESSED_KEYS_RETRIES = 30
+# While the AWS maximum is 100, we set this to 10 to avoid hitting the 4MB limit for the transaction. See DAR-2637
 MAX_TRANSACT_WRITE_ITEMS = 10
 log = logging.getLogger(__name__)
 T = TypeVar("T")

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -42,7 +42,7 @@ MAX_SAVE_QUEUE = 500
 # infinite loops in the case where a key is truly unprocessable. We allow for more retries than it should
 # ever take to avoid failing restores due to transient issues.
 MAX_UNPROCESSED_KEYS_RETRIES = 30
-MAX_TRANSACT_WRITE_ITEMS = 100
+MAX_TRANSACT_WRITE_ITEMS = 10
 log = logging.getLogger(__name__)
 T = TypeVar("T")
 


### PR DESCRIPTION
There is no world where we can write 100 items of our chunk size without hitting the cap.