### PR TITLE
use refreshable tokens for api auth

### DIFF
--- a/tron/commands/client.py
+++ b/tron/commands/client.py
@@ -47,7 +47,7 @@ def get_sso_auth_token() -> str:
     from tron.commands.cmd_utils import get_client_config
 
     client_id = get_client_config().get("auth_sso_oidc_client_id")
-    return get_and_cache_jwt_default(client_id) if client_id else ""  # type: ignore
+    return get_and_cache_jwt_default(client_id, refreshable=True) if client_id else ""  # type: ignore
 
 
 def build_url_request(uri, data, headers=None, method=None):

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,6 +1,6 @@
 clusterman-metrics==2.2.1  # used by tron for pre-scaling for Spark runs
 logreader==1.2.0        # used by tron logreader
-okta-auth==1.0.2        # used for API auth
+okta-auth==1.1.0        # used for API auth
 pyjwt==2.9.0            # required by okta-auth
 saml-helper==2.5.3      # required by okta-auth
 simplejson==3.19.2      # required by tron CLI


### PR DESCRIPTION
The new version adds an option to use an authentication flow with refresh tokens, which will allow `tronctl` commands to be run unattended for over the set duration of an identity token (which is fixed to 1 hour). Refresh tokens are valid for 90 days, which should be more than enough for all use cases.
