### PR TITLE
U/kkasp/tron 2414 fix broken config parse

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -1844,7 +1844,6 @@ class TestValidKubeconfigPaths:
 
 class TestValidateStatePersistenceDefaults(TestCase):
     def test_post_validation_sees_defaults_for_omitted_keys(self):
-        # Intentionally omit max_transact_write_items to test default behaviour
         input_config = {
             "store_type": "dynamodb",
             "name": "test_state",
@@ -1874,27 +1873,15 @@ class TestValidateStatePersistenceDefaults(TestCase):
             validated_config = validator(input_config, context)
             mock_method.assert_called_once()
 
-        self.assertEqual(
-            post_validation_args.get("max_transact_write_items"),
-            8,
-            "post_validation should see the default value for omitted max_transact_write_items",
-        )
-        self.assertEqual(
-            post_validation_args.get("buffer_size"),
-            5,
-            "post_validation should see the provided value for buffer_size",
-        )
+        assert post_validation_args.get("max_transact_write_items") == 8
+        assert post_validation_args.get("buffer_size") == 5
 
-        self.assertEqual(validated_config.store_type, "dynamodb")
-        self.assertEqual(validated_config.name, "test_state")
-        self.assertEqual(validated_config.table_name, "test_table")
-        self.assertEqual(validated_config.dynamodb_region, "us-west-2")
-        self.assertEqual(validated_config.buffer_size, 5)
-        self.assertEqual(
-            validated_config.max_transact_write_items,
-            8,
-            "Final config object should have the default value for max_transact_write_items",
-        )
+        assert validated_config.store_type == "dynamodb"
+        assert validated_config.name == "test_state"
+        assert validated_config.table_name == "test_table"
+        assert validated_config.dynamodb_region == "us-west-2"
+        assert validated_config.buffer_size == 5
+        assert validated_config.max_transact_write_items == 8
 
     def test_post_validation_sees_provided_values(self):
         input_config = {
@@ -1903,7 +1890,7 @@ class TestValidateStatePersistenceDefaults(TestCase):
             "table_name": "test_table",
             "dynamodb_region": "us-west-2",
             "buffer_size": 5,
-            "max_transact_write_items": 25,  # Explicitly provide a non-default value
+            "max_transact_write_items": 25,
         }
 
         original_post_validation = config_parse.ValidateStatePersistence.post_validation
@@ -1924,22 +1911,14 @@ class TestValidateStatePersistenceDefaults(TestCase):
             validated_config = validator(input_config, context)
             mock_method.assert_called_once()
 
-        self.assertEqual(
-            post_validation_args.get("max_transact_write_items"),
-            25,
-            "post_validation should see the provided value for max_transact_write_items",
-        )
+        assert post_validation_args.get("max_transact_write_items") == 25
 
-        self.assertEqual(
-            validated_config.max_transact_write_items,
-            25,
-            "Final config object should have the provided value for max_transact_write_items",
-        )
-        self.assertEqual(validated_config.store_type, "dynamodb")
-        self.assertEqual(validated_config.name, "test_state")
-        self.assertEqual(validated_config.table_name, "test_table")
-        self.assertEqual(validated_config.dynamodb_region, "us-west-2")
-        self.assertEqual(validated_config.buffer_size, 5)
+        assert validated_config.max_transact_write_items == 25
+        assert validated_config.store_type == "dynamodb"
+        assert validated_config.name == "test_state"
+        assert validated_config.table_name == "test_table"
+        assert validated_config.dynamodb_region == "us-west-2"
+        assert validated_config.buffer_size == 5
 
 
 if __name__ == "__main__":

--- a/tron/config/config_utils.py
+++ b/tron/config/config_utils.py
@@ -392,8 +392,9 @@ class Validator:
         defaults, and returning an instance of the config_class.
         """
         output_dict = self.validate_contents(in_dict, config_context)
-        self.post_validation(output_dict, config_context)
         self.set_defaults(output_dict, config_context)
+        self.post_validation(output_dict, config_context)
+
         return self.config_class(**output_dict)
 
     def validate_contents(self, input, config_context):


### PR DESCRIPTION
In [https://github.com/Yelp/Tron/pull/1043](https://github.com/Yelp/Tron/pull/1043) I added a config value for the number of items in a write transaction. The previous validation flow (i.e. `validate_contents` -> `post_validation` -> `set_defaults`) caused errors when `post_validation` attempted to access this optional field when it was omitted in the config.

Since `set_defaults` hadn't run yet, accessing the key (using `.get()`) would yield `None` in the dictionary passed to `post_validation`, leading to crashes if the logic expected a default value to be present (e.g. checking `if not 1 <= max_transact <= 100` would check `1 <= None`).

## What
This change modifies the core Validator to run `set_defaults` before `post_validation`. The new order of `validate_contents` -> `set_defaults` -> `post_validation` prevents these errors by applying defaults before `post_validation` runs.

## Why
Even without the specific config issue I encountered, this new order is more intuitive as `post_validation` now validates the intended state of the config object, which includes any applicable defaults. It also simplifies future `post_validation` logic, as we don't need to explicitly handle cases where an optional key with a default might be missing from the input dictionary.

## SecretVolumeItem
I needed to handle the case where the items key (which defaults to None) was explicitly set to None by `set_defaults` before `post_validation` ran. The previous logic would fail with a TypeError when checking `len(None)`. The fix uses `valid_input.get("items") or []` to ensure iteration works.

### `default_mode`
My changes to the Validator broke some tests and in the course of addressing those I noticed that the logic for propagating a SecretVolume's `default_mode` to items lacking their own mode was flawed. We were calling `item._replace()` but ignoring the return, meaning `default_mode` was never actually applied. My fix uses the value from `_replace()` and reconstructs the `items` tuple if modifications were needed.

The impact of this is minimal right now, both because it's unused (only defined in one disabled job), and because "If not specified, the volume defaultMode will be used." (from [V1SecretVolumeSource.items](https://k8s-python.readthedocs.io/en/stable/kubernetes.client.models.html#kubernetes.client.models.v1_secret_volume_source.V1SecretVolumeSource.items) -> [V1KeyToPath](https://k8s-python.readthedocs.io/en/stable/kubernetes.client.models.html#kubernetes.client.models.v1_key_to_path.V1KeyToPath.mode)). That said, we probably don't want to rely on a fallback, especially when we allow for explicit config.

#### Example
Tron Job config with secret_volumes like:
```yaml
secret_volumes:
- container_path: /home/nobody/.ssh
  secret_volume_name: kevin
  secret_name: kevin
  default_mode: '0666'
  items:
  - key: kevin
    path: kevin
```

The podspec produced:
- [Before](https://fluffy.yelpcorp.com/i/fdKxnvgPm4BsJB1m3zM9L5h2LBNQlgmx.html)
- [After](https://fluffy.yelpcorp.com/i/rhLRBDsNPCc6LnZJwNQwdL4fSk5TQHvn.html)

## TestValidMesosAction
This check needs adjustment because `set_defaults` now ensures keys like `docker_image` (which defaults to `None`) are present. This check feels pretty irrelevant these days, so I opted to remove it instead of updating.

