### PR TITLE
add support for api auth via vault

### DIFF
--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -1,4 +1,5 @@
 asynctest
+botocore-stubs
 debugpy
 flake8
 mock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 astroid==2.13.3
 asynctest==0.12.0
+botocore-stubs==1.38.19
 cfgv==2.0.1
 debugpy==1.8.1
 dill==0.3.6
@@ -29,6 +30,7 @@ requirements-tools==1.2.1
 toml==0.10.2
 tomli==2.0.1
 tomlkit==0.11.6
+types-awscrt==0.27.2
 types-pytz==2024.2.0.20240913
 types-PyYAML==6.0.12
 types-requests==2.31.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,9 @@ cachetools==4.2.1
 certifi==2022.12.7
 cffi==1.12.3
 cfn-lint==0.24.4
-chardet==3.0.4
+charset-normalizer==2.0.12
 constantly==15.1.0
-cryptography==39.0.1
+cryptography==41.0.5
 dataclasses==0.6
 DateTime==4.3
 decorator==4.4.0
@@ -71,7 +71,7 @@ python-jose==3.0.1
 pytimeparse==1.1.8
 pytz==2019.3
 PyYAML==6.0.1
-requests==2.25.0
+requests==2.27.1
 requests-oauthlib==1.2.0
 responses==0.10.6
 rsa==4.9

--- a/tests/commands/authentication_test.py
+++ b/tests/commands/authentication_test.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+from tron.commands.authentication import get_vault_auth_token
+
+
+@patch("tron.commands.authentication.get_client_config", autospec=True)
+@patch("tron.commands.authentication.get_current_ecosystem", autospec=True)
+@patch("tron.commands.authentication.InstanceMetadataProvider", autospec=True)
+@patch("tron.commands.authentication.InstanceMetadataFetcher", autospec=True)
+@patch("tron.commands.authentication.get_vault_client", autospec=True)
+@patch("tron.commands.authentication.get_vault_url", autospec=True)
+@patch("tron.commands.authentication.get_vault_ca", autospec=True)
+def test_get_service_auth_token(
+    mock_vault_ca,
+    mock_vault_url,
+    mock_get_vault_client,
+    mock_metadata_fetcher,
+    mock_metadata_provider,
+    mock_ecosystem,
+    mock_config,
+):
+    mock_ecosystem.return_value = "dev"
+    mock_config.return_value = {"vault_api_auth_role": "foobar"}
+    mock_vault_client = mock_get_vault_client.return_value
+    mock_vault_client.secrets.identity.generate_signed_id_token.return_value = {
+        "data": {"token": "sometoken"},
+    }
+    assert get_vault_auth_token() == "sometoken"
+    mock_instance_creds = mock_metadata_provider.return_value.load.return_value.get_frozen_credentials.return_value
+    mock_metadata_provider.assert_called_once_with(iam_role_fetcher=mock_metadata_fetcher.return_value)
+    mock_vault_url.assert_called_once_with("dev")
+    mock_vault_ca.assert_called_once_with("dev")
+    mock_get_vault_client.assert_called_once_with(mock_vault_url.return_value, mock_vault_ca.return_value)
+    mock_vault_client.auth.aws.iam_login.assert_called_once_with(
+        mock_instance_creds.access_key,
+        mock_instance_creds.secret_key,
+        mock_instance_creds.token,
+        mount_point="aws-iam",
+        role="foobar",
+        use_token=True,
+    )
+    mock_vault_client.secrets.identity.generate_signed_id_token.assert_called_once_with(name="foobar")

--- a/tron/commands/authentication.py
+++ b/tron/commands/authentication.py
@@ -1,0 +1,70 @@
+import os
+from typing import cast
+
+from botocore.credentials import InstanceMetadataFetcher
+from botocore.credentials import InstanceMetadataProvider
+
+from tron.commands.cmd_utils import get_client_config
+
+try:
+    from vault_tools.paasta_secret import get_client as get_vault_client  # type: ignore
+    from vault_tools.paasta_secret import get_vault_url
+    from vault_tools.paasta_secret import get_vault_ca
+    from okta_auth import get_and_cache_jwt_default  # type: ignore
+except ImportError:
+
+    def get_vault_client(url: str, capath: str) -> None:
+        pass
+
+    def get_vault_url(ecosystem: str) -> str:
+        return ""
+
+    def get_vault_ca(ecosystem: str) -> str:
+        return ""
+
+    def get_and_cache_jwt_default(client_id: str) -> str:
+        return ""
+
+
+def get_current_ecosystem() -> str:
+    """Get current ecosystem from host configs, defaults to dev if no config is found"""
+    try:
+        with open("/nail/etc/ecosystem") as f:
+            return f.read().strip()
+    except OSError:
+        pass
+    return "devc"
+
+
+def get_sso_auth_token() -> str:
+    """Generate an authentication token for the calling user from the Single Sign On provider, if configured"""
+    client_id = get_client_config().get("auth_sso_oidc_client_id")
+    return get_and_cache_jwt_default(client_id, refreshable=True) if client_id else ""  # type: ignore
+
+
+def get_vault_auth_token() -> str:
+    """Generate an authentication token for the underlying instance via Vault"""
+    ecosystem = get_current_ecosystem()
+    vault_client = get_vault_client(get_vault_url(ecosystem), get_vault_ca(ecosystem))
+    vault_role = get_client_config().get("vault_api_auth_role", "service_authz")
+    metadata_provider = InstanceMetadataProvider(
+        iam_role_fetcher=InstanceMetadataFetcher(),
+    )
+    instance_credentials = metadata_provider.load()
+    assert instance_credentials, "No instance credentials found"  # make mypy happy
+    static_instance_credentials = instance_credentials.get_frozen_credentials()
+    vault_client.auth.aws.iam_login(
+        static_instance_credentials.access_key,
+        static_instance_credentials.secret_key,
+        static_instance_credentials.token,
+        mount_point="aws-iam",
+        role=vault_role,
+        use_token=True,
+    )
+    response = vault_client.secrets.identity.generate_signed_id_token(name=vault_role)
+    return cast(str, response["data"]["token"])
+
+
+def get_auth_token() -> str:
+    """Generate authentication token via Vault or Okta"""
+    return get_vault_auth_token() if os.getenv("TRONCTL_VAULT_AUTH") else get_sso_auth_token()

--- a/tron/commands/client.py
+++ b/tron/commands/client.py
@@ -10,6 +10,7 @@ from collections import namedtuple
 from typing import Dict
 
 import tron
+from tron.commands.authentication import get_auth_token
 from tron.config.schema import MASTER_NAMESPACE
 
 try:
@@ -18,6 +19,7 @@ try:
     assert simplejson  # Pyflakes
 except ImportError:
     import json as simplejson  # type: ignore
+
 
 log = logging.getLogger(__name__)
 
@@ -37,25 +39,12 @@ default_headers = {
 }
 
 
-def get_sso_auth_token() -> str:
-    """Generate an authentication token for the calling user from the Single Sign On provider, if configured"""
-
-    # These imports are here because:
-    # - okta-auth is an internal library, so can never be imported or type-checked in public builds
-    # - there's an annoying circular import with the cmd_utils module
-    from okta_auth import get_and_cache_jwt_default  # type: ignore
-    from tron.commands.cmd_utils import get_client_config
-
-    client_id = get_client_config().get("auth_sso_oidc_client_id")
-    return get_and_cache_jwt_default(client_id, refreshable=True) if client_id else ""  # type: ignore
-
-
 def build_url_request(uri, data, headers=None, method=None):
     headers = headers or default_headers
     enc_data = urllib.parse.urlencode(data).encode() if data else None
     # Currently implementing auth only for management actions (i.e. POST requests)
     if os.getenv("TRONCTL_API_AUTH") and (data or (method and method.upper() == "POST")):
-        token = get_sso_auth_token()
+        token = get_auth_token()
         if token:
             headers["Authorization"] = f"Bearer {token}"
     return urllib.request.Request(uri, enc_data, headers=headers, method=method)

--- a/tron/commands/cmd_utils.py
+++ b/tron/commands/cmd_utils.py
@@ -9,7 +9,6 @@ import sys
 
 import tron
 from tron import yaml
-from tron.commands.client import Client
 
 log = logging.getLogger("tron.commands")
 
@@ -78,6 +77,9 @@ def tron_jobs_completer(prefix, **kwargs):
             inputs=[job.strip("\n\r") for job in jobs],
         )
     else:
+        # this import is here to avoid an annoying circular dependency
+        from tron.commands.client import Client
+
         if "client" not in kwargs:
             client = Client(get_default_server())
         else:

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -20,8 +20,8 @@ from typing import Tuple
 from typing import TypeVar
 
 import boto3  # type: ignore
-import botocore  # type: ignore
-from botocore.config import Config  # type: ignore
+import botocore
+from botocore.config import Config
 
 import tron.prom_metrics as prom_metrics
 from tron.core.job import Job

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,7 +1,19 @@
+asn1crypto==1.5.1          # vault-tools dependency
+atomicfile==1.0.1          # vault-tools dependency
 clusterman-metrics==2.2.1  # used by tron for pre-scaling for Spark runs
-logreader==1.2.0        # used by tron logreader
-okta-auth==1.1.0        # used for API auth
-pyjwt==2.9.0            # required by okta-auth
-saml-helper==2.5.3      # required by okta-auth
-simplejson==3.19.2      # required by tron CLI
-yelp-meteorite==2.1.1   # used by task-processing to emit metrics, clusterman-metrics dependency
+crypto-lib==4.0.0          # vault-tools dependency
+gitdb==4.0.12              # vault-tools dependency
+gitpython==3.1.44          # vault-tools dependency
+hvac==1.2.1                # vault-tools dependency
+ipaddress==1.0.23          # vault-tools dependency
+logreader==1.2.0           # used by tron logreader
+ndg-httpsclient==0.5.1     # vault-tools dependency
+okta-auth==1.1.0           # used for API auth
+pygpgme==0.3               # vault-tools dependency
+pyhcl==0.4.5               # vault-tools dependency
+pyjwt==2.9.0               # required by okta-auth
+saml-helper==2.5.3         # required by okta-auth
+simplejson==3.19.2         # required by tron CLI
+smmap==5.0.2               # vault-tools dependency
+vault-tools==1.5.0         # used for API auth
+yelp-meteorite==2.1.1      # used by task-processing to emit metrics, clusterman-metrics dependency


### PR DESCRIPTION
This is on the same exact line of https://github.com/Yelp/paasta/pull/4053, since I found a case of tronctl being used in an unattended way.

I'll soon integrate the logic from `get_vault_auth_token` into a function in vault-tools, so that complexity goes to live somewhere else, but for the time being I did some simply copy-paste.