### PR TITLE
fix some annoying warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,7 @@ task-processing==1.3.5
 traitlets==5.0.0
 Twisted==22.10.0
 typing-extensions==4.5.0
-urllib3==1.26.5
+urllib3==1.25.10
 wcwidth==0.1.7
 websocket-client==0.56.0
 Werkzeug==2.2.3

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -14,6 +14,7 @@ pyhcl==0.4.5               # vault-tools dependency
 pyjwt==2.9.0               # required by okta-auth
 pyopenssl==23.2.0          # vault-tools dependency
 saml-helper==2.5.3         # required by okta-auth
+service-identity==24.2.0   # vault-tools dependency
 simplejson==3.19.2         # required by tron CLI
 smmap==5.0.2               # vault-tools dependency
 vault-tools==1.5.0         # used for API auth


### PR DESCRIPTION
Hadn't noticed, but changes from https://github.com/Yelp/Tron/pull/1048 introduced some annoying warnings for the CLI, and this couple of tweaks should fix them.

```
/opt/venvs/tron/lib/python3.8/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.5) or chardet (5.2.0)/charset_normalizer (2.0.12) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "
:0: UserWarning: You do not have a working installation of the service_identity module: 'No module named 'service_identity''.  Please install it from <https://pypi.python.org/pypi/service_identity> and make sure all of its dependencies are satisfied.  Without the service_identity module, Twisted can perform only rudimentary TLS client hostname verification.  Many valid certificate/hostname mappings may be rejected.
```