### PR TITLE
return auth error that clients can parse

### DIFF
--- a/tron/api/resource.py
+++ b/tron/api/resource.py
@@ -113,7 +113,7 @@ class AuthenticatedResource(resource.Resource):
         if not auth_outcome.authorized:
             return respond(
                 request=request,
-                response={"reason": auth_outcome.reason},
+                response={"error": f"Auth failed (reason: {auth_outcome.reason})"},
                 code=http.FORBIDDEN,
                 headers={"X-Auth-Failure-Reason": auth_outcome.reason},
             )


### PR DESCRIPTION
When implementing this I didn't notice that the API client actually expects an error field in the response body.

```
Traceback (most recent call last):
  File "/usr/bin/tronctl", line 475, in <module>
    main()
  File "/usr/bin/tronctl", line 463, in main
    for ret in cmd(args):
  File "/usr/bin/tronctl", line 339, in control_objects
    yield request(urljoin(args.server, tron_id.url), data)
  File "/usr/bin/tronctl", line 233, in request
    response = client.request(url, data=data, headers=headers, method=method, user_attribution=True)
  File "/opt/venvs/tron/lib/python3.8/site-packages/tron/commands/client.py", line 92, in request
    return build_http_error_response(e)
  File "/opt/venvs/tron/lib/python3.8/site-packages/tron/commands/client.py", line 74, in build_http_error_response
    content = content["error"]
KeyError: 'error'
```