### PR TITLE
cache auth tokens before starting backfill jobs

### DIFF
--- a/tests/commands/backfill_test.py
+++ b/tests/commands/backfill_test.py
@@ -121,6 +121,7 @@ def test_backfill_run_cancel(
     assert expected == event_loop.run_until_complete(fake_backfill_run.cancel())
 
 
+@mock.patch("tron.commands.backfill.get_auth_token", lambda: "")
 @mock.patch.object(client, "get_object_type_from_identifier", autospec=True)
 def test_run_backfill_for_date_range_job_dne(mock_get_obj_type, event_loop):
     mock_get_obj_type.side_effect = ValueError
@@ -130,6 +131,7 @@ def test_run_backfill_for_date_range_job_dne(mock_get_obj_type, event_loop):
         )
 
 
+@mock.patch("tron.commands.backfill.get_auth_token", lambda: "")
 @mock.patch.object(client, "get_object_type_from_identifier", autospec=True)
 def test_run_backfill_for_date_range_not_a_job(mock_get_obj_type, event_loop):
     mock_get_obj_type.return_value = client.TronObjectIdentifier("JOB_RUN", "a_url")
@@ -146,6 +148,7 @@ def test_run_backfill_for_date_range_not_a_job(mock_get_obj_type, event_loop):
         (False, {"succeeded", "failed", "not started"}),
     ],
 )
+@mock.patch("tron.commands.backfill.get_auth_token", lambda: "")
 @mock.patch.object(client, "get_object_type_from_identifier", autospec=True)
 def test_run_backfill_for_date_range_normal(mock_get_obj_type, event_loop, ignore_errors, expected):
     run_states = (state for state in ["succeeded", "failed", "unknown"])

--- a/tron/commands/backfill.py
+++ b/tron/commands/backfill.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import functools
+import os
 import pprint
 import re
 import signal
@@ -232,7 +233,8 @@ async def run_backfill_for_date_range(
 
     # Trigger authentication before submitting all async jobs, so auth tokens
     # are cached and won't prompt the user in the individual API calls
-    get_auth_token()
+    if os.getenv("TRONCTL_API_AUTH"):
+        get_auth_token()
 
     tron_client = client.Client(server, user_attribution=True)
     url_index = tron_client.index()

--- a/tron/commands/backfill.py
+++ b/tron/commands/backfill.py
@@ -11,6 +11,7 @@ from urllib.parse import urljoin
 
 from tron.commands import client
 from tron.commands import display
+from tron.commands.authentication import get_auth_token
 from tron.core.actionrun import ActionRun
 
 DEFAULT_MAX_PARALLEL_RUNS = 3
@@ -228,6 +229,11 @@ async def run_backfill_for_date_range(
     most, max_parallel runs can run in parallel to prevent resource exhaustion.
     """
     loop = asyncio.get_event_loop()
+
+    # Trigger authentication before submitting all async jobs, so auth tokens
+    # are cached and won't prompt the user in the individual API calls
+    get_auth_token()
+
     tron_client = client.Client(server, user_attribution=True)
     url_index = tron_client.index()
 


### PR DESCRIPTION
The `backfill` command makes multiple API calls in async tasks, which causes users to be prompted for authz in concurrent threads, which of course it's a problem.
This should ensure that authentication is performed before the tasks are launched, so that the user can auth once, and then the tasks will be able to rely on the cached token values.