### PR TITLE
ignore cached okta token in backfills

### DIFF
--- a/tron/commands/authentication.py
+++ b/tron/commands/authentication.py
@@ -12,14 +12,14 @@ except ImportError:
     def get_instance_oidc_identity_token(role: str, ecosystem: Optional[str] = None) -> str:
         return ""
 
-    def get_and_cache_jwt_default(client_id: str) -> str:
+    def get_and_cache_jwt_default(client_id: str, refreshable: bool = False, force: bool = False) -> str:
         return ""
 
 
-def get_sso_auth_token() -> str:
+def get_sso_auth_token(no_cache: bool = False) -> str:
     """Generate an authentication token for the calling user from the Single Sign On provider, if configured"""
     client_id = get_client_config().get("auth_sso_oidc_client_id")
-    return cast(str, get_and_cache_jwt_default(client_id, refreshable=True)) if client_id else ""
+    return cast(str, get_and_cache_jwt_default(client_id, refreshable=True, force=no_cache)) if client_id else ""
 
 
 def get_vault_auth_token() -> str:
@@ -28,6 +28,6 @@ def get_vault_auth_token() -> str:
     return cast(str, get_instance_oidc_identity_token(vault_role))
 
 
-def get_auth_token() -> str:
+def get_auth_token(no_cache: bool = False) -> str:
     """Generate authentication token via Vault or Okta"""
-    return get_vault_auth_token() if os.getenv("TRONCTL_VAULT_AUTH") else get_sso_auth_token()
+    return get_vault_auth_token() if os.getenv("TRONCTL_VAULT_AUTH") else get_sso_auth_token(no_cache)

--- a/tron/commands/backfill.py
+++ b/tron/commands/backfill.py
@@ -232,9 +232,10 @@ async def run_backfill_for_date_range(
     loop = asyncio.get_event_loop()
 
     # Trigger authentication before submitting all async jobs, so auth tokens
-    # are cached and won't prompt the user in the individual API calls
+    # are cached and won't prompt the user in the individual API calls.
+    # We pass `no_cache` to ensure a new refresh token is generated and stored in memory.
     if os.getenv("TRONCTL_API_AUTH"):
-        get_auth_token()
+        get_auth_token(no_cache=True)
 
     tron_client = client.Client(server, user_attribution=True)
     url_index = tron_client.index()

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -8,7 +8,7 @@ hvac==1.2.1                # vault-tools dependency
 ipaddress==1.0.23          # vault-tools dependency
 logreader==1.2.0           # used by tron logreader
 ndg-httpsclient==0.5.1     # vault-tools dependency
-okta-auth==1.1.0           # used for API auth
+okta-auth==1.1.1           # used for API auth
 pygpgme==0.3               # vault-tools dependency
 pyhcl==0.4.5               # vault-tools dependency
 pyjwt==2.9.0               # required by okta-auth


### PR DESCRIPTION
Tokens cached on disk are currently a problem if the user launches a long backfill job less than one hour after running another tronctl command. This ensures can in case of backfills the cached token is ignored, and a fresh long-lasting refresh token is stored into memory, allowing the backfill command to correctly function for multiple hours.

NOTE: do not merge, the new version of `okta-auth` is not released yet internally.