### PR TITLE
Add disk eviction error code and check logic

### DIFF
--- a/tron/utils/exitcode.py
+++ b/tron/utils/exitcode.py
@@ -11,6 +11,7 @@ EXIT_KUBERNETES_ABNORMAL = -9
 EXIT_KUBERNETES_SPOT_INTERRUPTION = -10
 EXIT_KUBERNETES_NODE_SCALEDOWN = -11
 EXIT_KUBERNETES_TASK_LOST = -12
+EXIT_KUBERNETES_EPHEMERAL_STORAGE_EVICTION = -13
 
 EXIT_REASONS = {
     EXIT_INVALID_COMMAND: "Invalid command",
@@ -24,5 +25,6 @@ EXIT_REASONS = {
     EXIT_KUBERNETES_ABNORMAL: "Kubernetes task failed in an unexpected manner",
     EXIT_KUBERNETES_SPOT_INTERRUPTION: "Kubernetes task failed due to spot interruption",
     EXIT_KUBERNETES_NODE_SCALEDOWN: "Kubernetes task failed due to the autoscaler scaling down a node",
-    EXIT_KUBERNETES_TASK_LOST: "Tron lost track of a pod it already thought it had started for a job.",
+    EXIT_KUBERNETES_TASK_LOST: "Kubernetes task is lost and the final outcome unknown",
+    EXIT_KUBERNETES_EPHEMERAL_STORAGE_EVICTION: "Kubernetes task failed due to ephemeral storage eviction",
 }

--- a/tron/utils/exitcode.py
+++ b/tron/utils/exitcode.py
@@ -26,5 +26,5 @@ EXIT_REASONS = {
     EXIT_KUBERNETES_SPOT_INTERRUPTION: "Kubernetes task failed due to spot interruption",
     EXIT_KUBERNETES_NODE_SCALEDOWN: "Kubernetes task failed due to the autoscaler scaling down a node",
     EXIT_KUBERNETES_TASK_LOST: "Kubernetes task is lost and the final outcome unknown",
-    EXIT_KUBERNETES_EPHEMERAL_STORAGE_EVICTION: "Kubernetes task failed due to ephemeral storage eviction",
+    EXIT_KUBERNETES_EPHEMERAL_STORAGE_EVICTION: "Kubernetes task failed due to exceeding disk-space usage limits",
 }


### PR DESCRIPTION
## Problem
Tron currently thinks any pods evicted for disk reasons are spot terminated, which confuses folks who don't know what to look for. The new error -13 (spooky 🎺💀) will catch disk evictions.

## Solution
- Updated the current logic to look for an eviction message
- Fixed some typos

Tested in infrastage with a job that gets evicted and it works. I was also planning to include a hack to get this to the UI but I think I'll leave that to another time because it's kind of gross.