### PR TITLE
Enable disallow_untyped_decorators mypy option

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -4,7 +4,7 @@ python_version = 3.8
 # disallow_any_generics = true
 disallow_incomplete_defs = true
 # disallow_untyped_calls = true
-# disallow_untyped_decorators = true
+disallow_untyped_decorators = true
 # disallow_untyped_defs = true
 
 show_column_numbers = True


### PR DESCRIPTION
For once, a small mypy PR :p

There was just a single untyped decorator and I went ahead and wrote some inline comments 'cause I don't think I'll remember how to read this after this gets merged :deepfried-loljpg:

depends on https://github.com/Yelp/Tron/pull/1060 and https://github.com/Yelp/Tron/pull/1061