### PR TITLE
TRON-2340: Update tron unit file to ensure proper sigterm handling

### DIFF
--- a/debian/tron.service
+++ b/debian/tron.service
@@ -5,8 +5,10 @@ After=network.target
 [Service]
 User=tron
 EnvironmentFile=/etc/default/tron
-ExecStart=/usr/bin/zk-flock tron_master_${CLUSTER_NAME} "/usr/bin/trond --lock-file=${LOCKFILE:-$PIDFILE} --working-dir=${WORKINGDIR} --host ${LISTEN_HOST} --port ${LISTEN_PORT} ${DAEMON_OPTS}"
+ExecStart=/usr/bin/zk-flock -k 60 tron_master_${CLUSTER_NAME} "/usr/bin/trond --lock-file=${LOCKFILE:-$PIDFILE} --working-dir=${WORKINGDIR} --host ${LISTEN_HOST} --port ${LISTEN_PORT} ${DAEMON_OPTS}"
 ExecStopPost=/usr/bin/logger -t tron_exit_status "SERVICE_RESULT:${SERVICE_RESULT} EXIT_CODE:${EXIT_CODE} EXIT_STATUS:${EXIT_STATUS}"
+# This is generally not recommended, but we need to not send SIGKILL to the child trond process and instead let the SIGTERM from zk-flock propagate down
+KillMode=process
 TimeoutStopSec=20
 Restart=always
 LimitNOFILE=100000

--- a/debian/tron.service
+++ b/debian/tron.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 User=tron
 EnvironmentFile=/etc/default/tron
+ExecStartPre=/bin/bash -c 'if pgrep -x trond >/dev/null; then echo "ERROR: trond process already running" >&2; exit 1; fi'
 ExecStart=/usr/bin/zk-flock -k 60 tron_master_${CLUSTER_NAME} "/usr/bin/trond --lock-file=${LOCKFILE:-$PIDFILE} --working-dir=${WORKINGDIR} --host ${LISTEN_HOST} --port ${LISTEN_PORT} ${DAEMON_OPTS}"
 ExecStopPost=/usr/bin/logger -t tron_exit_status "SERVICE_RESULT:${SERVICE_RESULT} EXIT_CODE:${EXIT_CODE} EXIT_STATUS:${EXIT_STATUS}"
 # This is generally not recommended, but we need to not send SIGKILL to the child trond process and instead let the SIGTERM from zk-flock propagate down


### PR DESCRIPTION
Right now, our version of zk-flock will almost immediately (after a 1s delay) send a SIGKILL to the trond process during a restart, which prevents us from hitting all of our proper shutdown/cleanup code. 

With an [updated version](https://github.yelpcorp.com/packages/zk-flock/pull/25) of zk-flock, we can pass along a `--kill-timeout|-k` param to delay that SIGKILL, giving trond enough time to do what it needs to do. 

One other change required is that right now, we use the `KillMode` default of `control-group`: https://www.freedesktop.org/software/systemd/man/latest/systemd.kill.html which will kill all processes in the tree, including trond
Changing this to `KillMode=process` will ensure the SIGTERM is only sent to the parent process (zk-flock), which should then allow the signal to propagate to trond & proper handling to execute.   Per the docs this is not usually recommended, but I believe we should be able to ensure safety with the added `ExecPreStart` that will not attempt to start the service if there is still a running `trond` process. This has been tested on tron-infrastage and we seem to be able to restart the tron service w/o issue with this updated unit file. 

NB: A maybe simpler, but felt hackier approach is to override `ExecStop` to kill trond directly, which actually doesn't need to wait for an improved zk-flock: https://github.com/Yelp/tron/compare/master..u/jfong/pkill-trond-restart

Open to discussion/preferred options