### PR TITLE
Remove redundant log line because it's redundant

### DIFF
--- a/tron/commands/client.py
+++ b/tron/commands/client.py
@@ -195,7 +195,6 @@ class Client:
         return self.request(build_get_url(url, data))
 
     def request(self, url, data=None):
-        log.info(f"Request: {self.url_base}, {url}, {data}")
         uri = urllib.parse.urljoin(self.url_base, url)
         response = request(uri, data, headers=self.headers)
         if response.error:


### PR DESCRIPTION
Client.request() was logging the request details, and then calling the top-level request() function which also logged the same request. This change removes the redundant log from Client.request(), keeping the "lower-level" log which logs the final URI.