### PR TITLE
Reduce noise from tronctl commands

### DIFF
--- a/bin/tronctl
+++ b/bin/tronctl
@@ -118,6 +118,16 @@ def parse_cli():
                 "id", nargs="*", help=id_help_text
             ).completer = cmd_utils.tron_jobs_completer
 
+        # HACK: this is slightly funky since we already add --verbose in cmd_utils.build_option_parser(),
+        # but that requires something like tronctl --verbose start JOB rathter than tronctl start -v JOB
+        cmd_parsers[cmd_name].add_argument(
+            "-v",
+            "--verbose",
+            action="count",
+            help="Verbose logging",
+            default=None,
+        )
+
     # start
     cmd_parsers["start"].add_argument(
         "--run-date",
@@ -456,8 +466,12 @@ COMMANDS: Dict[str, Callable[[argparse.Namespace], Generator[bool, None, None]]]
 def main():
     """run tronctl"""
     args = parse_cli()
-    cmd_utils.setup_logging(args)
     cmd_utils.load_config(args)
+
+    # NOTE: we do this after load_configs() since load_config() may set some logging defaults that we want to override
+    desired_level = cmd_utils.setup_logging(args)
+    logging.getLogger().setLevel(desired_level)
+
     cmd = COMMANDS[args.command]
     try:
         for ret in cmd(args):

--- a/tron/commands/client.py
+++ b/tron/commands/client.py
@@ -195,7 +195,6 @@ class Client:
         return self.request(build_get_url(url, data))
 
     def request(self, url, data=None):
-        log.info(f"Request: {self.url_base}, {url}, {data}")
         uri = urllib.parse.urljoin(self.url_base, url)
         response = request(uri, data, headers=self.headers)
         if response.error:

--- a/tron/commands/cmd_utils.py
+++ b/tron/commands/cmd_utils.py
@@ -189,7 +189,7 @@ def save_config(options):
     write_config(config)
 
 
-def setup_logging(options):
+def setup_logging(options: argparse.Namespace) -> int:
     if options.verbose is None:
         level = logging.CRITICAL
     elif options.verbose == 1:
@@ -204,6 +204,8 @@ def setup_logging(options):
         format="%(name)s %(levelname)s %(message)s",
         stream=sys.stdout,
     )
+
+    return level
 
 
 def suggest_possibilities(word, possibilities, max_suggestions=6):


### PR DESCRIPTION
See the individual commits for more details, but this should significantly reduce visual noise when running tronctl commands:
```
> bin/tronctl --server 'http://tron-infrastage.yelpcorp.com:8089/' enable katamari_test_service.test_load_foo2
Job:katamari_test_service.test_load_foo2 is enabled

> bin/tronctl --server 'http://tron-infrastage.yelpcorp.com:8089/' enable katamari_test_service.test_load_foo2 -v
Job:katamari_test_service.test_load_foo2 is enabled

> bin/tronctl --server 'http://tron-infrastage.yelpcorp.com:8089/' enable katamari_test_service.test_load_foo2 -vv
INFO - tron.commands.client - Request to http://tron-infrastage.yelpcorp.com:8089/api/ with None
INFO - tron.commands.client - Request to http://tron-infrastage.yelpcorp.com:8089/api/jobs/katamari_test_service.test_load_foo2 with {'command': 'enable'}
Job:katamari_test_service.test_load_foo2 is enabled

> bin/tronctl --server 'http://tron-infrastage.yelpcorp.com:8089/' enable katamari_test_service.test_load_foo2 -vvv
INFO - tron.commands.client - Request to http://tron-infrastage.yelpcorp.com:8089/api/ with None
INFO - tron.commands.client - Request to http://tron-infrastage.yelpcorp.com:8089/api/jobs/katamari_test_service.test_load_foo2 with {'command': 'enable'}
Job:katamari_test_service.test_load_foo2 is enabled

# this is the existing output
> tronctl-infrastage enable katamari_test_service.test_load_foo2
INFO - tron.commands.client - Request: http://tron-infrastage.yelpcorp.com:8089, /api/, None
INFO - tron.commands.client - Request to http://tron-infrastage.yelpcorp.com:8089/api/ with None
INFO - tron.commands.client - Request to http://tron-infrastage.yelpcorp.com:8089/api/jobs/katamari_test_service.test_load_foo2 with {'command': 'enable'}
Job:katamari_test_service.test_load_foo2 is enabled
```