### PR TITLE
TRON-2477: Do some more validation of TimeSpecs

### DIFF
--- a/tron/utils/trontimespec.py
+++ b/tron/utils/trontimespec.py
@@ -177,6 +177,16 @@ class TimeSpecification:
             [],
             True,
         )
+
+        if self.monthdays and self.months:
+            month_max_days = []
+            for month in self.months:
+                month_max_days.append(calendar.monthrange(1972, month)[1])  # Use leap year as base to allow feb 29 jobs
+            max_days = max(month_max_days)
+            for day in self.monthdays:
+                if day != TOKEN_LAST and day > max_days:
+                    raise ValueError(f"Day {day} does not exist in month {month}")
+
         self.timezone = get_timezone(timezone)
 
     def next_day(self, first_day, year, month):

--- a/tron/utils/trontimespec.py
+++ b/tron/utils/trontimespec.py
@@ -258,6 +258,9 @@ class TimeSpecification:
             return start_date.day
 
         for month, year in self.next_month(start_date):
+            if year > datetime.MAXYEAR:
+                raise ValueError(f"Year {year} is out of range, cannot find match")
+
             first_day = get_first_day(month, year)
 
             for day in self.next_day(first_day, year, month):

--- a/tron/utils/trontimespec.py
+++ b/tron/utils/trontimespec.py
@@ -185,7 +185,7 @@ class TimeSpecification:
             max_days = max(month_max_days)
             for day in self.monthdays:
                 if day != TOKEN_LAST and day > max_days:
-                    raise ValueError(f"Day {day} does not exist in month {month}")
+                    raise ValueError(f"Day {day} does not exist in any specified month ({self.months})")
 
         self.timezone = get_timezone(timezone)
 


### PR DESCRIPTION
We ran into an infinite loop in our current TimeSpecification.get_match when asked for the next 30th of februrary, for example. 

Other similar impossible job schedules such as April 31 would have run into the same issue.  I considered changing this in the schedule parsing logic, but this will catch if (in the extremely slim chance) someone also specified an impossible date  using our complex scheduling format (`groc daily`, `value: 30th day in feb`). 

In this PR, we now do not allow an invalid TimeSpecificaation to be created, and when initially scheduling the next job runs, we check whether we get a valid TimeSpecification back, and if not, simply print an error in our logs and skip that job in our JobCollection.

In general, I do think our yelpsoa-configs validation should prevent us from even getting here again and will provide a better interface to job owners that show the invalid config, but if config on disk/in memory was ever able to get into a bad state like this, these changes would allow tron to continue gracefully, simply skipping that job with an invalid schedule. In addition, config change requests would succeed if provided with a new, valid schedule. 

In addition to the TimeSpecification tests, I've tested locally and ensured if tron starts w/ an invalid schedule, it simply skips:
```
2025-08-28 13:12:22,169 tron.core.job_collection ERROR Failed to build job 'MASTER.testjob0': Day 30 does not exist in any specified month ([2]). Skipping job.
```
One unintuitive behavior as a result of this change is that the job will also no longer be shown in tronweb, though it persists in config, which could potentially lead to confusion.  That said, I think trying to add the job but ensure everything down the line can properly handle+display appropriate warnings when it has an impossible schedule may be more trouble than this edge case is worth, tbh. I'm happy to give it a shot though if ppl think the opposite. 

