### PR TITLE
Document which command context time placeholders respect TZ

### DIFF
--- a/docs/source/command_context.rst
+++ b/docs/source/command_context.rst
@@ -29,30 +29,36 @@ The command would get rendered at job runtime to::
     Run date in ``YYYY-MM-DD`` format. Supports simple arithmetic of the
     form ``{shortdate+6}`` which returns a date 6 days in the future,
     ``{shortdate-2}`` which returns a date 2 days before the run date.
+    NOTE: this takes into account the job's configured timezone, if any.
 
 **ym, ymd, ymdh, ymdhm**
     Same as ``shortdate`` but better granularity. Arithmetic works with most
     granular unit: ``ymdh+1`` is  +1 hours, ``ymdhm+1`` is +1 minute.
+    NOTE: this takes into account the job's configured timezone, if any.
 
 **year**
     Current year in ``YYYY`` format. Supports the same arithmetic operations
     as `shortdate`. For example, ``{year-1}`` would return the year previous
     to the run date.
+    NOTE: this takes into account the job's configured timezone, if any.
 
 **month**
     Current month in `MM` format. Supports the same arithmetic operations
     as `shortdate`. For example, ``{month+2}`` would return 2 months in the
     future.
+    NOTE: this takes into account the job's configured timezone, if any.
 
 **day**
     Current day in `DD` format. Supports the same arithmetic operations
     as `shortdate`. For example, ``{day+1}`` would return the day after the
     run date.
+    NOTE: this takes into account the job's configured timezone, if any.
 
 **hour**
     Current hour in `HH` (0-23) format. Supports the same arithmetic operations
     as `shortdate`. For example, ``{hour+1}`` would return the hour after the
     run hour (mod 24).
+    NOTE: this takes into account the job's configured timezone, if any.
 
 **unixtime**
     Current timestamp. Supports addition and subtraction of seconds. For
@@ -63,6 +69,7 @@ The command would get rendered at job runtime to::
     Current day number as an ordinal (datetime.toordinal()). Supports addition
     and subtraction of days. For example ``{daynumber-3}`` would be 3 days
     before the run date.
+    NOTE: this takes into account the job's configured timezone, if any.
 
 **name**
     Name of the job (e.g. ``myservice.myjob``).


### PR DESCRIPTION
An onpoint question was recently asked around the behavior of the ymdhm context and its interaction with the job's timezone - I had to create a temp job to test this since I couldn't confirm/deny if the timezone was applied by just following the code.

Since all of these use the same code - all of these should respect TZ (apart from unixtime, since that's TZ-independent :p)