### PR TITLE
Support relaying a datetime to `start` commands from tronctl

### DIFF
--- a/bin/tronctl
+++ b/bin/tronctl
@@ -13,6 +13,7 @@ import sys
 from collections import defaultdict
 from collections.abc import Callable
 from collections.abc import Generator
+from functools import partial
 from typing import Any
 from urllib.parse import urljoin
 
@@ -127,7 +128,7 @@ def parse_cli():
     # start
     cmd_parsers["start"].add_argument(
         "--run-date",
-        type=parse_date,
+        type=partial(parse_date, allow_datetime=True),
         dest="run_date",
         help="What the run-date should be set to",
     )
@@ -137,13 +138,13 @@ def parse_cli():
     mutex_dates_group = backfill_parser.add_mutually_exclusive_group(required=True)
     mutex_dates_group.add_argument(
         "--start-date",
-        type=parse_date,
+        type=partial(parse_date, allow_datetime=False),
         dest="start_date",
         help="First run-date to backfill",
     )
     backfill_parser.add_argument(
         "--end-date",
-        type=parse_date,
+        type=partial(parse_date, allow_datetime=False),
         dest="end_date",
         help=(
             "Last run-date to backfill (note: many jobs operate on date-1), "

--- a/bin/tronctl
+++ b/bin/tronctl
@@ -33,6 +33,7 @@ from tron.commands.client import RequestError
 from tron.commands.client import TronObjectIdentifier
 from tron.commands.cmd_utils import COLOR_YELLOW
 from tron.commands.cmd_utils import ExitCode
+from tron.commands.cmd_utils import parse_date
 from tron.commands.cmd_utils import suggest_possibilities
 from tron.commands.cmd_utils import tron_jobs_completer
 from tron.commands.cmd_utils import warning_output
@@ -99,10 +100,6 @@ COMMAND_HELP = (
 )
 
 log = logging.getLogger("tronctl")
-
-
-def parse_date(date_string):
-    return datetime.datetime.strptime(date_string, "%Y-%m-%d")
 
 
 def parse_cli():

--- a/tests/commands/cmd_utils_test.py
+++ b/tests/commands/cmd_utils_test.py
@@ -1,11 +1,33 @@
 import argparse
+import datetime
 from unittest import mock
+
+import pytest
 
 from testifycompat import assert_equal
 from testifycompat import assert_in
 from testifycompat import setup_teardown
 from testifycompat import TestCase
 from tron.commands import cmd_utils
+
+
+@pytest.mark.parametrize(
+    "date_string,expected",
+    [
+        ("2026-07-08", datetime.datetime(2026, 7, 8)),
+        ("2026-07-08 12:50", datetime.datetime(2026, 7, 8, 12, 50)),
+        ("2026-07-08 12:50:30", datetime.datetime(2026, 7, 8, 12, 50, 30)),
+        ("2026-07-08T12:50", datetime.datetime(2026, 7, 8, 12, 50)),
+        ("2026-07-08T12:50:30", datetime.datetime(2026, 7, 8, 12, 50, 30)),
+    ],
+)
+def test_parse_date_valid(date_string, expected):
+    assert cmd_utils.parse_date(date_string) == expected
+
+
+def test_parse_date_invalid():
+    with pytest.raises(ValueError):
+        cmd_utils.parse_date("not-a-date")
 
 
 class TestGetConfig(TestCase):

--- a/tests/commands/cmd_utils_test.py
+++ b/tests/commands/cmd_utils_test.py
@@ -21,8 +21,17 @@ from tron.commands import cmd_utils
         ("2026-07-08T12:50:30", datetime.datetime(2026, 7, 8, 12, 50, 30)),
     ],
 )
-def test_parse_date_valid(date_string, expected):
-    assert cmd_utils.parse_date(date_string) == expected
+def test_parse_date_valid_with_datetime(date_string, expected):
+    assert cmd_utils.parse_date(date_string, allow_datetime=True) == expected
+
+
+def test_parse_date_valid_date_only():
+    assert cmd_utils.parse_date("2026-07-08") == datetime.datetime(2026, 7, 8)
+
+
+def test_parse_date_rejects_datetime_when_not_allowed():
+    with pytest.raises(ValueError, match="Try: YYYY-MM-DD."):
+        cmd_utils.parse_date("2026-07-08T12:50:30")
 
 
 def test_parse_date_invalid():

--- a/tron/commands/cmd_utils.py
+++ b/tron/commands/cmd_utils.py
@@ -210,15 +210,20 @@ def setup_logging(options: argparse.Namespace) -> int:
     return level
 
 
-def parse_date(date_string: str) -> datetime.datetime:
-    for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M", "%Y-%m-%d"):
+def parse_date(date_string: str, allow_datetime: bool = False) -> datetime.datetime:
+    if allow_datetime:
+        formats = ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M", "%Y-%m-%d")
+        hint = "YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS"
+    else:
+        formats = ("%Y-%m-%d",)
+        hint = "YYYY-MM-DD"
+
+    for fmt in formats:
         try:
             return datetime.datetime.strptime(date_string, fmt)
         except ValueError:
             continue
-    raise ValueError(
-        f"Unable to parse date '{date_string}'. Try a common format such as YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS."
-    )
+    raise ValueError(f"Unable to parse date '{date_string}'. Try: {hint}.")
 
 
 def suggest_possibilities(word, possibilities, max_suggestions=6):

--- a/tron/commands/cmd_utils.py
+++ b/tron/commands/cmd_utils.py
@@ -2,6 +2,7 @@
 Common code for command line utilities (see bin/)
 """
 import argparse
+import datetime
 import difflib
 import logging
 import os
@@ -207,6 +208,17 @@ def setup_logging(options: argparse.Namespace) -> int:
     )
 
     return level
+
+
+def parse_date(date_string: str) -> datetime.datetime:
+    for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M", "%Y-%m-%d"):
+        try:
+            return datetime.datetime.strptime(date_string, fmt)
+        except ValueError:
+            continue
+    raise ValueError(
+        f"Unable to parse date '{date_string}'. Try a common format such as YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS."
+    )
 
 
 def suggest_possibilities(word, possibilities, max_suggestions=6):

--- a/tron/commands/cmd_utils.py
+++ b/tron/commands/cmd_utils.py
@@ -212,10 +212,10 @@ def setup_logging(options: argparse.Namespace) -> int:
 
 def parse_date(date_string: str, allow_datetime: bool = False) -> datetime.datetime:
     if allow_datetime:
-        formats = ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M", "%Y-%m-%d")
+        formats = ["%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M", "%Y-%m-%d"]
         hint = "YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS"
     else:
-        formats = ("%Y-%m-%d",)
+        formats = ["%Y-%m-%d"]
         hint = "YYYY-MM-DD"
 
     for fmt in formats:


### PR DESCRIPTION
Today, tronctl start and tronctl backfill commands accept date-only parameters because they use the `parse_date` helper which only knows the `%Y-%m-%d` format. 

However, this meant t hat we would never be able to initiate a run with a custom start _time_, e.g. to backfill a sub-daily (eg hourly) job. 

The `start` support in the api, however, doesn't seem to reduce the `run_time` param to just a date: 
resource.py's [render_POST](https://github.com/Yelp/Tron/blob/master/tron/api/resource.py#L280) -> requestarg's [get_datetime](https://github.com/Yelp/Tron/blob/master/tron/api/requestargs.py#L55C48-L55C59) -> [DATE_FORMAT](https://github.com/Yelp/Tron/blob/master/tron/api/requestargs.py#L5) which includes time (`"%Y-%m-%d %H:%M:%S"`)

This PR expands the supported formats in parse_date to some common datetime formats.  I also took the opportunity to move it to our shared cmd_utils rather than leaving it just in tronctl itself, and added some dumb tests. 

This change won't help `tronctl backfill` generate more than daily schedules, but at least allows folks to work around that limitation and send their own datetime thru `tronctl start`. 
