### PR TITLE
look at jobs that run more frequently than x minutes

### DIFF
--- a/tools/count_frequent_tron_jobs.py
+++ b/tools/count_frequent_tron_jobs.py
@@ -1,5 +1,13 @@
-#!/usr/bin/env python3
-"""List Tron jobs whose schedule fires at or under a given frequency threshold."""
+"""
+List Tron jobs whose schedule fires at or under a given frequency threshold.
+
+The script takes two arguments:
+
+--minutes: The threshold in minutes (inclusive)
+--repo: path to yelpsoa-configs (the script goes through all tron-*.yaml files under the repo)
+
+both arguments are required.
+"""
 import argparse
 import glob
 import os
@@ -69,13 +77,11 @@ def cron_frequency_minutes(cron_expr):
         return 1440  # fires once per day
 
     # Minimum gap between consecutive fires (wrapping midnight)
-    gaps = []
-    for i in range(len(fire_times)):
-        next_time = fire_times[(i + 1) % len(fire_times)]
-        curr_time = fire_times[i]
-        gap = (next_time - curr_time) % 1440
-        if gap > 0:
-            gaps.append(gap)
+    gaps = [
+        gap
+        for i in range(len(fire_times))
+        if (gap := (fire_times[(i + 1) % len(fire_times)] - fire_times[i]) % 1440) > 0
+    ]
 
     return min(gaps) if gaps else 1440
 
@@ -98,16 +104,16 @@ def normalize_schedule(schedule):
             return ("groc", None, raw)
 
     if isinstance(schedule, dict):
-        raw = str(schedule)
         stype = schedule.get("type", "")
         if stype == "cron":
-            return ("cron", schedule.get("value", ""), raw)
+            value = schedule.get("value", "")
+            return ("cron", value, f"cron {value}")
         elif stype == "daily":
-            return ("daily", None, raw)
+            return ("daily", None, str(schedule))
         elif "start_time" in schedule:
-            return ("daily", None, raw)
+            return ("daily", None, str(schedule))
         else:
-            return ("groc", None, raw)
+            return ("groc", None, str(schedule))
 
     return ("groc", None, str(schedule))
 
@@ -142,7 +148,7 @@ def main():
     parser.add_argument(
         "--repo",
         required=True,
-        help="Path to yelpsoa-configs checkout root (the directory containing service subdirectories)",
+        help="Path to yelpsoa-configs root (the directory containing service subdirectories)",
     )
     args = parser.parse_args()
 
@@ -182,6 +188,13 @@ def main():
                 if freq is not None and freq <= args.minutes:
                     _, _, raw = normalize_schedule(schedule)
                     results.append((freq, service, key, raw))
+
+    seen = {}
+    for freq, service, job_name, raw in results:
+        dedup_key = (service, job_name)
+        if dedup_key not in seen or freq < seen[dedup_key][0]:
+            seen[dedup_key] = (freq, raw)
+    results = [(freq, svc, job, raw) for (svc, job), (freq, raw) in seen.items()]
 
     results.sort(key=lambda r: (r[0], r[1], r[2]))
 

--- a/tools/count_frequent_tron_jobs.py
+++ b/tools/count_frequent_tron_jobs.py
@@ -3,17 +3,35 @@ List Tron jobs whose schedule fires at or under a given frequency threshold.
 
 The script takes two arguments:
 
---minutes: The threshold in minutes (inclusive)
---repo: path to yelpsoa-configs (the script goes through all tron-*.yaml files under the repo)
+It pulls data from the Tron API and analyzes the cron schedules for each job in the response.
 
-both arguments are required.
+Arguments:
+    --minutes: The threshold in minutes (inclusive)
+    --cluster: The Tron cluster to query (default: pnw-prod)
+
+    --url: Override base URL for the Tron API (this one is optional, we can use it to test with the other Tron clusters)
+
+Example usage:
+
+For prod:
+    python count_frequent_tron_jobs.py --minutes 30 --cluster pnw-prod
+    (you could skip the --cluster argument and just use minutes for easier testing)
+For devc cluster:
+    python count_frequent_tron_jobs.py --minutes 30 --cluster pnw-devc
+
+For testing with the other Tron clusters:
+    python count_frequent_tron_jobs.py --minutes 30 --url http://tron-pnw-infrastage.yelpcorp.com
 """
 import argparse
-import glob
-import os
 import sys
 
-import yaml
+import requests
+
+
+CLUSTER_URLS = {
+    "pnw-prod": "https://tron-pnw-prod-api.yelpcorp.com",
+    "pnw-devc": "http://tron-pnw-devc.yelpcorp.com",
+}
 
 
 def expand_cron_field(field_str, min_val, max_val):
@@ -53,7 +71,7 @@ CRON_ALIASES = {
 
 
 def cron_frequency_minutes(cron_expr):
-    """Return the minimum interval in minutes between consecutive fires of a cron expression."""
+    """This computes and returns the minimum interval in minutes between consecutive fires of a cron expression."""
     expr = cron_expr.strip()
     if expr in CRON_ALIASES:
         expr = CRON_ALIASES[expr]
@@ -70,13 +88,11 @@ def cron_frequency_minutes(cron_expr):
     if not minutes or not hours:
         return None
 
-    # Build all (hour, minute) fire times in a 24h window, sorted
     fire_times = sorted(h * 60 + m for h in hours for m in minutes)
 
     if len(fire_times) == 1:
-        return 1440  # fires once per day
+        return 1440
 
-    # Minimum gap between consecutive fires (wrapping midnight)
     gaps = [
         gap
         for i in range(len(fire_times))
@@ -89,7 +105,7 @@ def cron_frequency_minutes(cron_expr):
 def normalize_schedule(schedule):
     """
     Return (schedule_type, cron_expr_or_None, raw_string).
-    schedule_type is one of: 'cron', 'daily', 'groc', 'disabled'.
+    schedule_type were taken from the original script that parsed from yelpsoa-configs repo
     """
     if schedule is None or schedule == "":
         return ("disabled", None, str(schedule))
@@ -119,25 +135,34 @@ def normalize_schedule(schedule):
 
 
 def compute_frequency(schedule):
-    """Return frequency in minutes, or None if disabled/unparseable."""
+    """Return frequency in minutes, or None if cannot be computed. We return 1440 for any schedule that goes over a day"""
     stype, cron_expr, _ = normalize_schedule(schedule)
     if stype == "disabled":
         return None
     if stype in ("daily", "groc"):
         return 1440
     freq = cron_frequency_minutes(cron_expr)
+    if stype is None:
+        print(f"Unknown schedule type: {schedule}")
     return freq
 
 
-def find_tron_files(repo_root):
-    pattern = os.path.join(repo_root, "*/tron-*.yaml")
-    return glob.glob(pattern)
+def fetch_jobs_from_api(base_url):
+    """Fetch all jobs from the Tron API with minimal payload."""
+    url = f"{base_url}/api/jobs?include_job_runs=0&include_action_runs=0&include_action_graph=0&include_node_pool=0"
+    try:
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching jobs from {base_url}: {e}", file=sys.stderr)
+        sys.exit(1)
+    return response.json()["jobs"]
 
 
 def main():
     parser = argparse.ArgumentParser(
         description="List Tron jobs firing at or under a frequency threshold.",
-        epilog="Example: %(prog)s --repo /path/to/yelpsoa-configs --minutes 30",
+        epilog="Example: %(prog)s --cluster pnw-prod --minutes 30",
     )
     parser.add_argument(
         "--minutes",
@@ -146,55 +171,30 @@ def main():
         help="Threshold in minutes (inclusive)",
     )
     parser.add_argument(
-        "--repo",
-        required=True,
-        help="Path to yelpsoa-configs root (the directory containing service subdirectories)",
+        "--cluster",
+        choices=CLUSTER_URLS.keys(),
+        default="pnw-prod",
+        help="Tron cluster to query (default: pnw-prod)",
+    )
+    parser.add_argument(
+        "--url",
+        help="Override base URL for the Tron API (takes precedence over --cluster)",
     )
     args = parser.parse_args()
 
-    tron_files = find_tron_files(args.repo)
-    if not tron_files:
-        print(f"No tron-*.yaml files found under {args.repo}", file=sys.stderr)
-        sys.exit(1)
+    base_url = args.url if args.url else CLUSTER_URLS[args.cluster]
+
+    jobs = fetch_jobs_from_api(base_url)
 
     results = []
-    for filepath in sorted(tron_files):
-        service = os.path.basename(os.path.dirname(filepath))
-        try:
-            with open(filepath) as f:
-                data = yaml.safe_load(f)
-        except Exception as e:
-            print(f"Warning: could not parse {filepath}: {e}", file=sys.stderr)
-            continue
-
-        if not isinstance(data, dict):
-            continue
-
-        for key, job in data.items():
-            if key == "jobs" and isinstance(job, dict):
-                # tron-<cluster>.yaml top-level 'jobs:' dict
-                for job_name, job_def in job.items():
-                    if not isinstance(job_def, dict):
-                        continue
-                    schedule = job_def.get("schedule")
-                    freq = compute_frequency(schedule)
-                    if freq is not None and freq <= args.minutes:
-                        _, _, raw = normalize_schedule(schedule)
-                        results.append((freq, service, job_name, raw))
-            elif isinstance(job, dict) and "schedule" in job:
-                # direct job dict at top level
-                schedule = job.get("schedule")
-                freq = compute_frequency(schedule)
-                if freq is not None and freq <= args.minutes:
-                    _, _, raw = normalize_schedule(schedule)
-                    results.append((freq, service, key, raw))
-
-    seen = {}
-    for freq, service, job_name, raw in results:
-        dedup_key = (service, job_name)
-        if dedup_key not in seen or freq < seen[dedup_key][0]:
-            seen[dedup_key] = (freq, raw)
-    results = [(freq, svc, job, raw) for (svc, job), (freq, raw) in seen.items()]
+    for job in jobs:
+        name = job["name"]
+        scheduler = job.get("scheduler")
+        freq = compute_frequency(scheduler)
+        if freq is not None and freq <= args.minutes:
+            _, _, raw = normalize_schedule(scheduler)
+            namespace, _, job_name = name.partition(".")
+            results.append((freq, namespace, job_name, raw))
 
     results.sort(key=lambda r: (r[0], r[1], r[2]))
 
@@ -202,21 +202,22 @@ def main():
         print(f"No jobs found firing every {args.minutes} minutes or less.")
         return
 
-    col_svc = max(len("SERVICE"), max(len(r[1]) for r in results))
+    col_ns = max(len("NAMESPACE"), max(len(r[1]) for r in results))
     col_job = max(len("JOB NAME"), max(len(r[2]) for r in results))
     col_sched = max(len("SCHEDULE"), max(len(r[3]) for r in results))
     col_freq = len("FREQ (min)")
 
     header = (
-        f"{'SERVICE':<{col_svc}}  {'JOB NAME':<{col_job}}  " f"{'SCHEDULE':<{col_sched}}  {'FREQ (min)':<{col_freq}}"
+        f"{'NAMESPACE':<{col_ns}}  {'JOB NAME':<{col_job}}  " f"{'SCHEDULE':<{col_sched}}  {'FREQ (min)':<{col_freq}}"
     )
     print(header)
     print("-" * len(header))
 
-    for freq, service, job_name, raw_sched in results:
-        print(f"{service:<{col_svc}}  {job_name:<{col_job}}  " f"{raw_sched:<{col_sched}}  {freq:<{col_freq}}")
+    for freq, namespace, job_name, raw_sched in results:
+        print(f"{namespace:<{col_ns}}  {job_name:<{col_job}}  " f"{raw_sched:<{col_sched}}  {freq:<{col_freq}}")
 
     print(f"\nTotal: {len(results)} job(s) fire every {args.minutes} minutes or less.")
+    print(f"Total jobs: {len(jobs)}")
 
 
 if __name__ == "__main__":

--- a/tools/count_frequent_tron_jobs.py
+++ b/tools/count_frequent_tron_jobs.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""List Tron jobs whose schedule fires at or under a given frequency threshold."""
+import argparse
+import glob
+import os
+import sys
+
+import yaml
+
+
+def expand_cron_field(field_str, min_val, max_val):
+    """Expand a cron field string to a sorted list of concrete int values."""
+    values = set()
+    for part in field_str.split(","):
+        if part == "*":
+            values.update(range(min_val, max_val + 1))
+        elif part.startswith("*/"):
+            step = int(part[2:])
+            values.update(range(min_val, max_val + 1, step))
+        elif "/" in part:
+            range_part, step = part.split("/", 1)
+            step = int(step)
+            if "-" in range_part:
+                start, end = range_part.split("-", 1)
+                values.update(range(int(start), int(end) + 1, step))
+            else:
+                values.update(range(int(range_part), max_val + 1, step))
+        elif "-" in part:
+            start, end = part.split("-", 1)
+            values.update(range(int(start), int(end) + 1))
+        else:
+            values.add(int(part))
+    return sorted(values)
+
+
+CRON_ALIASES = {
+    "@yearly": "0 0 1 1 *",
+    "@annually": "0 0 1 1 *",
+    "@monthly": "0 0 1 * *",
+    "@weekly": "0 0 * * 0",
+    "@daily": "0 0 * * *",
+    "@midnight": "0 0 * * *",
+    "@hourly": "0 * * * *",
+}
+
+
+def cron_frequency_minutes(cron_expr):
+    """Return the minimum interval in minutes between consecutive fires of a cron expression."""
+    expr = cron_expr.strip()
+    if expr in CRON_ALIASES:
+        expr = CRON_ALIASES[expr]
+
+    parts = expr.split()
+    if len(parts) != 5:
+        return None
+
+    minute_field, hour_field = parts[0], parts[1]
+
+    minutes = expand_cron_field(minute_field, 0, 59)
+    hours = expand_cron_field(hour_field, 0, 23)
+
+    if not minutes or not hours:
+        return None
+
+    # Build all (hour, minute) fire times in a 24h window, sorted
+    fire_times = sorted(h * 60 + m for h in hours for m in minutes)
+
+    if len(fire_times) == 1:
+        return 1440  # fires once per day
+
+    # Minimum gap between consecutive fires (wrapping midnight)
+    gaps = []
+    for i in range(len(fire_times)):
+        next_time = fire_times[(i + 1) % len(fire_times)]
+        curr_time = fire_times[i]
+        gap = (next_time - curr_time) % 1440
+        if gap > 0:
+            gaps.append(gap)
+
+    return min(gaps) if gaps else 1440
+
+
+def normalize_schedule(schedule):
+    """
+    Return (schedule_type, cron_expr_or_None, raw_string).
+    schedule_type is one of: 'cron', 'daily', 'groc', 'disabled'.
+    """
+    if schedule is None or schedule == "":
+        return ("disabled", None, str(schedule))
+
+    if isinstance(schedule, str):
+        raw = schedule
+        if schedule.startswith("cron "):
+            return ("cron", schedule[5:].strip(), raw)
+        elif schedule.startswith("daily "):
+            return ("daily", None, raw)
+        else:
+            return ("groc", None, raw)
+
+    if isinstance(schedule, dict):
+        raw = str(schedule)
+        stype = schedule.get("type", "")
+        if stype == "cron":
+            return ("cron", schedule.get("value", ""), raw)
+        elif stype == "daily":
+            return ("daily", None, raw)
+        elif "start_time" in schedule:
+            return ("daily", None, raw)
+        else:
+            return ("groc", None, raw)
+
+    return ("groc", None, str(schedule))
+
+
+def compute_frequency(schedule):
+    """Return frequency in minutes, or None if disabled/unparseable."""
+    stype, cron_expr, _ = normalize_schedule(schedule)
+    if stype == "disabled":
+        return None
+    if stype in ("daily", "groc"):
+        return 1440
+    freq = cron_frequency_minutes(cron_expr)
+    return freq
+
+
+def find_tron_files(repo_root):
+    pattern = os.path.join(repo_root, "*/tron-*.yaml")
+    return glob.glob(pattern)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="List Tron jobs firing at or under a frequency threshold.",
+        epilog="Example: %(prog)s --repo /path/to/yelpsoa-configs --minutes 30",
+    )
+    parser.add_argument(
+        "--minutes",
+        type=int,
+        required=True,
+        help="Threshold in minutes (inclusive)",
+    )
+    parser.add_argument(
+        "--repo",
+        required=True,
+        help="Path to yelpsoa-configs checkout root (the directory containing service subdirectories)",
+    )
+    args = parser.parse_args()
+
+    tron_files = find_tron_files(args.repo)
+    if not tron_files:
+        print(f"No tron-*.yaml files found under {args.repo}", file=sys.stderr)
+        sys.exit(1)
+
+    results = []
+    for filepath in sorted(tron_files):
+        service = os.path.basename(os.path.dirname(filepath))
+        try:
+            with open(filepath) as f:
+                data = yaml.safe_load(f)
+        except Exception as e:
+            print(f"Warning: could not parse {filepath}: {e}", file=sys.stderr)
+            continue
+
+        if not isinstance(data, dict):
+            continue
+
+        for key, job in data.items():
+            if key == "jobs" and isinstance(job, dict):
+                # tron-<cluster>.yaml top-level 'jobs:' dict
+                for job_name, job_def in job.items():
+                    if not isinstance(job_def, dict):
+                        continue
+                    schedule = job_def.get("schedule")
+                    freq = compute_frequency(schedule)
+                    if freq is not None and freq <= args.minutes:
+                        _, _, raw = normalize_schedule(schedule)
+                        results.append((freq, service, job_name, raw))
+            elif isinstance(job, dict) and "schedule" in job:
+                # direct job dict at top level
+                schedule = job.get("schedule")
+                freq = compute_frequency(schedule)
+                if freq is not None and freq <= args.minutes:
+                    _, _, raw = normalize_schedule(schedule)
+                    results.append((freq, service, key, raw))
+
+    results.sort(key=lambda r: (r[0], r[1], r[2]))
+
+    if not results:
+        print(f"No jobs found firing every {args.minutes} minutes or less.")
+        return
+
+    col_svc = max(len("SERVICE"), max(len(r[1]) for r in results))
+    col_job = max(len("JOB NAME"), max(len(r[2]) for r in results))
+    col_sched = max(len("SCHEDULE"), max(len(r[3]) for r in results))
+    col_freq = len("FREQ (min)")
+
+    header = (
+        f"{'SERVICE':<{col_svc}}  {'JOB NAME':<{col_job}}  " f"{'SCHEDULE':<{col_sched}}  {'FREQ (min)':<{col_freq}}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for freq, service, job_name, raw_sched in results:
+        print(f"{service:<{col_svc}}  {job_name:<{col_job}}  " f"{raw_sched:<{col_sched}}  {freq:<{col_freq}}")
+
+    print(f"\nTotal: {len(results)} job(s) fire every {args.minutes} minutes or less.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Updated 2026-07-31: 

This is a tool that identifies Tron jobs that run too frequently for the Airflow migration (TRON-2630)

It takes the following arguments:

--minutes: max interval to search for, this is inclusive.
--Cluster: cluster to fetch data from (default is pnw-prod and you can skip the argument if that is the cluster you want)

The script reads the schedule config from each tron job config in the API response and then aggregates a list of jobs that run at or under the desired timeframe.

### Example Output:
```
SERVICE                     JOB NAME                                                     SCHEDULE             FREQ (min)
------------------------------------------------------------------------------------------------------------------------
jupyter_folium              schedule_run_notebook                                        cron */1 * * * *     1         
nowait-server               _1m_job_template                                             cron */1 * * * *     1         
nowait-server               get_cc_hold_charge_state                                     cron */1 * * * *     1         
video                       retry_video_processing                                       cron * * * * *       1         
yelp-main                   log_in_flight_bulk_update_tasks                              cron * * * * *       1             
```