### PR TITLE
add default max_runtime

### DIFF
--- a/tests/config/config_parse_test.py
+++ b/tests/config/config_parse_test.py
@@ -158,7 +158,7 @@ def make_job(**kwargs):
     kwargs.setdefault("run_limit", 50)
     kwargs.setdefault("all_nodes", False)
     kwargs.setdefault("cleanup_action", make_cleanup_action())
-    kwargs.setdefault("max_runtime")
+    kwargs.setdefault("max_runtime", datetime.timedelta(hours=36))
     kwargs.setdefault("allow_overlap", False)
     kwargs.setdefault("time_zone", None)
     kwargs.setdefault("expected_runtime", datetime.timedelta(0, 3600))

--- a/tron/config/config_parse.py
+++ b/tron/config/config_parse.py
@@ -774,7 +774,7 @@ class ValidateJob(Validator):
         "enabled": True,
         "queueing": True,
         "allow_overlap": False,
-        "max_runtime": None,
+        "max_runtime": datetime.timedelta(hours=36),
         "monitoring": {},
         "time_zone": None,
         "expected_runtime": datetime.timedelta(hours=24),


### PR DESCRIPTION
Changes to default max_runtime as preparation to Airflow migration. Airflow max job runtime is 12 hours.

I chose the 36h default after making some calls to the Tron API and measuring the max runtime duration I could find, which hovered over 18 hours. This should be a safe starting point to avoid prematurely killing any ongoing or future Tron jobs.

Tests passed.