### PR TITLE
First run of a new job is never persisted to dynamodb

### DIFF
--- a/tests/core/job_collection_test.py
+++ b/tests/core/job_collection_test.py
@@ -31,6 +31,16 @@ class TestJobCollection(TestCase):
             job_scheduler.schedule.assert_called_with()
             job_scheduler.get_job.assert_called_with()
 
+    def test_map_to_job_and_schedule(self):
+        autospec_method(self.collection.jobs.filter_by_name)
+        autospec_method(self.collection.add)
+        factory = mock.create_autospec(JobSchedulerFactory)
+        job_configs = {"a": mock.Mock(), "b": mock.Mock()}
+        generator = self.collection.update_from_config(job_configs, factory, True)
+        next(generator)
+        job_schedulers = [call[1][0] for call in self.collection.add.mock_calls[::2]]
+        job_schedulers[0].schedule.assert_not_called()
+
     def test_update_from_config_reconfigure_one_namespace(self):
         autospec_method(self.collection.jobs.filter_by_name)
         autospec_method(self.collection.add)

--- a/tron/core/job_collection.py
+++ b/tron/core/job_collection.py
@@ -30,9 +30,9 @@ class JobCollection:
 
         def map_to_job_and_schedule(job_schedulers):
             for job_scheduler in job_schedulers:
+                yield job_scheduler.get_job()
                 if reconfigure:
                     job_scheduler.schedule()
-                yield job_scheduler.get_job()
 
         def reconfigure_filter(config):
             if not reconfigure or not namespace_to_reconfigure:


### PR DESCRIPTION
This PR aims to fix a bug where Tron did not to attach a watcher to the first run of a new job. Interestingly enough, this bug has existed for several years now; since 85% of Tron jobs run every 20 minutes or so, this went unnoticed for a while since reaching the run_limit for a given job removes the old runs from the tail.

This will help heavier, less frequent job runs in ensuring data integrity and consistent observability across Tron. A unit test has been added to assert old behavior is no longer present.

All tests pass, keeping as draft PR for the time being until I verify more job runs on my local env.