### PR TITLE
Skip initial backoff for unprocessed keys during dynamodb restore

### DIFF
--- a/tests/serialize/runstate/dynamodb_state_store_test.py
+++ b/tests/serialize/runstate/dynamodb_state_store_test.py
@@ -10,6 +10,7 @@ from moto.dynamodb.responses import dynamo_json_dump
 
 from tron.serialize.runstate.dynamodb_state_store import DynamoDBStateStore
 from tron.serialize.runstate.dynamodb_state_store import MAX_UNPROCESSED_KEYS_RETRIES
+from tron.serialize.runstate.dynamodb_state_store import UNPROCESSED_KEYS_IMMEDIATE_RETRIES
 
 
 def mock_transact_write_items(self):
@@ -380,9 +381,10 @@ class TestDynamoDBStateStore:
             return_value=unprocessed_value,
         ) as mock_batch_get_item, mock.patch("time.sleep") as mock_sleep, pytest.raises(Exception) as exec_info:
             store.restore(keys)
+
         assert "failed to retrieve items with keys" in str(exec_info.value)
         assert mock_batch_get_item.call_count == MAX_UNPROCESSED_KEYS_RETRIES
-        assert mock_sleep.call_count == MAX_UNPROCESSED_KEYS_RETRIES
+        assert mock_sleep.call_count == (MAX_UNPROCESSED_KEYS_RETRIES - UNPROCESSED_KEYS_IMMEDIATE_RETRIES)
 
     def test_restore_exception_propagation(self, store):
         # This test is to ensure that restore propagates exceptions upwards: see DAR-2328

--- a/tron/serialize/runstate/dynamodb_state_store.py
+++ b/tron/serialize/runstate/dynamodb_state_store.py
@@ -37,6 +37,7 @@ MAX_SAVE_QUEUE = 500
 # infinite loops in the case where a key is truly unprocessable. We allow for more retries than it should
 # ever take to avoid failing restores due to transient issues.
 MAX_UNPROCESSED_KEYS_RETRIES = 30
+UNPROCESSED_KEYS_IMMEDIATE_RETRIES = 3
 log = logging.getLogger(__name__)
 T = TypeVar("T")
 
@@ -150,13 +151,16 @@ class DynamoDBStateStore:
                 # We use _calculate_backoff_delay to get a delay that increases exponentially
                 # with each retry. These retry attempts are distinct from the boto3 retry_config
                 # and are used specifically to handle unprocessed keys.
+                # NOTE: We don't sleep for the first 3 attempts to speed up the initial restore.
                 attempts += 1
-                delay = self._calculate_backoff_delay(attempts)
+                delay = 0
+                if attempts > UNPROCESSED_KEYS_IMMEDIATE_RETRIES:
+                    delay = self._calculate_backoff_delay(attempts - UNPROCESSED_KEYS_IMMEDIATE_RETRIES)
+                    time.sleep(delay)
                 log.warning(
                     f"Attempt {attempts}/{MAX_UNPROCESSED_KEYS_RETRIES} - "
                     f"Retrying {len(cand_keys_list)} unprocessed keys after {delay}s delay."
                 )
-                time.sleep(delay)
         if cand_keys_list:
             msg = f"tron_dynamodb_restore_failure: failed to retrieve items with keys \n{cand_keys_list}\n from dynamodb after {MAX_UNPROCESSED_KEYS_RETRIES} retries."
             log.error(msg)


### PR DESCRIPTION
### **Motivation:**

As of recently, Tron has been reaching restart times of over 6 minutes in `pnw-prod`. The motivation of this series of PRs is to reduce this number in the safest and most approachable way possible.

By not doing `time.sleep()` on the first 3 reattempts on `_get_items` after an `UNPROCESSED_KEYS` error, we can save some time since most retrieval errors are fixed on immediate retries.

This is the first of many incremental restart improvements.

Tests pass and an existing unit test was modified to reflect new behavior.