### PR TITLE
Improve Tron restart times by adding parallelization to job_collection.restore_state()

### DIFF
--- a/tron/core/job_collection.py
+++ b/tron/core/job_collection.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import logging
 
 from tron.core.job import Job
@@ -75,9 +76,17 @@ class JobCollection:
         state for each run. As we load the state, we will also schedule the next
         runs for each job
         """
-        for name, state in job_state_data.items():
-            self.jobs[name].restore_state(state, config_action_runner)
-        log.info(f"Loaded state for {len(job_state_data)} jobs")
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            results = {
+                executor.submit(self.jobs[name].restore_state, state, config_action_runner): name
+                for name, state in job_state_data.items()
+            }
+            for result in concurrent.futures.as_completed(results):
+                try:
+                    result.result()
+                except Exception:
+                    log.exception(f"Unable to restore state for {results[result]} - exiting")
 
     def get_by_name(self, name):
         return self.jobs.get(name)


### PR DESCRIPTION
Follow-up to the series of Tron restart improvements.

As of recently, Tron has been seeing restart times of over 6 minutes in pnw-prod. Optimizing these restart times allows for less downtime and more opportunities to experiment with new changes.

This change adds a `ThreadPoolExecutor` to parallelize `job_collection.restore_state()`. By setting `max_workers` to 5 we can see a significant improvement in state restoration times:

Original performance (tested with copy of tron-pnw-devc dynamodb table):

```
Run: linear run (Tue Jul 28 10:32:01 AM PDT 2026)
Total startup: 93.59s
Schedulers built: 3.786149263381958s
DynamoDB retrieval: 10:27:25 -> 10:27:55 (30.000s)
Apply state: 10:27:55 -> 10:28:53 (58.000s)
Unprocessed key retries: 5
Log: /tmp/output_log_linear_attempt1.log
Restore state: 57.425s <----- 
```

Performance after parallelization (same environment as original test, 5 workers):

```
Run: parallel run (Tue Jul 28 10:19:16 AM PDT 2026)
Total startup: 66.10s
Schedulers built: 3.781592607498169s
DynamoDB retrieval: 10:14:21 -> 10:14:52 (31.000s)
Apply state: 10:14:52 -> 10:15:22 (30.000s)
Unprocessed key retries: 7
Log: /tmp/output_log_parallel_attempt2.log
Restore state: 29.658s <-----
```

Tests passed